### PR TITLE
Harden file listing and add reader file path metadata

### DIFF
--- a/src/refiner/execution/operators/vectorized.py
+++ b/src/refiner/execution/operators/vectorized.py
@@ -10,7 +10,7 @@ from refiner.execution.tracking.shards import (
     count_table_by_shard,
     counts_delta,
 )
-from refiner.pipeline.data.tabular import repeat_scalar
+from refiner.pipeline.data.tabular import filter_table, repeat_scalar
 from refiner.pipeline.expressions import eval_expr_arrow
 from refiner.pipeline.steps import (
     CastStep,
@@ -69,14 +69,7 @@ def apply_vectorized_op(
         return out, None
 
     if isinstance(op, FilterExprStep):
-        mask = eval_expr_arrow(op.predicate, table)
-        next_table = (
-            table
-            if isinstance(mask, pa.Scalar) and bool(mask.as_py())
-            else (
-                table.slice(0, 0) if isinstance(mask, pa.Scalar) else table.filter(mask)
-            )
-        )
+        next_table = filter_table(table, op.predicate)
         next_shard_counts = count_table_by_shard(next_table)
         for shard_id in set(shard_counts) | set(next_shard_counts):
             previous = int(shard_counts.get(shard_id, 0))

--- a/src/refiner/io/datafolder.py
+++ b/src/refiner/io/datafolder.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from os import PathLike
 from typing import IO, Any, TypeAlias, Union, cast
 
@@ -113,6 +113,34 @@ class DataFolder(DirFileSystem):
             return self.abs_path(paths)
         return [self.abs_path(p) for p in paths]
 
+    def find(self, path: str, *args, **kwargs):
+        # Avoid DirFileSystem.find(): some backends (notably HF buckets) can leak
+        # sibling prefix matches like `root-2/...` or return the bare root entry,
+        # and DirFileSystem._relpath() asserts before we can filter them out.
+        """List paths under this folder, skipping backend results outside the base path."""
+        detail = kwargs.get("detail", False)
+        target = self._join(path.rstrip("/"))
+        ret = self.fs.find(target, *args, **kwargs)
+        target = target.rstrip("/")
+        target_prefix = target + self.fs.sep
+        alt_target = target[1:] if target.startswith(self.fs.sep) else None
+        alt_prefix = alt_target + self.fs.sep if alt_target is not None else None
+
+        def rel(p: str) -> str | None:
+            if p == target or (alt_target is not None and p == alt_target):
+                return path.rstrip("/")
+            if p.startswith(target_prefix):
+                suffix = p[len(target_prefix) :]
+            elif alt_prefix is not None and p.startswith(alt_prefix):
+                suffix = p[len(alt_prefix) :]
+            else:
+                return None
+            return suffix if path in {"", "/"} else f"{path.rstrip('/')}/{suffix}"
+
+        if detail:
+            return {r: info for p, info in ret.items() if (r := rel(p)) is not None}
+        return [r for p in ret if (r := rel(p)) is not None]
+
     def open_files(
         self, paths: Iterable[str], mode: str = "rb", **kwargs
     ) -> list[IO[Any]]:
@@ -159,3 +187,29 @@ class DataFolder(DirFileSystem):
 
     def files(self, relpaths: Iterable[str]) -> list[DataFile]:
         return [self.file(p) for p in relpaths]
+
+    def iter_files_with_sizes(
+        self, *, recursive: bool = False, **kwargs: Any
+    ) -> Iterator[tuple[DataFile, int | None]]:
+        if recursive:
+            found = self.find("", detail=True, **kwargs)
+            items: Iterable[tuple[str, Mapping[str, Any]]] = found.items()
+        else:
+            items = (
+                (str(info["name"]), info)
+                for info in self.ls("", detail=True, **kwargs)
+                if isinstance(info, Mapping)
+            )
+
+        for relpath, info in sorted(items, key=lambda item: item[0]):
+            info_dict = dict(info)
+            if info_dict.get("type") != "file":
+                continue
+            size = info_dict.get("size")
+            yield self.file(relpath), size if isinstance(size, int) else None
+
+    def iter_files(
+        self, *, recursive: bool = False, **kwargs: Any
+    ) -> Iterator[DataFile]:
+        for file, _ in self.iter_files_with_sizes(recursive=recursive, **kwargs):
+            yield file

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -170,62 +170,77 @@ class DataFileSet:
         exts = tuple(e.lower() for e in self.extensions)
         seen: set[tuple[int, str]] = set()
         expanded: list[tuple[DataFile, ...]] = []
+        sizes = dict(self._sizes)
 
-        def _append_file(out: list[DataFile], file: DataFile) -> None:
-            if exts and not file.path.lower().endswith(exts):
+        def _append_file(
+            out: list[DataFile],
+            file: DataFile,
+            *,
+            size: int | None = None,
+            apply_extensions: bool = True,
+        ) -> None:
+            if apply_extensions and exts and not file.path.lower().endswith(exts):
                 return
             key = (id(file.fs), file.path)
             if key in seen:
                 return
             seen.add(key)
             out.append(file)
+            if size is not None:
+                sizes[(len(expanded), file.abs_path())] = int(size)
 
         for entry in self.entries:
             files: list[DataFile] = []
-            if isinstance(entry, DataFile):
-                _append_file(files, entry)
-            elif isinstance(entry, DataFolder):
-                paths = (
-                    sorted(entry.find(""))
-                    if self.recursive
-                    else sorted(
-                        e["name"] if isinstance(e, dict) else e
-                        for e in entry.ls("", detail=True)
-                        if not isinstance(e, dict) or e.get("type") == "file"
+            if isinstance(entry, _PathSource) and not glob.has_magic(entry.path):
+                try:
+                    info = entry.fs.info(entry.path)
+                except FileNotFoundError:
+                    raise FileNotFoundError(
+                        f"Could not resolve input: {entry.fs.unstrip_protocol(entry.path)!r}"
                     )
-                )
-                for path in paths:
-                    _append_file(files, entry.file(path))
+                item_type = info.get("type")
+                if item_type == "directory":
+                    entry = DataFolder(path=entry.path, fs=entry.fs)
+                elif item_type == "file":
+                    entry = DataFile(fs=entry.fs, path=entry.path)
+                else:
+                    raise TypeError(
+                        f"Unsupported file type {item_type!r} for input: "
+                        f"{entry.fs.unstrip_protocol(entry.path)!r}"
+                    )
+
+            if isinstance(entry, DataFile):
+                _append_file(files, entry, apply_extensions=False)
+            elif isinstance(entry, DataFolder):
+                for file, size in entry.iter_files_with_sizes(recursive=self.recursive):
+                    _append_file(files, file, size=size)
             else:
                 next_fs, path = entry.fs, entry.path
                 if glob.has_magic(path):
-                    for expanded_path in sorted(next_fs.glob(path)):
-                        _append_file(files, DataFile(fs=next_fs, path=expanded_path))
-                elif next_fs.exists(path):
-                    if next_fs.isdir(path):
-                        paths = (
-                            sorted(next_fs.find(path))
-                            if self.recursive
-                            else sorted(
-                                e["name"] if isinstance(e, dict) else e
-                                for e in next_fs.ls(path, detail=True)
-                                if not isinstance(e, dict) or e.get("type") == "file"
-                            )
+                    matched = next_fs.glob(path, detail=True)
+                    items = matched.items()
+                    for expanded_path, info in sorted(items):
+                        if not isinstance(expanded_path, str) or not isinstance(
+                            info, Mapping
+                        ):
+                            continue
+                        if info.get("type") != "file":
+                            continue
+                        size = info.get("size")
+                        _append_file(
+                            files,
+                            DataFile(fs=next_fs, path=expanded_path),
+                            size=size if isinstance(size, int) else None,
                         )
-                        for expanded_path in paths:
-                            _append_file(
-                                files, DataFile(fs=next_fs, path=expanded_path)
-                            )
-                    else:
-                        _append_file(files, DataFile(fs=next_fs, path=path))
                 else:
-                    raise FileNotFoundError(
-                        f"Could not resolve input: {next_fs.unstrip_protocol(path)!r}"
+                    raise AssertionError(
+                        "non-glob _PathSource should have been resolved"
                     )
             expanded.append(tuple(files))
 
         out = tuple(expanded)
         object.__setattr__(self, "_expanded_sources", out)
+        object.__setattr__(self, "_sizes", sizes)
         return out
 
     def resolve_file(self, source_index: int, path: str) -> DataFile:

--- a/src/refiner/pipeline/data/tabular.py
+++ b/src/refiner/pipeline/data/tabular.py
@@ -5,6 +5,7 @@ from itertools import count
 
 import pyarrow as pa
 
+from refiner.pipeline.expressions import Expr, eval_expr_arrow
 from refiner.pipeline.data.shard import SHARD_ID_COLUMN
 from refiner.pipeline.data.row import ArrowRowView, Row, _OverlayRow
 
@@ -93,6 +94,15 @@ def repeat_scalar(value: pa.Scalar, num_rows: int) -> pa.Array | pa.ChunkedArray
     if num_rows <= 0:
         return pa.array([], type=value.type)
     return pa.repeat(value, num_rows)
+
+
+def filter_table(table: pa.Table, predicate: Expr) -> pa.Table:
+    mask = eval_expr_arrow(predicate, table)
+    if isinstance(mask, pa.Scalar):
+        return table if bool(mask.as_py()) else table.slice(0, 0)
+    if isinstance(mask, pa.ChunkedArray):
+        mask = mask.combine_chunks()
+    return table.filter(mask)
 
 
 # everything below is for fast from_rows

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -432,6 +432,7 @@ def read_csv(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    file_path_column: str | None = "file_path",
     multiline_rows: bool = False,
     encoding: str = "utf-8",
     parse_use_threads: bool = False,
@@ -449,6 +450,7 @@ def read_csv(
             recursive=recursive,
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
+            file_path_column=file_path_column,
             multiline_rows=multiline_rows,
             encoding=encoding,
             parse_use_threads=parse_use_threads,
@@ -464,6 +466,7 @@ def read_jsonl(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    file_path_column: str | None = "file_path",
     parse_use_threads: bool = False,
 ) -> RefinerPipeline:
     """Create a pipeline with a JSONL reader source.
@@ -479,6 +482,7 @@ def read_jsonl(
             recursive=recursive,
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
+            file_path_column=file_path_column,
             parse_use_threads=parse_use_threads,
         )
     )
@@ -496,6 +500,7 @@ def read_parquet(
     columns_to_read: Sequence[str] | None = None,
     filter: Expr | None = None,
     split_row_groups: bool = False,
+    file_path_column: str | None = "file_path",
 ) -> RefinerPipeline:
     """Create a pipeline with a Parquet reader source.
 
@@ -516,6 +521,7 @@ def read_parquet(
             columns_to_read=columns_to_read,
             filter=filter,
             split_row_groups=split_row_groups,
+            file_path_column=file_path_column,
         )
     )
 

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from fsspec import AbstractFileSystem
+import pyarrow as pa
 
 from refiner.io import DataFile, DataFileSet, DataFolder
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.data.shard import FilePart, Shard
+from refiner.pipeline.data.tabular import repeat_scalar, set_or_append_column
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.pipeline.sources.readers.utils import (
     BoundedBinaryReader,
@@ -44,6 +46,8 @@ class BaseReader(BaseSource):
         extensions: Sequence[str] = (),
         target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
         num_shards: int | None = None,
+        file_path_column: str | None = "file_path",
+        split_by_bytes: bool = True,
     ):
         """Create a reader over a set of input files.
 
@@ -65,7 +69,8 @@ class BaseReader(BaseSource):
         )
         self.target_shard_bytes = max(1, target_shard_bytes)
         self.num_shards = num_shards
-        self.split_by_bytes = True
+        self.file_path_column = file_path_column
+        self.split_by_bytes = split_by_bytes
         # Single-open-file cache for readers that do byte-based seeks or stream reads.
         self._open_file: DataFile | None = None
         self._open_fh: Any | None = None
@@ -94,7 +99,28 @@ class BaseReader(BaseSource):
                 inputs.append(str(entry.abs_paths("")))
             else:
                 inputs.append(str(entry.fs.unstrip_protocol(entry.path)))
-        return {"path": ", ".join(inputs), "inputs": inputs}
+        return {
+            "path": ", ".join(inputs),
+            "inputs": inputs,
+            "file_path_column": self.file_path_column,
+        }
+
+    def _with_file_path(
+        self, row: dict[str, Any], source_file: DataFile
+    ) -> dict[str, Any]:
+        if self.file_path_column is None or self.file_path_column in row:
+            return row
+        row[self.file_path_column] = source_file.abs_path()
+        return row
+
+    def _table_with_file_path(self, table: pa.Table, source_file: DataFile) -> pa.Table:
+        if self.file_path_column is None or self.file_path_column in table.column_names:
+            return table
+        return set_or_append_column(
+            table,
+            self.file_path_column,
+            repeat_scalar(pa.scalar(source_file.abs_path()), table.num_rows),
+        )
 
     def _get_file_handle(
         self, file: DataFile, *, mode: str = "rb", force_reopen: bool = False

--- a/src/refiner/pipeline/sources/readers/csv.py
+++ b/src/refiner/pipeline/sources/readers/csv.py
@@ -5,6 +5,7 @@ import io
 from collections.abc import Iterator, Mapping
 from typing import Any, Optional
 
+import pyarrow as pa
 import pyarrow.csv as pa_csv
 from fsspec import AbstractFileSystem
 
@@ -36,6 +37,7 @@ class CsvReader(BaseReader):
         recursive: bool = False,
         target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
         num_shards: int | None = None,
+        file_path_column: str | None = "file_path",
         multiline_rows: bool = False,
         encoding: str = "utf-8",
         parse_use_threads: bool = False,
@@ -56,9 +58,10 @@ class CsvReader(BaseReader):
             extensions=(".csv",),
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
+            file_path_column=file_path_column,
+            split_by_bytes=not multiline_rows,
         )
         self.multiline_rows = multiline_rows
-        self.split_by_bytes = not multiline_rows
         self.encoding = encoding
         self.parse_use_threads = parse_use_threads
         self._open_header: Optional[list[str]] = None
@@ -134,7 +137,11 @@ class CsvReader(BaseReader):
                     ),
                 )
                 for batch in reader:
-                    yield Tabular.from_batch(batch)
+                    yield Tabular(
+                        self._table_with_file_path(
+                            pa.Table.from_batches([batch]), source
+                        )
+                    )
             return
 
         bounded = self._bounded_part(part)
@@ -162,7 +169,9 @@ class CsvReader(BaseReader):
             ),
         )
         for batch in reader:
-            yield Tabular.from_batch(batch)
+            yield Tabular(
+                self._table_with_file_path(pa.Table.from_batches([batch]), source)
+            )
 
     def _read_shard_python(self, part: FilePart) -> Iterator[SourceUnit]:
         source = self.fileset.resolve_file(part.source_index, part.path)
@@ -175,7 +184,7 @@ class CsvReader(BaseReader):
             ) as tf:
                 reader = csv.DictReader(tf)
                 for row in reader:
-                    yield DictRow(row)
+                    yield DictRow(self._with_file_path(dict(row), source))
             return
 
         bounded = self._bounded_part(part)
@@ -198,7 +207,7 @@ class CsvReader(BaseReader):
                 fields = list(fields) + [None] * (len(header) - len(fields))
             if len(fields) > len(header):
                 fields = fields[: len(header)]
-            yield DictRow(dict(zip(header, fields)))
+            yield DictRow(self._with_file_path(dict(zip(header, fields)), source))
 
 
 __all__ = ["CsvReader"]

--- a/src/refiner/pipeline/sources/readers/jsonl.py
+++ b/src/refiner/pipeline/sources/readers/jsonl.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator, Mapping
 from typing import Any
 
 from fsspec import AbstractFileSystem
+import pyarrow as pa
 import pyarrow.json as pa_json
 
 from refiner.io.fileset import DataFileSetLike
@@ -33,6 +34,7 @@ class JsonlReader(BaseReader):
         recursive: bool = False,
         target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
         num_shards: int | None = None,
+        file_path_column: str | None = "file_path",
         parse_use_threads: bool = False,
     ):
         """Create a JSONL reader.
@@ -49,6 +51,7 @@ class JsonlReader(BaseReader):
             extensions=(".jsonl", ".jsonl.gz", ".ndjson", ".jsonlines"),
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
+            file_path_column=file_path_column,
         )
         self.parse_use_threads = parse_use_threads
 
@@ -70,7 +73,11 @@ class JsonlReader(BaseReader):
                         ),
                     )
                     for batch in reader:
-                        yield Tabular.from_batch(batch)
+                        yield Tabular(
+                            self._table_with_file_path(
+                                pa.Table.from_batches([batch]), source
+                            )
+                        )
                 continue
 
             aligned = self._open_aligned_byte_span(part)
@@ -82,7 +89,9 @@ class JsonlReader(BaseReader):
                 read_options=pa_json.ReadOptions(use_threads=self.parse_use_threads),
             )
             for batch in reader:
-                yield Tabular.from_batch(batch)
+                yield Tabular(
+                    self._table_with_file_path(pa.Table.from_batches([batch]), source)
+                )
 
 
 __all__ = ["JsonlReader"]

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -79,6 +79,7 @@ class LeRobotEpisodeReader(ParquetReader):
             num_shards=num_shards,
             arrow_batch_size=arrow_batch_size,
             split_row_groups=split_row_groups,
+            file_path_column=None,
         )
 
     def describe(self) -> dict[str, Any]:

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -16,8 +16,8 @@ from refiner.io import DataFile
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.data.shard import FilePart
 from refiner.pipeline.data.shard import FilePartsDescriptor
-from refiner.pipeline.data.tabular import Tabular
-from refiner.pipeline.expressions import Expr, eval_expr_arrow
+from refiner.pipeline.data.tabular import Tabular, filter_table
+from refiner.pipeline.expressions import Expr
 from refiner.pipeline.sources.readers.base import BaseReader, Shard, SourceUnit
 from refiner.pipeline.sources.readers.utils import (
     DEFAULT_TARGET_SHARD_BYTES,
@@ -54,6 +54,7 @@ class ParquetReader(BaseReader):
         columns_to_read: Sequence[str] | None = None,
         filter: Expr | None = None,
         split_row_groups: bool = False,
+        file_path_column: str | None = "file_path",
     ):
         """Create a Parquet reader.
 
@@ -83,6 +84,7 @@ class ParquetReader(BaseReader):
             extensions=(".parquet", ".pq", ".parq"),
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
+            file_path_column=file_path_column,
         )
         self.arrow_batch_size = int(arrow_batch_size)
         self.split_row_groups = split_row_groups
@@ -104,6 +106,15 @@ class ParquetReader(BaseReader):
         self.columns_to_read = (
             tuple(columns_to_read) if columns_to_read is not None else None
         )
+        if (
+            self.columns_to_read is not None
+            and self.file_path_column is not None
+            and self.file_path_column in self.columns_to_read
+        ):
+            raise ValueError(
+                "columns_to_read cannot include the synthetic file_path_column; "
+                "omit it from columns_to_read and let the reader append it"
+            )
         # the columns we will actually load into memory. requested+needed for filtering
         self._scan_columns: list[str] | None = (
             None
@@ -251,12 +262,10 @@ class ParquetReader(BaseReader):
                 offset += batch_rows
             table = pa.Table.from_batches([batch])
             if self.filter is not None:
-                mask = eval_expr_arrow(self.filter, table)
-                if isinstance(mask, pa.ChunkedArray):
-                    mask = mask.combine_chunks()
-                table = table.filter(mask)
+                table = filter_table(table, self.filter)
             if self.columns_to_read is not None:
                 table = table.select(self.columns_to_read)
+            table = self._table_with_file_path(table, source_file)
             if table.num_rows > 0:
                 yield Tabular(table)
             if row_bounds is not None and offset >= row_end:

--- a/tests/io/test_datafile_datafolder.py
+++ b/tests/io/test_datafile_datafolder.py
@@ -70,6 +70,27 @@ class _CountingMemoryFS(MemoryFileSystem):
         return super().ls(path, detail=detail, **kwargs)
 
 
+class _PrefixLeakingMemoryFS(MemoryFileSystem):
+    def find(self, path, maxdepth=None, withdirs=False, detail=False, **kwargs):
+        leaked = super().find(
+            path,
+            maxdepth=maxdepth,
+            withdirs=withdirs,
+            detail=detail,
+            **kwargs,
+        )
+        sibling = f"{path.rstrip('/')}-2/other.txt"
+        if detail:
+            leaked[sibling] = {
+                "name": sibling,
+                "size": 1,
+                "type": "file",
+                "created": 0,
+            }
+            return leaked
+        return [*leaked, sibling]
+
+
 def test_datafileset_resolve_does_not_list_folders_eagerly():
     fs = _CountingMemoryFS()
     fs.pipe("root/a.txt", b"a")
@@ -80,6 +101,35 @@ def test_datafileset_resolve_does_not_list_folders_eagerly():
     assert len(fileset.files) == 1
     assert fileset.files[0].open().read() == "a"
     assert fs.ls_calls == 1
+
+
+def test_datafolder_find_filters_prefix_leaks():
+    fs = _PrefixLeakingMemoryFS()
+    fs.pipe("find-root/file.txt", b"ok")
+    folder = DataFolder.resolve(("find-root", fs))
+
+    assert folder.find("") == ["file.txt"]
+    assert folder.find("", withdirs=True) == ["", "file.txt"]
+
+
+def test_datafolder_find_preserves_file_paths():
+    fs = MemoryFileSystem()
+    fs.pipe("find-file-root/file.txt", b"ok")
+    folder = DataFolder.resolve(("find-file-root", fs))
+
+    assert folder.find("file.txt") == ["file.txt"]
+    detailed = folder.find("file.txt", detail=True)
+    assert list(detailed) == ["file.txt"]
+    assert detailed["file.txt"]["type"] == "file"
+
+
+def test_datafolder_find_accepts_backend_paths_without_leading_separator():
+    fs = MemoryFileSystem()
+    fs.pipe("find-slash-root/file.txt", b"ok")
+    folder = DataFolder("/find-slash-root", fs=fs)
+
+    assert folder.find("") == ["file.txt"]
+    assert folder.find("file.txt") == ["file.txt"]
 
 
 def test_datafileset_rejects_nested_filesets():

--- a/tests/readers/test_multi_source_readers.py
+++ b/tests/readers/test_multi_source_readers.py
@@ -27,6 +27,12 @@ def _write_parquet(path: Path, values: list[int]) -> None:
     pq.write_table(pa.table({"x": values}), path)
 
 
+def _write_parquet_with_file_path(
+    path: Path, values: list[int], file_paths: list[str]
+) -> None:
+    pq.write_table(pa.table({"x": values, "file_path": file_paths}), path)
+
+
 def _write_parquet_bytes(values: list[int]) -> bytes:
     buf = io.BytesIO()
     pq.write_table(pa.table({"x": values}), buf)
@@ -66,6 +72,17 @@ def test_datafileset_resolve_accepts_path_fs_tuple() -> None:
     assert fileset.files[0].fs is memfs
 
 
+def test_datafileset_extensions_do_not_filter_explicit_files() -> None:
+    with TemporaryDirectory() as tmp:
+        local_path = Path(tmp) / "local.txt"
+        local_path.write_text("x")
+
+        fileset = DataFileSet.resolve(str(local_path), extensions=(".jsonl",))
+
+        assert len(fileset.files) == 1
+        assert fileset.files[0].path == str(local_path)
+
+
 def test_jsonl_reader_reads_across_multiple_directories() -> None:
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -94,6 +111,17 @@ def test_csv_reader_reads_across_mixed_local_and_memory_files() -> None:
 
         assert _pipeline_values(pipeline) == [1, 2]
         assert len(pipeline.source.list_shards()) == 1
+
+
+def test_csv_reader_adds_file_path_column_by_default() -> None:
+    with TemporaryDirectory() as tmp:
+        local_path = Path(tmp) / "local.csv"
+        _write_csv(local_path, [1])
+
+        row = read_csv(str(local_path)).take(1)[0].to_dict()
+
+        assert row["x"] == 1
+        assert row["file_path"] == str(local_path)
 
 
 def test_parquet_reader_reads_across_mixed_local_and_memory_files() -> None:
@@ -126,6 +154,36 @@ def test_parquet_reader_filters_across_mixed_local_and_memory_files() -> None:
         )
 
         assert _pipeline_values(pipeline) == [3, 4]
+
+
+def test_parquet_reader_can_disable_file_path_column() -> None:
+    with TemporaryDirectory() as tmp:
+        local_path = Path(tmp) / "local.parquet"
+        _write_parquet(local_path, [1])
+
+        row = read_parquet(str(local_path), file_path_column=None).take(1)[0].to_dict()
+
+        assert row == {"x": 1}
+
+
+def test_parquet_reader_does_not_overwrite_existing_file_path_column() -> None:
+    with TemporaryDirectory() as tmp:
+        local_path = Path(tmp) / "local.parquet"
+        _write_parquet_with_file_path(local_path, [1], ["already-there"])
+
+        row = read_parquet(str(local_path)).take(1)[0].to_dict()
+
+        assert row["x"] == 1
+        assert row["file_path"] == "already-there"
+
+
+def test_parquet_reader_rejects_synthetic_file_path_in_projection() -> None:
+    with TemporaryDirectory() as tmp:
+        local_path = Path(tmp) / "local.parquet"
+        _write_parquet(local_path, [1])
+
+        with pytest.raises(ValueError, match="synthetic file_path_column"):
+            read_parquet(str(local_path), columns_to_read=["x", "file_path"])
 
 
 @pytest.mark.parametrize("split_sources", [False, True])

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -125,7 +125,7 @@ def test_parquet_filter_preserves_split_row_groups_and_projection(tmp_path):
     assert [row["x"] for row in out] == [
         f"{i:05d}-" + ("v" * 64) for i in range(9500, 9510)
     ]
-    assert all(set(row.keys()) == {"x"} for row in out)
+    assert all(set(row.keys()) == {"x", "file_path"} for row in out)
 
 
 def test_parquet_split_row_groups_has_no_gaps_or_overlaps(tmp_path):


### PR DESCRIPTION
## Summary
- harden `DataFolder.find()` against Hugging Face bucket listings that leak sibling prefix matches or return the bare root entry
- preserve both intended `fsspec.find()` use cases in `DataFolder`: recursive directory listings and file-path lookups
- add reusable file iteration helpers on `DataFolder` and propagate source file paths through CSV, JSONL, and Parquet readers

## What Changed
- add `DataFolder.iter_files()` and `iter_files_with_sizes()` for reusable file listing with size metadata
- override `DataFolder.find()` to bypass `DirFileSystem.find()`'s strict prefix assertion, filter backend results to the wrapped root, and preserve file-path lookups
- update `DataFileSet.expand_sources()` to:
  - preserve explicit file inputs even when `extensions=` is set
  - resolve non-glob path sources into `DataFile` or `DataFolder` once before expansion
  - reuse listing and glob size metadata to avoid redundant `fs.size()` calls during shard planning
- add a shared `filter_table()` helper and reuse it in vectorized filtering and parquet residual filtering
- add optional `file_path_column` support to CSV, JSONL, and Parquet readers, defaulting to `"file_path"`
- disable automatic file path injection for LeRobot episode reads
- add regression tests for HF-style prefix leaks, explicit file handling with extensions, file path column behavior, and `find()` on file paths

## Verification
- `uv run pytest /home/gui/macrodata/refiner/tests/io/test_datafile_datafolder.py /home/gui/macrodata/refiner/tests/readers/test_multi_source_readers.py /home/gui/macrodata/refiner/tests/readers/test_parquet_reader.py`