### PR TITLE
Fix local launcher demo shard id key

### DIFF
--- a/examples/local_launcher_demo.py
+++ b/examples/local_launcher_demo.py
@@ -40,7 +40,7 @@ NUM = 0
 def add_text_len(row):
     global NUM
     text = row.get("text")
-    shard_id = str(row["shard_id"])
+    shard_id = str(row["__shard_id"])
     mdr.log_throughput("text_len_counter", len(str(text)), shard_id=shard_id)
     mdr.log_histogram("text_len_histogram", len(str(text)), shard_id=shard_id)
     mdr.log_gauge("meter", NUM)


### PR DESCRIPTION
Summary:
- Fix examples/local_launcher_demo.py to read the injected shard key as __shard_id.
- Keep throughput/histogram logging using the resolved shard id.

Why:
Workers were failing with KeyError shard_id because source rows expose __shard_id.

Verification:
- python3 syntax compile check for examples/local_launcher_demo.py