### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.2.1"
+version = "0.2.2"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -879,7 +879,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
## Summary
- bump the package version from 0.2.1 to 0.2.2
- update the lockfile package version entry to match

## Validation
- pre-commit hooks from commit ran successfully
- uv run ty check
