### PR TITLE
Add local launcher stage heartbeats

### DIFF
--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -38,6 +38,8 @@ class LaunchStats:
 
 class LocalLauncher(BaseLauncher):
     _STAGE_HEARTBEAT_INTERVAL_SECONDS = 15.0
+    _STAGE_HEARTBEAT_FAILURE_THRESHOLD = 3
+    _PROCESS_POLL_INTERVAL_SECONDS = 1.0
 
     def __init__(
         self,
@@ -196,7 +198,9 @@ class LocalLauncher(BaseLauncher):
         gpu_ids: tuple[str, ...],
     ) -> subprocess.Popen[str]:
         cmd = [
-            sys.executable,
+            "uv",
+            "run",
+            "python",
             "-m",
             "refiner.worker.entrypoint",
             "--pipeline-payload",
@@ -302,18 +306,23 @@ class LocalLauncher(BaseLauncher):
 
         stop_event = threading.Event()
         heartbeat_errors: list[BaseException] = []
+        consecutive_failures = 0
 
         def _run() -> None:
+            nonlocal consecutive_failures
             while not stop_event.wait(self._STAGE_HEARTBEAT_INTERVAL_SECONDS):
                 try:
                     tracking_client.report_stage_heartbeat(
                         job_id=job_id,
                         stage_index=stage_index,
                     )
+                    consecutive_failures = 0
                 except BaseException as err:
-                    heartbeat_errors.append(err)
-                    stop_event.set()
-                    return
+                    consecutive_failures += 1
+                    if consecutive_failures >= self._STAGE_HEARTBEAT_FAILURE_THRESHOLD:
+                        heartbeat_errors.append(err)
+                        stop_event.set()
+                        return
 
         thread = threading.Thread(
             target=_run,
@@ -323,10 +332,42 @@ class LocalLauncher(BaseLauncher):
         thread.start()
         return stop_event, heartbeat_errors, thread
 
+    @staticmethod
+    def _terminate_processes(
+        processes: list[tuple[str, subprocess.Popen[str]]],
+    ) -> None:
+        for _, process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for _, process in processes:
+            try:
+                process.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5.0)
+
+    def _wait_for_processes(
+        self,
+        *,
+        processes: list[tuple[str, subprocess.Popen[str]]],
+        stage_index: int,
+        heartbeat_errors: list[BaseException] | None,
+    ) -> None:
+        while True:
+            if heartbeat_errors:
+                self._terminate_processes(processes)
+                raise RuntimeError(
+                    f"stage {stage_index} heartbeat failed: {heartbeat_errors[0]}"
+                ) from heartbeat_errors[0]
+            if all(process.poll() is not None for _, process in processes):
+                return
+            time.sleep(self._PROCESS_POLL_INTERVAL_SECONDS)
+
     def _launch_stage(
         self,
         *,
         stage: PlannedStage,
+        heartbeat_errors: list[BaseException] | None = None,
     ) -> LaunchStats:
         # Resolve worker capacity and remaining stage shards.
         stage_workers = stage.compute.num_workers
@@ -412,6 +453,12 @@ class LocalLauncher(BaseLauncher):
                 )
             )
 
