### PR TITLE
Add Parquet reader filtering metrics

### DIFF
--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -200,38 +200,25 @@ class ParquetReader(BaseReader):
         assert isinstance(descriptor, FilePartsDescriptor)
         for part in descriptor.parts:
             source: DataFile = self.fileset.resolve_file(part.source_index, part.path)
+            pf = self._get_parquet_file(source)
+            metadata = self._metadata(pf)
             if part.end == -1:
-                pf = self._get_parquet_file(source)
-                metadata = self._metadata(pf)
                 row_groups = (
                     list(range(len(metadata.row_group_num_rows)))
                     if metadata is not None
                     else None
                 )
-                filtered_row_groups = self._filtered_row_groups(source, row_groups)
+                row_bounds = None
+            else:
+                row_groups, row_bounds = self._row_bounds_for_span(pf, part)
+            filtered_row_groups = self._filtered_row_groups(source, row_groups)
+            if row_bounds is None:
                 self._log_pushdown_pruning(
                     shard_id=shard.id,
                     metadata=metadata,
                     row_groups=row_groups,
                     filtered_row_groups=filtered_row_groups,
                 )
-                yield from self._read_fragment_scan(
-                    source,
-                    shard_id=shard.id,
-                    row_groups=filtered_row_groups,
-                )
-                continue
-
-            pf = self._get_parquet_file(source)
-            metadata = self._metadata(pf)
-            row_groups, row_bounds = self._row_bounds_for_span(pf, part)
-            filtered_row_groups = self._filtered_row_groups(source, row_groups)
-            self._log_pushdown_pruning(
-                shard_id=shard.id,
-                metadata=metadata,
-                row_groups=row_groups,
-                filtered_row_groups=filtered_row_groups,
-            )
             row_groups = filtered_row_groups
             if row_groups == []:
                 continue
@@ -350,8 +337,6 @@ class ParquetReader(BaseReader):
             return
 
         pruned_row_groups = len(row_groups) - len(filtered_row_groups)
