### PR TITLE
Set up automated PyPI releases for macrodata-refiner

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,266 @@
+name: Publish package
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - pyproject.toml
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publishing target"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.package_meta.outputs.version }}
+      tag_name: ${{ steps.package_meta.outputs.tag_name }}
+      should_run: ${{ steps.plan.outputs.should_run }}
+      publish_testpypi: ${{ steps.plan.outputs.publish_testpypi }}
+      publish_pypi: ${{ steps.plan.outputs.publish_pypi }}
+      create_release: ${{ steps.plan.outputs.create_release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read package version
+        id: package_meta
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = data["project"]["version"]
+          print(f"version={version}")
+          print(f"tag_name=v{version}")
+          PY
+
+      - name: Plan publish targets
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TARGET: ${{ github.event.inputs.target }}
+          CURRENT_VERSION: ${{ steps.package_meta.outputs.version }}
+          CURRENT_TAG: ${{ steps.package_meta.outputs.tag_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          should_run=false
+          publish_testpypi=false
+          publish_pypi=false
+          create_release=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            target="${DISPATCH_TARGET:-testpypi}"
+            if [ "$target" = "testpypi" ]; then
+              should_run=true
+              publish_testpypi=true
+            elif [ "$target" = "pypi" ]; then
+              if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+                echo "Manual PyPI publish is only allowed from main." >&2
+                exit 1
+              fi
+              should_run=true
+              publish_testpypi=true
+              publish_pypi=true
+              create_release=true
+            else
+              echo "Unknown dispatch target: $target" >&2
+              exit 1
+            fi
+          else
+            old_version=""
+            if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              old_version="$(python - "$BEFORE_SHA" <<'PY' || true
+import subprocess
+import sys
+import tomllib
+
+before_sha = sys.argv[1]
+try:
+    content = subprocess.check_output(["git", "show", f"{before_sha}:pyproject.toml"])
+except Exception:
+    sys.exit(0)
+
+data = tomllib.loads(content.decode("utf-8"))
+print(data["project"]["version"])
+PY
+)"
+            fi
+
+            if [ "$old_version" != "$CURRENT_VERSION" ]; then
+              should_run=true
+              publish_testpypi=true
+              publish_pypi=true
+              create_release=true
+            fi
+          fi
+
+          git fetch --tags --force
+          if [ "$publish_pypi" = "true" ] && git rev-parse -q --verify "refs/tags/$CURRENT_TAG" >/dev/null; then
+            echo "Tag $CURRENT_TAG already exists. Bump pyproject version before releasing." >&2
+            exit 1
+          fi
+
+          {
+            echo "should_run=$should_run"
+            echo "publish_testpypi=$publish_testpypi"
+            echo "publish_pypi=$publish_pypi"
+            echo "create_release=$create_release"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ needs.prepare.outputs.version }}
+      tag_name: ${{ needs.prepare.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distribution artifacts
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: twine check dist/*
+
+      - name: Ensure version did not change during workflow
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          current_version="$(python - <<'PY'
+import tomllib
+from pathlib import Path
+
+data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+print(data["project"]["version"])
+PY
+)"
+          if [ "$current_version" != "$EXPECTED_VERSION" ]; then
+            echo "Version changed unexpectedly during workflow." >&2
+            exit 1
+          fi
+
+      - name: Ensure release tag does not already exist
+        env:
+          TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+            echo "Tag ${TAG_NAME} already exists. Bump version before releasing." >&2
+            exit 1
+          fi
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    if: needs.prepare.outputs.publish_testpypi == 'true'
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/macrodata-refiner
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          skip-existing: true
+
+  publish-pypi:
+    if: needs.prepare.outputs.publish_pypi == 'true'
+    needs:
+      - prepare
+      - build
+      - publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/macrodata-refiner
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+  tag-and-release:
+    if: needs.prepare.outputs.create_release == 'true'
+    needs:
+      - prepare
+      - publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create and push release tag
+        env:
+          TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+        run: |
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+            echo "Tag ${TAG_NAME} already exists."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}" "${GITHUB_SHA}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
+          name: ${{ needs.prepare.outputs.tag_name }}
+          generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,9 @@
 [project]
-name = "refiner"
-version = "0.1.0"
+name = "macrodata-refiner"
+version = "0.0.0"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
-license = { file = "LICENSE" }
-classifiers = [
-    "License :: OSI Approved :: Apache Software License",
-]
+license = "Apache-2.0"
 authors = [
     { name = "Macrodata Labs" }
 ]
@@ -26,6 +23,16 @@ dependencies = [
 
 [project.scripts]
 macrodata = "refiner.cli.main:main"
+
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+refiner = ["py.typed"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,55 @@ wheels = [
 ]
 
 [[package]]
+name = "macrodata-refiner"
+version = "0.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "orjson" },
+    { name = "psutil" },
+    { name = "pyarrow" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cloudpickle", specifier = "==3.1.2" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub", specifier = ">=1.4.1" },
+    { name = "loguru" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "orjson" },
+    { name = "psutil" },
+    { name = "pyarrow" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "ruff", specifier = ">=0.14.10" },
+    { name = "ty", specifier = ">=0.0.7" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -898,55 +947,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "refiner"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "fsspec" },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "loguru" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
-    { name = "orjson" },
-    { name = "psutil" },
-    { name = "pyarrow" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "cloudpickle", specifier = "==3.1.2" },
-    { name = "fsspec" },
-    { name = "httpx" },
-    { name = "huggingface-hub", specifier = ">=1.4.1" },
-    { name = "loguru" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
-    { name = "orjson" },
-    { name = "psutil" },
-    { name = "pyarrow" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "ruff", specifier = ">=0.14.10" },
-    { name = "ty", specifier = ">=0.0.7" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- rename distribution package to `macrodata-refiner` and reset version to `0.0.0`
- add a trusted-publishing workflow (`pypi-release.yml`) that:
  - runs on `main` when `pyproject.toml` version changes
  - builds package artifacts and validates them
  - publishes to TestPyPI first, then PyPI
  - auto-creates release tag and GitHub Release after successful publish
  - supports manual reruns via `workflow_dispatch` (`testpypi` or full `pypi` flow)
- update `uv.lock` to reflect renamed package/version

## Notes
- this flow is retry-safe (`skip-existing` on both TestPyPI and PyPI publish steps)
- tag/release creation is intentionally the final step