+        self._wait_for_processes(
+            processes=processes,
+            stage_index=stage.index,
+            heartbeat_errors=heartbeat_errors,
+        )
+
         return self._collect_worker_results(
             stage_workers=stage_workers,
             processes=processes,
@@ -468,11 +515,8 @@ class LocalLauncher(BaseLauncher):
             try:
                 stage_stats = self._launch_stage(
                     stage=stage,
+                    heartbeat_errors=heartbeat_errors,
                 )
-                if heartbeat_errors:
-                    raise RuntimeError(
-                        f"stage {stage.index} heartbeat failed: {heartbeat_errors[0]}"
-                    ) from heartbeat_errors[0]
             except KeyboardInterrupt:
                 if tracking_client is not None:
                     try:

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -36,6 +37,8 @@ class LaunchStats:
 
 
 class LocalLauncher(BaseLauncher):
+    _STAGE_HEARTBEAT_INTERVAL_SECONDS = 15.0
+
     def __init__(
         self,
         *,
@@ -263,6 +266,63 @@ class LocalLauncher(BaseLauncher):
         )
         return tracking_client
 
+    def _report_stage_finished(
+        self,
+        *,
+        tracking_client: MacrodataClient,
+        stage_index: int,
+        status: str,
+        reason: str | None = None,
+    ) -> None:
+        if self.job_id is None:
+            raise RuntimeError("local launcher job_id is unset")
+        if reason and reason.strip():
+            tracking_client.report_stage_finished(
+                job_id=self.job_id,
+                stage_index=stage_index,
+                status=status,
+                reason=reason.strip(),
+            )
+            return
+        tracking_client.report_stage_finished(
+            job_id=self.job_id,
+            stage_index=stage_index,
+            status=status,
+        )
+
+    def _start_stage_heartbeat(
+        self,
+        *,
+        tracking_client: MacrodataClient,
+        stage_index: int,
+    ) -> tuple[threading.Event, list[BaseException], threading.Thread]:
+        if self.job_id is None:
+            raise RuntimeError("local launcher job_id is unset")
+        job_id = self.job_id
+
+        stop_event = threading.Event()
+        heartbeat_errors: list[BaseException] = []
+
+        def _run() -> None:
+            while not stop_event.wait(self._STAGE_HEARTBEAT_INTERVAL_SECONDS):
+                try:
+                    tracking_client.report_stage_heartbeat(
+                        job_id=job_id,
+                        stage_index=stage_index,
+                    )
+                except BaseException as err:
+                    heartbeat_errors.append(err)
+                    stop_event.set()
+                    return
+
+        thread = threading.Thread(
+            target=_run,
+            name=f"refiner-stage-heartbeat-{stage_index}",
+            daemon=True,
+        )
+        thread.start()
+        return stop_event, heartbeat_errors, thread
+
     def _launch_stage(
         self,
         *,
@@ -384,10 +444,21 @@ class LocalLauncher(BaseLauncher):
             output_rows=0,
         )
         for stage in stages:
+            heartbeat_stop: threading.Event | None = None
+            heartbeat_errors: list[BaseException] | None = None
+            heartbeat_thread: threading.Thread | None = None
             if tracking_client is not None:
                 try:
                     tracking_client.report_stage_started(
                         job_id=self.job_id,
+                        stage_index=stage.index,
+                    )
+                    (
+                        heartbeat_stop,
+                        heartbeat_errors,
+                        heartbeat_thread,
+                    ) = self._start_stage_heartbeat(
+                        tracking_client=tracking_client,
                         stage_index=stage.index,
                     )
                 except Exception as err:
@@ -398,11 +469,29 @@ class LocalLauncher(BaseLauncher):
                 stage_stats = self._launch_stage(
                     stage=stage,
                 )
+                if heartbeat_errors:
+                    raise RuntimeError(
+                        f"stage {stage.index} heartbeat failed: {heartbeat_errors[0]}"
+                    ) from heartbeat_errors[0]
+            except KeyboardInterrupt:
+                if tracking_client is not None:
+                    try:
+                        self._report_stage_finished(
+                            tracking_client=tracking_client,
+                            stage_index=stage.index,
+                            status="failed",
+                            reason="Local launcher interrupted",
+                        )
+                    except Exception as err:
+                        logger.warning(
+                            f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
+                        )
+                raise
             except Exception:
                 if tracking_client is not None:
                     try:
-                        tracking_client.report_stage_finished(
-                            job_id=self.job_id,
+                        self._report_stage_finished(
+                            tracking_client=tracking_client,
                             stage_index=stage.index,
                             status="failed",
                         )
@@ -411,10 +500,15 @@ class LocalLauncher(BaseLauncher):
                             f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
                         )
                 raise
+            finally:
+                if heartbeat_stop is not None:
+                    heartbeat_stop.set()
+                if heartbeat_thread is not None:
+                    heartbeat_thread.join(timeout=1.0)
             if tracking_client is not None:
                 try:
-                    tracking_client.report_stage_finished(
-                        job_id=self.job_id,
+                    self._report_stage_finished(
+                        tracking_client=tracking_client,
                         stage_index=stage.index,
                         status="completed" if stage_stats.failed == 0 else "failed",
                     )

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -50,6 +50,8 @@ class LocalLauncher(BaseLauncher):
     _STAGE_HEARTBEAT_INTERVAL_SECONDS = 15.0
     _STAGE_HEARTBEAT_FAILURE_THRESHOLD = 3
     _PROCESS_POLL_INTERVAL_SECONDS = 1.0
+    _WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS = 5.0
+    _HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
 
     def __init__(
         self,
@@ -105,7 +107,11 @@ class LocalLauncher(BaseLauncher):
         output_rows = 0
         for worker_id, process, state, reader_thread in processes:
             if reader_thread is not None:
-                reader_thread.join()
+                reader_thread.join(timeout=self._WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS)
+                if reader_thread.is_alive():
+                    errors.append(
+                        f"worker {worker_id}: output reader did not finish within {self._WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS:.1f}s"
+                    )
             error_state = state.get("error")
             if error_state is not None:
                 errors.append(f"worker {worker_id}: {error_state}")
@@ -548,6 +554,7 @@ class LocalLauncher(BaseLauncher):
             heartbeat_errors: list[Exception] | None = None
             heartbeat_thread: threading.Thread | None = None
             post_shutdown_error: Exception | None = None
+            stage_error: BaseException | None = None
             if tracking_client is not None:
                 try:
                     tracking_client.report_stage_started(
@@ -571,7 +578,8 @@ class LocalLauncher(BaseLauncher):
                     stage=stage,
                     heartbeat_errors=heartbeat_errors,
                 )
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as err:
+                stage_error = err
                 if tracking_client is not None:
                     try:
                         self._report_stage_finished(
@@ -585,7 +593,8 @@ class LocalLauncher(BaseLauncher):
                             f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
                         )
                 raise
-            except Exception:
+            except Exception as err:
+                stage_error = err
                 if tracking_client is not None:
                     try:
                         self._report_stage_finished(
@@ -602,14 +611,26 @@ class LocalLauncher(BaseLauncher):
                 if heartbeat_stop is not None:
                     heartbeat_stop.set()
                 if heartbeat_thread is not None:
-                    heartbeat_thread.join(timeout=1.0)
-                try:
-                    self._raise_for_heartbeat_failure(
-                        stage_index=stage.index,
-                        heartbeat_errors=heartbeat_errors,
+                    heartbeat_thread.join(
+                        timeout=self._HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS
                     )
-                except Exception as err:
-                    post_shutdown_error = err
+                    thread_alive = getattr(heartbeat_thread, "is_alive", None)
+                    if (
+                        callable(thread_alive)
+                        and thread_alive()
+                        and stage_error is None
+                    ):
+                        post_shutdown_error = RuntimeError(
+                            f"stage {stage.index} heartbeat thread did not stop within {self._HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS:.1f}s"
+                        )
+                if stage_error is None:
+                    try:
+                        self._raise_for_heartbeat_failure(
+                            stage_index=stage.index,
+                            heartbeat_errors=heartbeat_errors,
+                        )
+                    except Exception as err:
+                        post_shutdown_error = err
             if post_shutdown_error is not None:
                 if tracking_client is not None:
                     try:

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -38,14 +38,12 @@ class LaunchStats:
     output_rows: int
 
 
-@dataclass(slots=True)
-class _WorkerOutput:
-    worker_id: str
-    process: subprocess.Popen[str]
-    stdout: str = ""
-    stderr: str = ""
-    error: Exception | None = None
-    reader_thread: threading.Thread | None = None
+_WorkerOutput = tuple[
+    str,
+    subprocess.Popen[str],
+    dict[str, object],
+    threading.Thread | None,
+]
 
 
 class LocalLauncher(BaseLauncher):
@@ -105,14 +103,14 @@ class LocalLauncher(BaseLauncher):
         completed = 0
         failed = 0
         output_rows = 0
-        for output in processes:
-            process = output.process
-            if output.reader_thread is not None:
-                output.reader_thread.join(timeout=1.0)
-            if output.error is not None:
-                errors.append(f"worker {output.worker_id}: {output.error}")
-            stdout = output.stdout
-            stderr = output.stderr
+        for worker_id, process, state, reader_thread in processes:
+            if reader_thread is not None:
+                reader_thread.join()
+            error_state = state.get("error")
+            if error_state is not None:
+                errors.append(f"worker {worker_id}: {error_state}")
+            stdout = str(state.get("stdout", ""))
+            stderr = str(state.get("stderr", ""))
             final_stdout_line = next(
                 (line for line in reversed(stdout.splitlines()) if line.strip()),
                 "",
@@ -123,7 +121,7 @@ class LocalLauncher(BaseLauncher):
                     decoded
                     if isinstance(decoded, dict)
                     else self._failed_worker_payload(
-                        worker_id=output.worker_id,
+                        worker_id=worker_id,
                         stdout=stdout,
                         stderr=stderr,
                         returncode=process.returncode,
@@ -131,7 +129,7 @@ class LocalLauncher(BaseLauncher):
                 )
             except json.JSONDecodeError:
                 raw = self._failed_worker_payload(
-                    worker_id=output.worker_id,
+                    worker_id=worker_id,
                     stdout=stdout,
                     stderr=stderr,
                     returncode=process.returncode,
@@ -354,12 +352,10 @@ class LocalLauncher(BaseLauncher):
     def _terminate_processes(
         processes: list[_WorkerOutput],
     ) -> None:
-        for output in processes:
-            process = output.process
+        for _, process, _, _ in processes:
             if process.poll() is None:
                 process.terminate()
-        for output in processes:
-            process = output.process
+        for _, process, _, _ in processes:
             try:
                 process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
@@ -367,22 +363,29 @@ class LocalLauncher(BaseLauncher):
                 process.wait(timeout=5.0)
 
     @staticmethod
-    def _start_worker_output_reader(output: _WorkerOutput) -> None:
+    def _start_worker_output_reader(
+        *,
+        worker_id: str,
+        process: subprocess.Popen[str],
+    ) -> tuple[dict[str, object], threading.Thread]:
+        state: dict[str, object] = {"stdout": "", "stderr": "", "error": None}
+
         def _read() -> None:
             try:
-                stdout, stderr = output.process.communicate()
+                stdout, stderr = process.communicate()
             except Exception as err:
-                output.error = err
+                state["error"] = err
                 return
-            output.stdout = stdout
-            output.stderr = stderr
+            state["stdout"] = stdout
+            state["stderr"] = stderr
 
-        output.reader_thread = threading.Thread(
+        thread = threading.Thread(
             target=_read,
-            name=f"refiner-worker-output-{output.worker_id}",
+            name=f"refiner-worker-output-{worker_id}",
             daemon=True,
         )
-        output.reader_thread.start()
+        thread.start()
+        return state, thread
 
     @staticmethod
     def _raise_for_heartbeat_failure(
@@ -409,7 +412,7 @@ class LocalLauncher(BaseLauncher):
                     stage_index=stage_index,
                     heartbeat_errors=heartbeat_errors,
                 )
-            if all(output.process.poll() is not None for output in processes):
+            if all(process.poll() is not None for _, process, _, _ in processes):
                 return
             time.sleep(self._PROCESS_POLL_INTERVAL_SECONDS)
 
@@ -488,20 +491,20 @@ class LocalLauncher(BaseLauncher):
                     sort_keys=True,
                 )
             )
-            output = _WorkerOutput(
+            process = self._spawn_local_worker(
+                pipeline_payload=str(payload_path),
+                job_id=self.job_id,
+                stage_index=stage.index,
+                worker_name=f"stage-{stage.index}-rank-{rank}",
                 worker_id=worker_id,
-                process=self._spawn_local_worker(
-                    pipeline_payload=str(payload_path),
-                    job_id=self.job_id,
-                    stage_index=stage.index,
-                    worker_name=f"stage-{stage.index}-rank-{rank}",
-                    worker_id=worker_id,
-                    rundir=self.rundir,
-                    gpu_ids=tuple(gpu_sets[rank]),
-                ),
+                rundir=self.rundir,
+                gpu_ids=tuple(gpu_sets[rank]),
             )
-            self._start_worker_output_reader(output)
-            processes.append(output)
+            state, reader_thread = self._start_worker_output_reader(
+                worker_id=worker_id,
+                process=process,
+            )
+            processes.append((worker_id, process, state, reader_thread))
 
         self._wait_for_processes(
             processes=processes,

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -268,23 +268,6 @@ class LocalLauncher(BaseLauncher):
         )
         return tracking_client
 
-    def _report_stage_finished(
-        self,
-        *,
-        tracking_client: MacrodataClient,
-        stage_index: int,
-        status: str,
-        reason: str | None = None,
-    ) -> None:
-        if self.job_id is None:
-            raise RuntimeError("local launcher job_id is unset")
-        tracking_client.report_stage_finished(
-            job_id=self.job_id,
-            stage_index=stage_index,
-            status=status,
-            reason=reason,
-        )
-
     def _start_stage_heartbeat(
         self,
         *,
@@ -471,8 +454,8 @@ class LocalLauncher(BaseLauncher):
             except KeyboardInterrupt:
                 if tracking_client is not None:
                     try:
-                        self._report_stage_finished(
-                            tracking_client=tracking_client,
+                        tracking_client.report_stage_finished(
+                            job_id=self.job_id,
                             stage_index=stage.index,
                             status="failed",
                             reason="Local launcher interrupted",
@@ -485,8 +468,8 @@ class LocalLauncher(BaseLauncher):
             except Exception:
                 if tracking_client is not None:
                     try:
-                        self._report_stage_finished(
-                            tracking_client=tracking_client,
+                        tracking_client.report_stage_finished(
+                            job_id=self.job_id,
                             stage_index=stage.index,
                             status="failed",
                         )
@@ -508,8 +491,8 @@ class LocalLauncher(BaseLauncher):
                         )
             if tracking_client is not None:
                 try:
-                    self._report_stage_finished(
-                        tracking_client=tracking_client,
+                    tracking_client.report_stage_finished(
+                        job_id=self.job_id,
                         stage_index=stage.index,
                         status="completed" if stage_stats.failed == 0 else "failed",
                     )

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -38,6 +38,16 @@ class LaunchStats:
     output_rows: int
 
 
+@dataclass(slots=True)
+class _WorkerOutput:
+    worker_id: str
+    process: subprocess.Popen[str]
+    stdout: str = ""
+    stderr: str = ""
+    error: Exception | None = None
+    reader_thread: threading.Thread | None = None
+
+
 class LocalLauncher(BaseLauncher):
     _STAGE_HEARTBEAT_INTERVAL_SECONDS = 15.0
     _STAGE_HEARTBEAT_FAILURE_THRESHOLD = 3
@@ -86,7 +96,7 @@ class LocalLauncher(BaseLauncher):
         self,
         *,
         stage_workers: int,
-        processes: list[tuple[str, subprocess.Popen[str]]],
+        processes: list[_WorkerOutput],
     ) -> LaunchStats:
         if self.job_id is None:
             raise RuntimeError("local launcher job_id is unset")
@@ -95,8 +105,14 @@ class LocalLauncher(BaseLauncher):
         completed = 0
         failed = 0
         output_rows = 0
-        for worker_id, process in processes:
-            stdout, stderr = process.communicate()
+        for output in processes:
+            process = output.process
+            if output.reader_thread is not None:
+                output.reader_thread.join(timeout=1.0)
+            if output.error is not None:
+                errors.append(f"worker {output.worker_id}: {output.error}")
+            stdout = output.stdout
+            stderr = output.stderr
             final_stdout_line = next(
                 (line for line in reversed(stdout.splitlines()) if line.strip()),
                 "",
@@ -107,7 +123,7 @@ class LocalLauncher(BaseLauncher):
                     decoded
                     if isinstance(decoded, dict)
                     else self._failed_worker_payload(
-                        worker_id=worker_id,
+                        worker_id=output.worker_id,
                         stdout=stdout,
                         stderr=stderr,
                         returncode=process.returncode,
@@ -115,7 +131,7 @@ class LocalLauncher(BaseLauncher):
                 )
             except json.JSONDecodeError:
                 raw = self._failed_worker_payload(
-                    worker_id=worker_id,
+                    worker_id=output.worker_id,
                     stdout=stdout,
                     stderr=stderr,
                     returncode=process.returncode,
@@ -336,32 +352,64 @@ class LocalLauncher(BaseLauncher):
 
     @staticmethod
     def _terminate_processes(
-        processes: list[tuple[str, subprocess.Popen[str]]],
+        processes: list[_WorkerOutput],
     ) -> None:
-        for _, process in processes:
+        for output in processes:
+            process = output.process
             if process.poll() is None:
                 process.terminate()
-        for _, process in processes:
+        for output in processes:
+            process = output.process
             try:
                 process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=5.0)
 
+    @staticmethod
+    def _start_worker_output_reader(output: _WorkerOutput) -> None:
+        def _read() -> None:
+            try:
+                stdout, stderr = output.process.communicate()
+            except Exception as err:
+                output.error = err
+                return
+            output.stdout = stdout
+            output.stderr = stderr
+
+        output.reader_thread = threading.Thread(
+            target=_read,
+            name=f"refiner-worker-output-{output.worker_id}",
+            daemon=True,
+        )
+        output.reader_thread.start()
+
+    @staticmethod
+    def _raise_for_heartbeat_failure(
+        *,
+        stage_index: int,
+        heartbeat_errors: list[Exception] | None,
+    ) -> None:
+        if heartbeat_errors:
+            raise RuntimeError(
+                f"stage {stage_index} heartbeat failed: {heartbeat_errors[0]}"
+            ) from heartbeat_errors[0]
+
     def _wait_for_processes(
         self,
         *,
-        processes: list[tuple[str, subprocess.Popen[str]]],
+        processes: list[_WorkerOutput],
         stage_index: int,
         heartbeat_errors: list[Exception] | None,
     ) -> None:
         while True:
             if heartbeat_errors:
                 self._terminate_processes(processes)
-                raise RuntimeError(
-                    f"stage {stage_index} heartbeat failed: {heartbeat_errors[0]}"
-                ) from heartbeat_errors[0]
-            if all(process.poll() is not None for _, process in processes):
+                self._raise_for_heartbeat_failure(
+                    stage_index=stage_index,
+                    heartbeat_errors=heartbeat_errors,
+                )
+            if all(output.process.poll() is not None for output in processes):
                 return
             time.sleep(self._PROCESS_POLL_INTERVAL_SECONDS)
 
@@ -427,7 +475,7 @@ class LocalLauncher(BaseLauncher):
 
         # Spawn one subprocess per worker assignment.
         worker_ids = [uuid4().hex[:12] for _ in range(stage_workers)]
-        processes: list[tuple[str, subprocess.Popen[str]]] = []
+        processes: list[_WorkerOutput] = []
         for rank in range(stage_workers):
             worker_id = worker_ids[rank]
             assignments_path = (
@@ -440,20 +488,20 @@ class LocalLauncher(BaseLauncher):
                     sort_keys=True,
                 )
             )
-            processes.append(
-                (
-                    worker_id,
-                    self._spawn_local_worker(
-                        pipeline_payload=str(payload_path),
-                        job_id=self.job_id,
-                        stage_index=stage.index,
-                        worker_name=f"stage-{stage.index}-rank-{rank}",
-                        worker_id=worker_id,
-                        rundir=self.rundir,
-                        gpu_ids=tuple(gpu_sets[rank]),
-                    ),
-                )
+            output = _WorkerOutput(
+                worker_id=worker_id,
+                process=self._spawn_local_worker(
+                    pipeline_payload=str(payload_path),
+                    job_id=self.job_id,
+                    stage_index=stage.index,
+                    worker_name=f"stage-{stage.index}-rank-{rank}",
+                    worker_id=worker_id,
+                    rundir=self.rundir,
+                    gpu_ids=tuple(gpu_sets[rank]),
+                ),
             )
+            self._start_worker_output_reader(output)
+            processes.append(output)
 
         self._wait_for_processes(
             processes=processes,
@@ -496,6 +544,7 @@ class LocalLauncher(BaseLauncher):
             heartbeat_stop: threading.Event | None = None
             heartbeat_errors: list[Exception] | None = None
             heartbeat_thread: threading.Thread | None = None
+            post_shutdown_error: Exception | None = None
             if tracking_client is not None:
                 try:
                     tracking_client.report_stage_started(
@@ -551,6 +600,26 @@ class LocalLauncher(BaseLauncher):
                     heartbeat_stop.set()
                 if heartbeat_thread is not None:
                     heartbeat_thread.join(timeout=1.0)
+                try:
+                    self._raise_for_heartbeat_failure(
+                        stage_index=stage.index,
+                        heartbeat_errors=heartbeat_errors,
+                    )
+                except Exception as err:
+                    post_shutdown_error = err
+            if post_shutdown_error is not None:
+                if tracking_client is not None:
+                    try:
+                        self._report_stage_finished(
+                            tracking_client=tracking_client,
+                            stage_index=stage.index,
+                            status="failed",
+                        )
+                    except Exception as err:
+                        logger.warning(
+                            f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
+                        )
+                raise post_shutdown_error
             if tracking_client is not None:
                 try:
                     self._report_stage_finished(

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import threading
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -38,19 +36,9 @@ class LaunchStats:
     output_rows: int
 
 
-_WorkerOutput = tuple[
-    str,
-    subprocess.Popen[str],
-    dict[str, object],
-    threading.Thread | None,
-]
-
-
 class LocalLauncher(BaseLauncher):
     _STAGE_HEARTBEAT_INTERVAL_SECONDS = 15.0
     _STAGE_HEARTBEAT_FAILURE_THRESHOLD = 3
-    _PROCESS_POLL_INTERVAL_SECONDS = 1.0
-    _WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS = 5.0
     _HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
 
     def __init__(
@@ -96,7 +84,7 @@ class LocalLauncher(BaseLauncher):
         self,
         *,
         stage_workers: int,
-        processes: list[_WorkerOutput],
+        processes: list[tuple[str, subprocess.Popen[str]]],
     ) -> LaunchStats:
         if self.job_id is None:
             raise RuntimeError("local launcher job_id is unset")
@@ -105,18 +93,8 @@ class LocalLauncher(BaseLauncher):
         completed = 0
         failed = 0
         output_rows = 0
-        for worker_id, process, state, reader_thread in processes:
-            if reader_thread is not None:
-                reader_thread.join(timeout=self._WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS)
-                if reader_thread.is_alive():
-                    errors.append(
-                        f"worker {worker_id}: output reader did not finish within {self._WORKER_OUTPUT_JOIN_TIMEOUT_SECONDS:.1f}s"
-                    )
-            error_state = state.get("error")
-            if error_state is not None:
-                errors.append(f"worker {worker_id}: {error_state}")
-            stdout = str(state.get("stdout", ""))
-            stderr = str(state.get("stderr", ""))
+        for worker_id, process in processes:
+            stdout, stderr = process.communicate()
             final_stdout_line = next(
                 (line for line in reversed(stdout.splitlines()) if line.strip()),
                 "",
@@ -219,14 +197,6 @@ class LocalLauncher(BaseLauncher):
         rundir: str,
         gpu_ids: tuple[str, ...],
     ) -> subprocess.Popen[str]:
-        src_root = str(Path(__file__).resolve().parents[2])
-        env = os.environ.copy()
-        existing_pythonpath = env.get("PYTHONPATH", "").strip()
-        env["PYTHONPATH"] = (
-            f"{src_root}{os.pathsep}{existing_pythonpath}"
-            if existing_pythonpath
-            else src_root
-        )
         cmd = [
             sys.executable,
             "-m",
@@ -251,7 +221,6 @@ class LocalLauncher(BaseLauncher):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env=env,
         )
 
     def _register_tracked_job(
@@ -321,13 +290,12 @@ class LocalLauncher(BaseLauncher):
         *,
         tracking_client: MacrodataClient,
         stage_index: int,
-    ) -> tuple[threading.Event, list[Exception], threading.Thread]:
+    ) -> tuple[threading.Event, threading.Thread]:
         if self.job_id is None:
             raise RuntimeError("local launcher job_id is unset")
         job_id = self.job_id
 
         stop_event = threading.Event()
-        heartbeat_errors: list[Exception] = []
         consecutive_failures = 0
 
         def _run() -> None:
@@ -342,7 +310,9 @@ class LocalLauncher(BaseLauncher):
                 except Exception as err:
                     consecutive_failures += 1
                     if consecutive_failures >= self._STAGE_HEARTBEAT_FAILURE_THRESHOLD:
-                        heartbeat_errors.append(err)
+                        logger.warning(
+                            f"Stopping local stage {stage_index} heartbeats after {consecutive_failures} consecutive failure(s): {err}"
+                        )
                         stop_event.set()
                         return
 
@@ -352,81 +322,12 @@ class LocalLauncher(BaseLauncher):
             daemon=True,
         )
         thread.start()
-        return stop_event, heartbeat_errors, thread
-
-    @staticmethod
-    def _terminate_processes(
-        processes: list[_WorkerOutput],
-    ) -> None:
-        for _, process, _, _ in processes:
-            if process.poll() is None:
-                process.terminate()
-        for _, process, _, _ in processes:
-            try:
-                process.wait(timeout=5.0)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5.0)
-
-    @staticmethod
-    def _start_worker_output_reader(
-        *,
-        worker_id: str,
-        process: subprocess.Popen[str],
-    ) -> tuple[dict[str, object], threading.Thread]:
-        state: dict[str, object] = {"stdout": "", "stderr": "", "error": None}
-
-        def _read() -> None:
-            try:
-                stdout, stderr = process.communicate()
-            except Exception as err:
-                state["error"] = err
-                return
-            state["stdout"] = stdout
-            state["stderr"] = stderr
-
-        thread = threading.Thread(
-            target=_read,
-            name=f"refiner-worker-output-{worker_id}",
-            daemon=True,
-        )
-        thread.start()
-        return state, thread
-
-    @staticmethod
-    def _raise_for_heartbeat_failure(
-        *,
-        stage_index: int,
-        heartbeat_errors: list[Exception] | None,
-    ) -> None:
-        if heartbeat_errors:
-            raise RuntimeError(
-                f"stage {stage_index} heartbeat failed: {heartbeat_errors[0]}"
-            ) from heartbeat_errors[0]
-
-    def _wait_for_processes(
-        self,
-        *,
-        processes: list[_WorkerOutput],
-        stage_index: int,
-        heartbeat_errors: list[Exception] | None,
-    ) -> None:
-        while True:
-            if heartbeat_errors:
-                self._terminate_processes(processes)
-                self._raise_for_heartbeat_failure(
-                    stage_index=stage_index,
-                    heartbeat_errors=heartbeat_errors,
-                )
-            if all(process.poll() is not None for _, process, _, _ in processes):
-                return
-            time.sleep(self._PROCESS_POLL_INTERVAL_SECONDS)
+        return stop_event, thread
 
     def _launch_stage(
         self,
         *,
         stage: PlannedStage,
-        heartbeat_errors: list[Exception] | None = None,
     ) -> LaunchStats:
         # Resolve worker capacity and remaining stage shards.
         stage_workers = stage.compute.num_workers
@@ -484,7 +385,7 @@ class LocalLauncher(BaseLauncher):
 
         # Spawn one subprocess per worker assignment.
         worker_ids = [uuid4().hex[:12] for _ in range(stage_workers)]
-        processes: list[_WorkerOutput] = []
+        processes: list[tuple[str, subprocess.Popen[str]]] = []
         for rank in range(stage_workers):
             worker_id = worker_ids[rank]
             assignments_path = (
@@ -497,26 +398,20 @@ class LocalLauncher(BaseLauncher):
                     sort_keys=True,
                 )
             )
-            process = self._spawn_local_worker(
-                pipeline_payload=str(payload_path),
-                job_id=self.job_id,
-                stage_index=stage.index,
-                worker_name=f"stage-{stage.index}-rank-{rank}",
-                worker_id=worker_id,
-                rundir=self.rundir,
-                gpu_ids=tuple(gpu_sets[rank]),
+            processes.append(
+                (
+                    worker_id,
+                    self._spawn_local_worker(
+                        pipeline_payload=str(payload_path),
+                        job_id=self.job_id,
+                        stage_index=stage.index,
+                        worker_name=f"stage-{stage.index}-rank-{rank}",
+                        worker_id=worker_id,
+                        rundir=self.rundir,
+                        gpu_ids=tuple(gpu_sets[rank]),
+                    ),
+                )
             )
-            state, reader_thread = self._start_worker_output_reader(
-                worker_id=worker_id,
-                process=process,
-            )
-            processes.append((worker_id, process, state, reader_thread))
-
-        self._wait_for_processes(
-            processes=processes,
-            stage_index=stage.index,
-            heartbeat_errors=heartbeat_errors,
-        )
 
         return self._collect_worker_results(
             stage_workers=stage_workers,
@@ -551,10 +446,7 @@ class LocalLauncher(BaseLauncher):
         )
         for stage in stages:
             heartbeat_stop: threading.Event | None = None
-            heartbeat_errors: list[Exception] | None = None
             heartbeat_thread: threading.Thread | None = None
-            post_shutdown_error: Exception | None = None
-            stage_error: BaseException | None = None
             if tracking_client is not None:
                 try:
                     tracking_client.report_stage_started(
@@ -563,7 +455,6 @@ class LocalLauncher(BaseLauncher):
                     )
                     (
                         heartbeat_stop,
-                        heartbeat_errors,
                         heartbeat_thread,
                     ) = self._start_stage_heartbeat(
                         tracking_client=tracking_client,
@@ -576,10 +467,8 @@ class LocalLauncher(BaseLauncher):
             try:
                 stage_stats = self._launch_stage(
                     stage=stage,
-                    heartbeat_errors=heartbeat_errors,
                 )
-            except KeyboardInterrupt as err:
-                stage_error = err
+            except KeyboardInterrupt:
                 if tracking_client is not None:
                     try:
                         self._report_stage_finished(
@@ -593,8 +482,7 @@ class LocalLauncher(BaseLauncher):
                             f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
                         )
                 raise
-            except Exception as err:
-                stage_error = err
+            except Exception:
                 if tracking_client is not None:
                     try:
                         self._report_stage_finished(
@@ -614,36 +502,10 @@ class LocalLauncher(BaseLauncher):
                     heartbeat_thread.join(
                         timeout=self._HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS
                     )
-                    thread_alive = getattr(heartbeat_thread, "is_alive", None)
-                    if (
-                        callable(thread_alive)
-                        and thread_alive()
-                        and stage_error is None
-                    ):
-                        post_shutdown_error = RuntimeError(
-                            f"stage {stage.index} heartbeat thread did not stop within {self._HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS:.1f}s"
-                        )
-                if stage_error is None:
-                    try:
-                        self._raise_for_heartbeat_failure(
-                            stage_index=stage.index,
-                            heartbeat_errors=heartbeat_errors,
-                        )
-                    except Exception as err:
-                        post_shutdown_error = err
-            if post_shutdown_error is not None:
-                if tracking_client is not None:
-                    try:
-                        self._report_stage_finished(
-                            tracking_client=tracking_client,
-                            stage_index=stage.index,
-                            status="failed",
-                        )
-                    except Exception as err:
+                    if heartbeat_thread.is_alive():
                         logger.warning(
-                            f"Failed to report local stage {stage.index} finish to Macrodata: {err}"
+                            f"Local stage {stage.index} heartbeat thread did not stop within {self._HEARTBEAT_THREAD_JOIN_TIMEOUT_SECONDS:.1f}s"
                         )
-                raise post_shutdown_error
             if tracking_client is not None:
                 try:
                     self._report_stage_finished(

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -197,10 +199,16 @@ class LocalLauncher(BaseLauncher):
         rundir: str,
         gpu_ids: tuple[str, ...],
     ) -> subprocess.Popen[str]:
+        src_root = str(Path(__file__).resolve().parents[2])
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH", "").strip()
+        env["PYTHONPATH"] = (
+            f"{src_root}{os.pathsep}{existing_pythonpath}"
+            if existing_pythonpath
+            else src_root
+        )
         cmd = [
-            "uv",
-            "run",
-            "python",
+            sys.executable,
             "-m",
             "refiner.worker.entrypoint",
             "--pipeline-payload",
@@ -223,6 +231,7 @@ class LocalLauncher(BaseLauncher):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=env,
         )
 
     def _register_tracked_job(
@@ -280,18 +289,11 @@ class LocalLauncher(BaseLauncher):
     ) -> None:
         if self.job_id is None:
             raise RuntimeError("local launcher job_id is unset")
-        if reason and reason.strip():
-            tracking_client.report_stage_finished(
-                job_id=self.job_id,
-                stage_index=stage_index,
-                status=status,
-                reason=reason.strip(),
-            )
-            return
         tracking_client.report_stage_finished(
             job_id=self.job_id,
             stage_index=stage_index,
             status=status,
+            reason=reason,
         )
 
     def _start_stage_heartbeat(
@@ -299,13 +301,13 @@ class LocalLauncher(BaseLauncher):
         *,
         tracking_client: MacrodataClient,
         stage_index: int,
-    ) -> tuple[threading.Event, list[BaseException], threading.Thread]:
+    ) -> tuple[threading.Event, list[Exception], threading.Thread]:
         if self.job_id is None:
             raise RuntimeError("local launcher job_id is unset")
         job_id = self.job_id
 
         stop_event = threading.Event()
-        heartbeat_errors: list[BaseException] = []
+        heartbeat_errors: list[Exception] = []
         consecutive_failures = 0
 
         def _run() -> None:
@@ -317,7 +319,7 @@ class LocalLauncher(BaseLauncher):
                         stage_index=stage_index,
                     )
                     consecutive_failures = 0
-                except BaseException as err:
+                except Exception as err:
                     consecutive_failures += 1
                     if consecutive_failures >= self._STAGE_HEARTBEAT_FAILURE_THRESHOLD:
                         heartbeat_errors.append(err)
@@ -351,7 +353,7 @@ class LocalLauncher(BaseLauncher):
         *,
         processes: list[tuple[str, subprocess.Popen[str]]],
         stage_index: int,
-        heartbeat_errors: list[BaseException] | None,
+        heartbeat_errors: list[Exception] | None,
     ) -> None:
         while True:
             if heartbeat_errors:
@@ -367,7 +369,7 @@ class LocalLauncher(BaseLauncher):
         self,
         *,
         stage: PlannedStage,
-        heartbeat_errors: list[BaseException] | None = None,
+        heartbeat_errors: list[Exception] | None = None,
     ) -> LaunchStats:
         # Resolve worker capacity and remaining stage shards.
         stage_workers = stage.compute.num_workers
@@ -492,7 +494,7 @@ class LocalLauncher(BaseLauncher):
         )
         for stage in stages:
             heartbeat_stop: threading.Event | None = None
-            heartbeat_errors: list[BaseException] | None = None
+            heartbeat_errors: list[Exception] | None = None
             heartbeat_thread: threading.Thread | None = None
             if tracking_client is not None:
                 try:

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -207,13 +207,34 @@ class MacrodataClient:
         )
 
     def report_stage_finished(
-        self, *, job_id: str, stage_index: int, status: str
+        self,
+        *,
+        job_id: str,
+        stage_index: int,
+        status: str,
+        reason: str | None = None,
     ) -> StageLifecycleResponse:
+        payload: dict[str, Any] = {"status": status}
+        if reason and reason.strip():
+            payload["reason"] = reason.strip()
         return self._request(
             method="POST",
             path=f"/api/jobs/{job_id}/stages/{stage_index}/finish",
             response_type=StageLifecycleResponse,
-            json_payload={"status": status},
+            json_payload=payload,
+        )
+
+    def report_stage_heartbeat(
+        self,
+        *,
+        job_id: str,
+        stage_index: int,
+    ) -> StageLifecycleResponse:
+        return self._request(
+            method="POST",
+            path=f"/api/jobs/{job_id}/stages/{stage_index}/heartbeat",
+            response_type=StageLifecycleResponse,
+            json_payload={},
         )
 
     def cloud_submit_job(

--- a/src/refiner/worker/entrypoint.py
+++ b/src/refiner/worker/entrypoint.py
@@ -32,11 +32,11 @@ def main() -> int:
         "error": None,
     }
     try:
-        with open(args.pipeline_payload, "rb") as f:
-            pipeline = cloudpickle.load(f)
         gpu_ids = parse_gpu_ids(args.gpu_ids)
         if gpu_ids:
             set_visible_gpu_ids(gpu_ids)
+        with open(args.pipeline_payload, "rb") as f:
+            pipeline = cloudpickle.load(f)
 
         with open(
             f"{args.rundir}/stage-{args.stage_index}/assignments/worker-{args.worker_id}.json",

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
+import threading
 import pytest
 
 from refiner.pipeline.data.shard import FilePart, Shard
@@ -521,3 +522,85 @@ def test_local_launcher_reports_failed_stage_to_tracking(
         launcher.launch()
 
     assert finished == [("job-remote", 0, "failed")]
+
+
+def test_local_launcher_reports_interrupted_stage_with_reason(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "a.jsonl"
+    path.write_text('{"x": 1}\n')
+    pipeline = read_jsonl(str(path))
+    finished: list[dict[str, object]] = []
+    heartbeat_started: list[int] = []
+
+    class _FakeClient:
+        base_url = "https://macrodata.co"
+
+        def create_job(self, **kwargs):
+            from refiner.platform.client.models import CreateJobResponse
+
+            return CreateJobResponse(
+                job_id="job-remote",
+                stage_index=0,
+                workspace_slug="workspace",
+            )
+
+        def report_stage_started(self, *, job_id: str, stage_index: int):
+            return None
+
+        def report_stage_finished(self, **kwargs):
+            finished.append(kwargs)
+
+    class _DummyThread:
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+    monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")
+    monkeypatch.setattr(
+        "refiner.launchers.local.MacrodataClient", lambda **kwargs: _FakeClient()
+    )
+
+    launcher = LocalLauncher(
+        pipeline=pipeline,
+        name="local-stage-interrupt-report",
+        num_workers=1,
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_planned_stages",
+        lambda: [
+            PlannedStage(
+                index=0,
+                name="stage_0",
+                pipeline=pipeline,
+                compute=StageComputeRequirements(num_workers=1),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_start_stage_heartbeat",
+        lambda *, tracking_client, stage_index: (
+            heartbeat_started.append(stage_index) or threading.Event(),
+            [],
+            _DummyThread(),
+        ),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_launch_stage",
+        lambda **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        launcher.launch()
+
+    assert heartbeat_started == [0]
+    assert finished == [
+        {
+            "job_id": "job-remote",
+            "stage_index": 0,
+            "status": "failed",
+            "reason": "Local launcher interrupted",
+        }
+    ]

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -708,6 +708,5 @@ def test_local_launcher_does_not_fail_stage_when_heartbeat_delivery_fails(
             "job_id": "job-remote",
             "stage_index": 0,
             "status": "completed",
-            "reason": None,
         }
     ]

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
+import subprocess
 import threading
+from typing import cast
 import pytest
 
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline import RefinerPipeline, read_csv, read_jsonl
-from refiner.launchers.local import LaunchStats, LocalLauncher
+from refiner.launchers.local import LaunchStats, LocalLauncher, _WorkerOutput
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
@@ -621,3 +623,122 @@ def test_local_launcher_reports_interrupted_stage_with_reason(
             "reason": "Local launcher interrupted",
         }
     ]
+
+
+def test_local_launcher_reports_failed_stage_when_heartbeat_dies_during_shutdown(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "a.jsonl"
+    path.write_text('{"x": 1}\n')
+    pipeline = read_jsonl(str(path))
+    finished: list[dict[str, object]] = []
+    heartbeat_errors: list[Exception] = [RuntimeError("heartbeat offline")]
+
+    class _FakeClient:
+        base_url = "https://macrodata.co"
+
+        def create_job(self, **kwargs):
+            from refiner.platform.client.models import CreateJobResponse
+
+            return CreateJobResponse(
+                job_id="job-remote",
+                stage_index=0,
+                workspace_slug="workspace",
+            )
+
+        def report_stage_started(self, *, job_id: str, stage_index: int):
+            return None
+
+        def report_stage_finished(self, **kwargs):
+            finished.append(kwargs)
+
+    class _DummyThread:
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+    monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")
+    monkeypatch.setattr(
+        "refiner.launchers.local.MacrodataClient", lambda **kwargs: _FakeClient()
+    )
+
+    launcher = LocalLauncher(
+        pipeline=pipeline,
+        name="local-stage-heartbeat-shutdown-failure",
+        num_workers=1,
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_planned_stages",
+        lambda: [
+            PlannedStage(
+                index=0,
+                name="stage_0",
+                pipeline=pipeline,
+                compute=StageComputeRequirements(num_workers=1),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_start_stage_heartbeat",
+        lambda *, tracking_client, stage_index: (
+            threading.Event(),
+            heartbeat_errors,
+            _DummyThread(),
+        ),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "_launch_stage",
+        lambda *, stage, heartbeat_errors=None: LaunchStats(
+            job_id="job-remote",
+            workers=1,
+            claimed=1,
+            completed=1,
+            failed=0,
+            output_rows=1,
+        ),
+    )
+
+    with pytest.raises(
+        RuntimeError, match="stage 0 heartbeat failed: heartbeat offline"
+    ):
+        launcher.launch()
+
+    assert finished == [
+        {
+            "job_id": "job-remote",
+            "stage_index": 0,
+            "status": "failed",
+            "reason": None,
+        }
+    ]
+
+
+def test_collect_worker_results_uses_reader_output_without_communicate() -> None:
+    launcher = LocalLauncher(
+        pipeline=RefinerPipeline(source=_FakeReader([], {})),
+        name="local-pipe-drain",
+        num_workers=1,
+    )
+    launcher.job_id = "job-1"
+
+    class _FakeProcess:
+        returncode = 0
+
+        def communicate(self):
+            raise AssertionError("communicate should already be running in the reader")
+
+    output = _WorkerOutput(
+        worker_id="worker-1",
+        process=cast("subprocess.Popen[str]", _FakeProcess()),
+        stdout='{"worker_id":"worker-1","claimed":1,"completed":1,"failed":0,"output_rows":2}\n',
+        stderr="",
+    )
+
+    stats = launcher._collect_worker_results(stage_workers=1, processes=[output])
+
+    assert stats.claimed == 1
+    assert stats.completed == 1
+    assert stats.failed == 0
+    assert stats.output_rows == 2

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -244,7 +244,7 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
     monkeypatch.setattr(
         launcher,
         "_launch_stage",
-        lambda *, stage: LaunchStats(
+        lambda *, stage, heartbeat_errors=None: LaunchStats(
             job_id="job-remote",
             workers=1,
             claimed=1,
@@ -403,7 +403,8 @@ def test_local_launcher_stops_after_failed_stage(
 
     monkeypatch.setattr(launcher, "_planned_stages", lambda: stages)
 
-    def fake_launch_stage(*, stage):  # noqa: ANN001
+    def fake_launch_stage(*, stage, heartbeat_errors=None):  # noqa: ANN001
+        assert heartbeat_errors is None or isinstance(heartbeat_errors, list)
         launched.append(stage.index)
         return LaunchStats(
             job_id="job-1",
@@ -450,7 +451,7 @@ def test_local_launcher_does_not_force_platform_terminal_state(
     monkeypatch.setattr(
         launcher,
         "_launch_stage",
-        lambda *, stage: LaunchStats(
+        lambda *, stage, heartbeat_errors=None: LaunchStats(
             job_id="job-1",
             workers=1,
             claimed=1,

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
-import subprocess
 import threading
-from typing import cast
+import time
 import pytest
 
 from refiner.pipeline.data.shard import FilePart, Shard
@@ -254,7 +253,7 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
     monkeypatch.setattr(
         launcher,
         "_launch_stage",
-        lambda *, stage, heartbeat_errors=None: LaunchStats(
+        lambda *, stage: LaunchStats(
             job_id="job-remote",
             workers=1,
             claimed=1,
@@ -413,8 +412,7 @@ def test_local_launcher_stops_after_failed_stage(
 
     monkeypatch.setattr(launcher, "_planned_stages", lambda: stages)
 
-    def fake_launch_stage(*, stage, heartbeat_errors=None):  # noqa: ANN001
-        assert heartbeat_errors is None or isinstance(heartbeat_errors, list)
+    def fake_launch_stage(*, stage):  # noqa: ANN001
         launched.append(stage.index)
         return LaunchStats(
             job_id="job-1",
@@ -461,7 +459,7 @@ def test_local_launcher_does_not_force_platform_terminal_state(
     monkeypatch.setattr(
         launcher,
         "_launch_stage",
-        lambda *, stage, heartbeat_errors=None: LaunchStats(
+        lambda *, stage: LaunchStats(
             job_id="job-1",
             workers=1,
             claimed=1,
@@ -574,6 +572,9 @@ def test_local_launcher_reports_interrupted_stage_with_reason(
         def join(self, timeout: float | None = None) -> None:
             return None
 
+        def is_alive(self) -> bool:
+            return False
+
     monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")
     monkeypatch.setattr(
         "refiner.launchers.local.MacrodataClient", lambda **kwargs: _FakeClient()
@@ -601,7 +602,6 @@ def test_local_launcher_reports_interrupted_stage_with_reason(
         "_start_stage_heartbeat",
         lambda *, tracking_client, stage_index: (
             heartbeat_started.append(stage_index) or threading.Event(),
-            [],
             _DummyThread(),
         ),
     )
@@ -625,14 +625,14 @@ def test_local_launcher_reports_interrupted_stage_with_reason(
     ]
 
 
-def test_local_launcher_reports_failed_stage_when_heartbeat_dies_during_shutdown(
+def test_local_launcher_does_not_fail_stage_when_heartbeat_delivery_fails(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = tmp_path / "a.jsonl"
     path.write_text('{"x": 1}\n')
     pipeline = read_jsonl(str(path))
     finished: list[dict[str, object]] = []
-    heartbeat_errors: list[Exception] = [RuntimeError("heartbeat offline")]
+    heartbeat_attempts = 0
 
     class _FakeClient:
         base_url = "https://macrodata.co"
@@ -649,12 +649,13 @@ def test_local_launcher_reports_failed_stage_when_heartbeat_dies_during_shutdown
         def report_stage_started(self, *, job_id: str, stage_index: int):
             return None
 
+        def report_stage_heartbeat(self, *, job_id: str, stage_index: int):
+            nonlocal heartbeat_attempts
+            heartbeat_attempts += 1
+            raise RuntimeError("heartbeat offline")
+
         def report_stage_finished(self, **kwargs):
             finished.append(kwargs)
-
-    class _DummyThread:
-        def join(self, timeout: float | None = None) -> None:
-            return None
 
     monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")
     monkeypatch.setattr(
@@ -663,9 +664,11 @@ def test_local_launcher_reports_failed_stage_when_heartbeat_dies_during_shutdown
 
     launcher = LocalLauncher(
         pipeline=pipeline,
-        name="local-stage-heartbeat-shutdown-failure",
+        name="local-stage-heartbeat-delivery-failure",
         num_workers=1,
     )
+    launcher._STAGE_HEARTBEAT_INTERVAL_SECONDS = 0.01
+    launcher._STAGE_HEARTBEAT_FAILURE_THRESHOLD = 2
     monkeypatch.setattr(
         launcher,
         "_planned_stages",
@@ -678,74 +681,33 @@ def test_local_launcher_reports_failed_stage_when_heartbeat_dies_during_shutdown
             )
         ],
     )
-    monkeypatch.setattr(
-        launcher,
-        "_start_stage_heartbeat",
-        lambda *, tracking_client, stage_index: (
-            threading.Event(),
-            heartbeat_errors,
-            _DummyThread(),
-        ),
-    )
-    monkeypatch.setattr(
-        launcher,
-        "_launch_stage",
-        lambda *, stage, heartbeat_errors=None: LaunchStats(
+
+    def fake_launch_stage(*, stage):  # noqa: ANN001
+        time.sleep(0.05)
+        return LaunchStats(
             job_id="job-remote",
             workers=1,
             claimed=1,
             completed=1,
             failed=0,
             output_rows=1,
-        ),
+        )
+
+    monkeypatch.setattr(
+        launcher,
+        "_launch_stage",
+        fake_launch_stage,
     )
 
-    with pytest.raises(
-        RuntimeError, match="stage 0 heartbeat failed: heartbeat offline"
-    ):
-        launcher.launch()
+    stats = launcher.launch()
 
+    assert stats.completed == 1
+    assert heartbeat_attempts >= 2
     assert finished == [
         {
             "job_id": "job-remote",
             "stage_index": 0,
-            "status": "failed",
+            "status": "completed",
             "reason": None,
         }
     ]
-
-
-def test_collect_worker_results_uses_reader_output_without_communicate() -> None:
-    launcher = LocalLauncher(
-        pipeline=RefinerPipeline(source=_FakeReader([], {})),
-        name="local-pipe-drain",
-        num_workers=1,
-    )
-    launcher.job_id = "job-1"
-
-    class _FakeProcess:
-        returncode = 0
-
-        def communicate(self):
-            raise AssertionError("communicate should already be running in the reader")
-
-    output = (
-        "worker-1",
-        cast("subprocess.Popen[str]", _FakeProcess()),
-        cast(
-            "dict[str, object]",
-            {
-                "stdout": '{"worker_id":"worker-1","claimed":1,"completed":1,"failed":0,"output_rows":2}\n',
-                "stderr": "",
-                "error": None,
-            },
-        ),
-        None,
-    )
-
-    stats = launcher._collect_worker_results(stage_workers=1, processes=[output])
-
-    assert stats.claimed == 1
-    assert stats.completed == 1
-    assert stats.failed == 0
-    assert stats.output_rows == 2

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -8,7 +8,7 @@ import pytest
 
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline import RefinerPipeline, read_csv, read_jsonl
-from refiner.launchers.local import LaunchStats, LocalLauncher, _WorkerOutput
+from refiner.launchers.local import LaunchStats, LocalLauncher
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
@@ -729,11 +729,18 @@ def test_collect_worker_results_uses_reader_output_without_communicate() -> None
         def communicate(self):
             raise AssertionError("communicate should already be running in the reader")
 
-    output = _WorkerOutput(
-        worker_id="worker-1",
-        process=cast("subprocess.Popen[str]", _FakeProcess()),
-        stdout='{"worker_id":"worker-1","claimed":1,"completed":1,"failed":0,"output_rows":2}\n',
-        stderr="",
+    output = (
+        "worker-1",
+        cast("subprocess.Popen[str]", _FakeProcess()),
+        cast(
+            "dict[str, object]",
+            {
+                "stdout": '{"worker_id":"worker-1","claimed":1,"completed":1,"failed":0,"output_rows":2}\n',
+                "stderr": "",
+                "error": None,
+            },
+        ),
+        None,
     )
 
     stats = launcher._collect_worker_results(stage_workers=1, processes=[output])

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -216,7 +216,15 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
         def report_stage_started(self, *, job_id: str, stage_index: int):
             started.append((job_id, stage_index))
 
-        def report_stage_finished(self, *, job_id: str, stage_index: int, status: str):
+        def report_stage_finished(
+            self,
+            *,
+            job_id: str,
+            stage_index: int,
+            status: str,
+            reason: str | None = None,
+        ):
+            assert reason is None
             finished.append((job_id, stage_index, status))
 
     monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")
@@ -488,7 +496,15 @@ def test_local_launcher_reports_failed_stage_to_tracking(
         def report_stage_started(self, *, job_id: str, stage_index: int):
             return None
 
-        def report_stage_finished(self, *, job_id: str, stage_index: int, status: str):
+        def report_stage_finished(
+            self,
+            *,
+            job_id: str,
+            stage_index: int,
+            status: str,
+            reason: str | None = None,
+        ):
+            assert reason is None
             finished.append((job_id, stage_index, status))
 
     monkeypatch.setattr("refiner.launchers.local.current_api_key", lambda: "md_test")

--- a/tests/platform/test_client.py
+++ b/tests/platform/test_client.py
@@ -54,3 +54,21 @@ def test_client_prefers_env_api_key_over_saved_key(
     client = MacrodataClient(base_url="https://example.com")
 
     assert client.api_key == "md_env"
+
+
+def test_report_stage_heartbeat_posts_to_stage_heartbeat_route(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request_json(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"stage": {"job_id": "job-1", "index": 2, "status": "running"}}
+
+    monkeypatch.setattr("refiner.platform.client.api.request_json", fake_request_json)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    response = client.report_stage_heartbeat(job_id="job-1", stage_index=2)
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/jobs/job-1/stages/2/heartbeat"
+    assert captured["json_payload"] == {}
+    assert response.stage.status == "running"

--- a/tests/worker/test_entrypoint.py
+++ b/tests/worker/test_entrypoint.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from refiner.worker import entrypoint
+
+
+def test_entrypoint_sets_visible_gpus_before_loading_pipeline(
+    tmp_path, monkeypatch
+) -> None:
+    payload_path = tmp_path / "pipeline.cloudpickle"
+    payload_path.write_bytes(b"placeholder")
+    assignments_dir = tmp_path / "stage-2" / "assignments"
+    assignments_dir.mkdir(parents=True, exist_ok=True)
+    (assignments_dir / "worker-worker-1.json").write_text("[]")
+
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "entrypoint.py",
+            "--pipeline-payload",
+            str(payload_path),
+            "--job-id",
+            "job-1",
+            "--stage-index",
+            "2",
+            "--worker-name",
+            "worker-name",
+            "--worker-id",
+            "worker-1",
+            "--rundir",
+            str(tmp_path),
+            "--gpu-ids",
+            "0,1",
+        ],
+    )
+    monkeypatch.setattr(
+        entrypoint,
+        "set_visible_gpu_ids",
+        lambda gpu_ids: events.append(f"set:{','.join(gpu_ids)}"),
+    )
+    monkeypatch.setattr(
+        entrypoint.cloudpickle,
+        "load",
+        lambda handle: events.append("load") or object(),
+    )
+    monkeypatch.setattr(
+        entrypoint,
+        "Worker",
+        lambda **kwargs: type(
+            "_FakeWorker",
+            (),
+            {
+                "run": staticmethod(
+                    lambda: type(
+                        "_FakeStats",
+                        (),
+                        {
+                            "claimed": 0,
+                            "completed": 0,
+                            "failed": 0,
+                            "output_rows": 0,
+                        },
+                    )()
+                )
+            },
+        )(),
+    )
+
+    assert entrypoint.main() == 0
+    assert events[:2] == ["set:0,1", "load"]


### PR DESCRIPTION
## Summary
- start a Modal-style attached heartbeat thread for tracked local stages
- report interrupted local stages as failed instead of leaving them orphaned
- add client coverage for the new local stage heartbeat endpoint

## Testing
- `uv run pytest tests/platform/test_client.py tests/launchers/test_local_launcher.py`

## Companion
- backend support lives in `macrodata-labs/perpetuity` PR for `codex/stage-session-heartbeats`