-        if pruned_row_groups <= 0:
-            return
         pruned_rows = sum(
             metadata.row_group_num_rows[row_group] for row_group in row_groups
         ) - sum(

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -212,13 +212,13 @@ class ParquetReader(BaseReader):
             else:
                 row_groups, row_bounds = self._row_bounds_for_span(pf, part)
             filtered_row_groups = self._filtered_row_groups(source, row_groups)
-            if row_bounds is None:
-                self._log_pushdown_pruning(
-                    shard_id=shard.id,
-                    metadata=metadata,
-                    row_groups=row_groups,
-                    filtered_row_groups=filtered_row_groups,
-                )
+            self._log_pushdown_pruning(
+                shard_id=shard.id,
+                metadata=metadata,
+                row_groups=row_groups,
+                filtered_row_groups=filtered_row_groups,
+                row_bounds=row_bounds,
+            )
             row_groups = filtered_row_groups
             if row_groups == []:
                 continue
@@ -325,6 +325,7 @@ class ParquetReader(BaseReader):
         metadata: _ParquetMetadata | None,
         row_groups: list[int] | None,
         filtered_row_groups: list[int] | None,
+        row_bounds: tuple[int, int] | None,
     ) -> None:
         if (
             self._pushdown_filter is None
@@ -336,19 +337,32 @@ class ParquetReader(BaseReader):
         if len(filtered_row_groups) >= len(row_groups):
             return
 
+        kept = set(filtered_row_groups)
+        pruned_groups = [row_group for row_group in row_groups if row_group not in kept]
         pruned_row_groups = len(row_groups) - len(filtered_row_groups)
-        pruned_rows = sum(
-            metadata.row_group_num_rows[row_group] for row_group in row_groups
-        ) - sum(
-            metadata.row_group_num_rows[row_group] for row_group in filtered_row_groups
-        )
+        if row_bounds is None:
+            pruned_rows = sum(
+                metadata.row_group_num_rows[row_group] for row_group in pruned_groups
+            )
+            log_throughput(
+                "pushdown_row_groups_filtered",
+                pruned_row_groups,
+                shard_id=shard_id,
+                unit="row_groups",
+            )
+        else:
+            row_start, row_end = row_bounds
+            pruned_rows = 0
+            for row_group in pruned_groups:
+                group_row_start = metadata.row_starts[row_group]
+                group_row_end = group_row_start + metadata.row_group_num_rows[row_group]
+                pruned_rows += max(
+                    0,
+                    min(row_end, group_row_end) - max(row_start, group_row_start),
+                )
 
-        log_throughput(
-            "pushdown_row_groups_filtered",
-            pruned_row_groups,
-            shard_id=shard_id,
-            unit="row_groups",
-        )
+        if pruned_rows <= 0:
+            return
         log_throughput(
             "total_rows_filtered",
             pruned_rows,

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -337,30 +337,23 @@ class ParquetReader(BaseReader):
         if len(filtered_row_groups) >= len(row_groups):
             return
 
-        kept = set(filtered_row_groups)
-        pruned_groups = [row_group for row_group in row_groups if row_group not in kept]
         pruned_row_groups = len(row_groups) - len(filtered_row_groups)
+        pruned_rows = self._rows_in_row_groups(
+            metadata,
+            row_groups=row_groups,
+            row_bounds=row_bounds,
+        ) - self._rows_in_row_groups(
+            metadata,
+            row_groups=filtered_row_groups,
+            row_bounds=row_bounds,
+        )
         if row_bounds is None:
-            pruned_rows = sum(
-                metadata.row_group_num_rows[row_group] for row_group in pruned_groups
-            )
             log_throughput(
                 "pushdown_row_groups_filtered",
                 pruned_row_groups,
                 shard_id=shard_id,
                 unit="row_groups",
             )
-        else:
-            row_start, row_end = row_bounds
-            pruned_rows = 0
-            for row_group in pruned_groups:
-                group_row_start = metadata.row_starts[row_group]
-                group_row_end = group_row_start + metadata.row_group_num_rows[row_group]
-                pruned_rows += max(
-                    0,
-                    min(row_end, group_row_end) - max(row_start, group_row_start),
-                )
-
         if pruned_rows <= 0:
             return
         log_throughput(
@@ -369,6 +362,28 @@ class ParquetReader(BaseReader):
             shard_id=shard_id,
             unit="rows",
         )
+
+    def _rows_in_row_groups(
+        self,
+        metadata: _ParquetMetadata,
+        *,
+        row_groups: list[int],
+        row_bounds: tuple[int, int] | None,
+    ) -> int:
+        if row_bounds is None:
+            return sum(
+                metadata.row_group_num_rows[row_group] for row_group in row_groups
+            )
+
+        row_start, row_end = row_bounds
+        total = 0
+        for row_group in row_groups:
+            group_row_start = metadata.row_starts[row_group]
+            group_row_end = group_row_start + metadata.row_group_num_rows[row_group]
+            total += max(
+                0, min(row_end, group_row_end) - max(row_start, group_row_start)
+            )
+        return total
 
     def _row_bounds_for_span(
         self,

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -22,12 +22,14 @@ from refiner.pipeline.sources.readers.base import BaseReader, Shard, SourceUnit
 from refiner.pipeline.sources.readers.utils import (
     DEFAULT_TARGET_SHARD_BYTES,
 )
+from refiner.worker.metrics.api import log_throughput
 
 
 @dataclass(frozen=True, slots=True)
 class _ParquetMetadata:
     row_group_starts: tuple[int, ...]
     row_starts: tuple[int, ...]
+    row_group_num_rows: tuple[int, ...]
     num_rows: int
 
 
@@ -171,19 +173,23 @@ class ParquetReader(BaseReader):
 
         row_group_starts: list[int] = []
         row_starts: list[int] = []
+        row_group_num_rows: list[int] = []
         total_bytes = 0
         total_rows = 0
         for index in range(md.num_row_groups):
             row_group_starts.append(total_bytes)
             row_starts.append(total_rows)
+            num_rows = int(md.row_group(index).num_rows)
+            row_group_num_rows.append(num_rows)
             width_raw = md.row_group(index).total_byte_size
             width = int(width_raw) if width_raw is not None else 0
             total_bytes += width
-            total_rows += int(md.row_group(index).num_rows)
+            total_rows += num_rows
 
         self._open_metadata = _ParquetMetadata(
             row_group_starts=tuple(row_group_starts),
             row_starts=tuple(row_starts),
+            row_group_num_rows=tuple(row_group_num_rows),
             num_rows=total_rows,
         )
         return self._open_metadata
@@ -195,19 +201,43 @@ class ParquetReader(BaseReader):
         for part in descriptor.parts:
             source: DataFile = self.fileset.resolve_file(part.source_index, part.path)
             if part.end == -1:
+                pf = self._get_parquet_file(source)
+                metadata = self._metadata(pf)
+                row_groups = (
+                    list(range(len(metadata.row_group_num_rows)))
+                    if metadata is not None
+                    else None
+                )
+                filtered_row_groups = self._filtered_row_groups(source, row_groups)
+                self._log_pushdown_pruning(
+                    shard_id=shard.id,
+                    metadata=metadata,
+                    row_groups=row_groups,
+                    filtered_row_groups=filtered_row_groups,
+                )
                 yield from self._read_fragment_scan(
                     source,
-                    row_groups=self._filtered_row_groups(source, None),
+                    shard_id=shard.id,
+                    row_groups=filtered_row_groups,
                 )
                 continue
 
             pf = self._get_parquet_file(source)
+            metadata = self._metadata(pf)
             row_groups, row_bounds = self._row_bounds_for_span(pf, part)
-            row_groups = self._filtered_row_groups(source, row_groups)
+            filtered_row_groups = self._filtered_row_groups(source, row_groups)
+            self._log_pushdown_pruning(
+                shard_id=shard.id,
+                metadata=metadata,
+                row_groups=row_groups,
+                filtered_row_groups=filtered_row_groups,
+            )
+            row_groups = filtered_row_groups
             if row_groups == []:
                 continue
             yield from self._read_fragment_scan(
                 source,
+                shard_id=shard.id,
                 row_groups=row_groups,
                 row_bounds=row_bounds,
             )
@@ -216,6 +246,7 @@ class ParquetReader(BaseReader):
         self,
         source_file: DataFile,
         *,
+        shard_id: str,
         row_groups: list[int] | None,
         row_bounds: tuple[int, int] | None = None,
     ) -> Iterator[SourceUnit]:
@@ -262,7 +293,16 @@ class ParquetReader(BaseReader):
                 offset += batch_rows
             table = pa.Table.from_batches([batch])
             if self.filter is not None:
+                before = int(table.num_rows)
                 table = filter_table(table, self.filter)
+                filtered = before - int(table.num_rows)
+                if filtered > 0:
+                    log_throughput(
+                        "total_rows_filtered",
+                        filtered,
+                        shard_id=shard_id,
+                        unit="rows",
+                    )
             if self.columns_to_read is not None:
                 table = table.select(self.columns_to_read)
             table = self._table_with_file_path(table, source_file)
@@ -290,6 +330,46 @@ class ParquetReader(BaseReader):
             )
             for row_group in row_group_fragment.row_groups
         ]
