### PR TITLE
add async no threading flag

### DIFF
--- a/docs/local-execution.md
+++ b/docs/local-execution.md
@@ -52,9 +52,20 @@ When set, Refiner shrinks row-to-Arrow chunk sizes during that run if an Arrow a
 
 Local iteration consumes the source stream continuously, so downstream batch steps can consume data that spans multiple shards.
 
+## Async Debugging
+
+If you need to debug blocking video/cache operations without any pipeline threadpool offloads, set `ASYNC_NO_THREADING=1` before running Refiner:
+
+```bash
+ASYNC_NO_THREADING=1 uv run examples/lerobot/motion_trim.py
+```
+
+This forces helpers that normally use `run_in_executor(...)` or `asyncio.to_thread(...)` to run inline on the async runtime thread instead. It is a debugging tool, not a performance mode.
+
 ## Internal Notes
 
 - Local execution compiles pipeline steps into row/vector segments once per pipeline instance and reuses that plan across repeated runs.
 - Row/UDF segments emit row blocks; when a vectorized segment follows, those rows are converted back to Arrow blocks at the segment boundary.
 - Async row steps use the same execution engine and run through a shared process-local asyncio runtime.
+- `ASYNC_NO_THREADING=1` disables pipeline threadpool offloads for blocking helpers, but it does not disable the shared asyncio runtime thread itself.
 - `take(n)` stops early without forcing full-stream materialization.

--- a/src/refiner/execution/asyncio/runtime.py
+++ b/src/refiner/execution/asyncio/runtime.py
@@ -6,6 +6,7 @@ import os
 import threading
 from collections.abc import Coroutine
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
 from typing import Any, TypeVar
 
 T = TypeVar("T")
@@ -106,7 +107,19 @@ def io_executor() -> ThreadPoolExecutor:
     return _runtime.io_executor()
 
 
+async def run_in_io_executor(func, /, *args, **kwargs):
+    if os.environ.get("ASYNC_NO_THREADING"):
+        return func(*args, **kwargs)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(io_executor(), partial(func, *args, **kwargs))
+
+
 atexit.register(_runtime.shutdown)
 
 
-__all__ = ["AsyncRuntime", "io_executor", "submit"]
+__all__ = [
+    "AsyncRuntime",
+    "io_executor",
+    "run_in_io_executor",
+    "submit",
+]

--- a/src/refiner/pipeline/sinks/lerobot/_lerobot_video_writer.py
+++ b/src/refiner/pipeline/sinks/lerobot/_lerobot_video_writer.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from refiner.execution.asyncio.runtime import io_executor
+from refiner.execution.asyncio.runtime import run_in_io_executor
 from refiner.io import DataFolder
 from refiner.media import VideoFile
 from refiner.pipeline.sinks.lerobot._lerobot_video_remux import (
@@ -157,11 +156,7 @@ class LeRobotVideoWriter:
     ) -> _CompletedVideoItem:
         # We need the lock so that we can rotate the writer without race conditions
         async with self._commit_lock:
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                io_executor(),
-                partial(self._commit_item_sync, prepared),
-            )
+            return await run_in_io_executor(self._commit_item_sync, prepared)
 
     def _commit_item_sync(
         self,

--- a/src/refiner/pipeline/utils/cache/decoder_cache.py
+++ b/src/refiner/pipeline/utils/cache/decoder_cache.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import atexit
-import asyncio
 from dataclasses import dataclass
 from fractions import Fraction
-from functools import partial
 from typing import IO, Any, cast
 
 import av
 
-from refiner.execution.asyncio.runtime import io_executor
+from refiner.execution.asyncio.runtime import run_in_io_executor
 from refiner.io import DataFile
 from refiner.pipeline.utils.cache.lease_cache import LeaseCache
 
@@ -59,12 +57,9 @@ class OpenedVideoSourceCache(LeaseCache[str, OpenedVideoSource]):
         self,
         key: str,
     ) -> tuple[OpenedVideoSource, int]:
-        source = await asyncio.get_running_loop().run_in_executor(
-            io_executor(),
-            partial(
-                _open_video_source,
-                uri=key,
-            ),
+        source = await run_in_io_executor(
+            _open_video_source,
+            uri=key,
         )
         return source, 0
 

--- a/src/refiner/pipeline/utils/cache/file_cache.py
+++ b/src/refiner/pipeline/utils/cache/file_cache.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import os
 import shutil
 import tempfile
@@ -8,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from refiner.io import DataFile
+from refiner.execution.asyncio.runtime import run_in_io_executor
 from refiner.pipeline.utils.cache.lease_cache import CacheLease, LeaseCache
 
 
@@ -43,7 +43,7 @@ class _FileLeaseCache(LeaseCache[_FileCacheKey, _FileResource]):
         self.name = name
 
     async def _create_resource(self, key: _FileCacheKey) -> tuple[_FileResource, int]:
-        downloaded_path, downloaded_size_bytes = await asyncio.to_thread(
+        downloaded_path, downloaded_size_bytes = await run_in_io_executor(
             _download_data_file_to_temp,
             key.file,
             cache_name=self.name,


### PR DESCRIPTION
## Summary
- add an `ASYNC_NO_THREADING` debug flag for pipeline blocking offloads
- route video commit, decoder cache opens, and media cache downloads through one helper
- document how to run the flag locally

## Testing
- `uv run ruff check src/refiner/execution/asyncio/runtime.py docs/local-execution.md src/refiner/pipeline/sinks/lerobot/_lerobot_video_writer.py src/refiner/pipeline/utils/cache/decoder_cache.py src/refiner/pipeline/utils/cache/file_cache.py`
- `uv run python - <<'PY'
import os, asyncio
from refiner.execution.asyncio.runtime import run_in_io_executor

async def main():
    os.environ["ASYNC_NO_THREADING"] = "1"
    value = await run_in_io_executor(lambda: "ok")
    print(value)

asyncio.run(main())
PY`