+
+    def _log_pushdown_pruning(
+        self,
+        *,
+        shard_id: str,
+        metadata: _ParquetMetadata | None,
+        row_groups: list[int] | None,
+        filtered_row_groups: list[int] | None,
+    ) -> None:
+        if (
+            self._pushdown_filter is None
+            or metadata is None
+            or row_groups is None
+            or filtered_row_groups is None
+        ):
+            return
+        if len(filtered_row_groups) >= len(row_groups):
+            return
+
+        pruned_row_groups = len(row_groups) - len(filtered_row_groups)
+        if pruned_row_groups <= 0:
+            return
+        pruned_rows = sum(
+            metadata.row_group_num_rows[row_group] for row_group in row_groups
+        ) - sum(
+            metadata.row_group_num_rows[row_group] for row_group in filtered_row_groups
+        )
+
+        log_throughput(
+            "pushdown_row_groups_filtered",
+            pruned_row_groups,
+            shard_id=shard_id,
+            unit="row_groups",
+        )
+        log_throughput(
+            "total_rows_filtered",
+            pruned_rows,
+            shard_id=shard_id,
+            unit="rows",
+        )
 
     def _row_bounds_for_span(
         self,

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -270,3 +270,32 @@ def test_parquet_logs_total_filtered_for_residual_in_memory_filter(tmp_path):
     assert "pushdown_row_groups_filtered" not in counters_by_label
     assert counters_by_label["total_rows_filtered"] == 45.0
     assert counters_by_label["rows_read"] == 5.0
+
+
+def test_parquet_does_not_log_pushdown_row_group_metrics_for_split_row_groups(tmp_path):
+    p = tmp_path / "many-row-groups.parquet"
+    table = pa.table(
+        {
+            "id": pa.array(list(range(200)), type=pa.int64()),
+            "keep": pa.array([i < 50 or i >= 150 for i in range(200)]),
+        }
+    )
+    pq.write_table(table, p, row_group_size=50)
+
+    reader = ParquetReader(
+        str(p),
+        target_shard_bytes=80,
+        split_row_groups=True,
+        filter=col("keep"),
+    )
+
+    emitter = _RecordingEmitter()
+    with set_active_user_metrics_emitter(emitter):
+        out = []
+        for shard in reader.list_shards():
+            out.extend(list(_rows_from_shard_units(reader.iter_shard_units(shard))))
+
+    assert [int(row["id"]) for row in out] == list(range(50)) + list(range(150, 200))
+    counters_by_label = _counter_totals(emitter)
+    assert "pushdown_row_groups_filtered" not in counters_by_label
+    assert "total_rows_filtered" not in counters_by_label

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -4,6 +4,47 @@ import pyarrow.parquet as pq
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.expressions import col
 from refiner.pipeline.sources.readers import ParquetReader
+from refiner.worker.metrics.context import set_active_user_metrics_emitter
+
+
+class _RecordingEmitter:
+    def __init__(self) -> None:
+        self.counters: list[dict[str, object]] = []
+
+    def emit_user_counter(self, **kwargs) -> None:
+        self.counters.append(kwargs)
+
+    def emit_user_gauge(self, **kwargs) -> None:
+        del kwargs
+
+    def register_user_gauge(self, **kwargs) -> None:
+        del kwargs
+
+    def emit_user_histogram(self, **kwargs) -> None:
+        del kwargs
+
+    def force_flush_user_metrics(self) -> None:
+        return None
+
+    def force_flush_resource_metrics(self) -> None:
+        return None
+
+    def force_flush_logs(self) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        return None
+
+
+def _counter_totals(emitter: _RecordingEmitter) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    for counter in emitter.counters:
+        label = counter["label"]
+        value = counter["value"]
+        assert isinstance(label, str)
+        assert isinstance(value, (int, float))
+        totals[label] = totals.get(label, 0.0) + float(value)
+    return totals
 
 
 def _write_parquet(tmp_path):
@@ -179,3 +220,53 @@ def test_parquet_filter_preserves_split_row_group_bounds_when_middle_groups_are_
         )
 
     assert seen == list(range(50)) + list(range(150, 200))
+
+
+def test_parquet_logs_pushdown_and_total_filtered_metrics(tmp_path):
+    p = tmp_path / "many-row-groups.parquet"
+    table = pa.table(
+        {
+            "id": pa.array(list(range(20)), type=pa.int64()),
+            "keep": pa.array([i < 10 for i in range(20)]),
+        }
+    )
+    pq.write_table(table, p, row_group_size=10)
+
+    reader = ParquetReader(
+        str(p),
+        target_shard_bytes=100_000,
+        filter=col("keep"),
+    )
+
+    emitter = _RecordingEmitter()
+    with set_active_user_metrics_emitter(emitter):
+        out = []
+        for shard in reader.list_shards():
+            out.extend(list(_rows_from_shard_units(reader.iter_shard_units(shard))))
+
+    assert [int(row["id"]) for row in out] == list(range(10))
+    counters_by_label = _counter_totals(emitter)
+    assert counters_by_label["pushdown_row_groups_filtered"] == 1.0
+    assert counters_by_label["total_rows_filtered"] == 10.0
+    assert counters_by_label["rows_read"] == 10.0
+
+
+def test_parquet_logs_total_filtered_for_residual_in_memory_filter(tmp_path):
+    p = _write_parquet(tmp_path)
+    reader = ParquetReader(
+        str(p),
+        target_shard_bytes=200,
+        filter=col("x").str.endswith("7"),
+    )
+
+    emitter = _RecordingEmitter()
+    with set_active_user_metrics_emitter(emitter):
+        out = []
+        for shard in reader.list_shards():
+            out.extend(list(_rows_from_shard_units(reader.iter_shard_units(shard))))
+
+    assert [int(row["id"]) for row in out] == [7, 17, 27, 37, 47]
+    counters_by_label = _counter_totals(emitter)
+    assert "pushdown_row_groups_filtered" not in counters_by_label
+    assert counters_by_label["total_rows_filtered"] == 45.0
+    assert counters_by_label["rows_read"] == 5.0

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -298,4 +298,4 @@ def test_parquet_does_not_log_pushdown_row_group_metrics_for_split_row_groups(tm
     assert [int(row["id"]) for row in out] == list(range(50)) + list(range(150, 200))
     counters_by_label = _counter_totals(emitter)
     assert "pushdown_row_groups_filtered" not in counters_by_label
-    assert "total_rows_filtered" not in counters_by_label
+    assert counters_by_label["total_rows_filtered"] == 100.0


### PR DESCRIPTION
## Summary
- add Parquet reader metrics for pushdown-pruned row groups and total filtered rows
- count in-memory residual filtering toward the same total filtered metric
- add reader-level tests covering pushdown and residual filtering metrics

## Validation
- uv run pytest -q tests/readers/test_parquet_reader.py
- uv run ty check src/refiner/pipeline/sources/readers/parquet.py tests/readers/test_parquet_reader.py
- uv run ruff check src/refiner/pipeline/sources/readers/parquet.py tests/readers/test_parquet_reader.py