### PR TITLE
[codex] Clarify local launcher rundir lifecycle

### DIFF
--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -6,7 +6,7 @@ import sys
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 import cloudpickle
@@ -57,7 +57,9 @@ class LocalLauncher(BaseLauncher):
             gpus_per_worker=gpus_per_worker,
         )
         self.job_id: str | None = None
-        self.rundir: str | None = rundir
+        self.rundir: str | None = (
+            str(Path(rundir).expanduser().resolve()) if rundir is not None else None
+        )
 
     @staticmethod
     def _failed_worker_payload(
@@ -225,7 +227,7 @@ class LocalLauncher(BaseLauncher):
 
     def _register_tracked_job(
         self, *, stages: list[PlannedStage]
-    ) -> MacrodataClient | None:
+    ) -> tuple[MacrodataClient | None, str | None]:
         try:
             api_key = current_api_key()
         except MacrodataCredentialsError:
@@ -240,33 +242,40 @@ class LocalLauncher(BaseLauncher):
             logger.warning(
                 "No valid Macrodata API key found. Run `macrodata login` to track local jobs."
             )
-            return None
+            return None, None
         except Exception as err:
             logger.warning(
                 f"Failed to load Macrodata credentials for local tracking: {err}"
             )
-            return None
+            return None, None
 
         tracking_client = MacrodataClient(api_key=api_key)
         try:
+            manifest = self._run_manifest()
+            manifest_environment = cast(
+                dict[str, Any], manifest.setdefault("environment", {})
+            )
+            if not isinstance(manifest_environment, dict):
+                raise RuntimeError("run manifest environment must be a dict")
+            manifest_environment["rundir"] = (
+                self.rundir
+                if self.rundir is not None
+                else str(Path(resolve_workdir()) / "runs" / "<jobid>")
+            )
             registered_job = tracking_client.create_job(
                 name=self.name,
                 executor={"type": "refiner-local"},
                 plan=self._compiled_plan(stages),
-                manifest=self._run_manifest(),
+                manifest=manifest,
             )
         except Exception as err:
             logger.warning(f"Failed to register local job with Macrodata: {err}")
-            return None
-
-        self.job_id = registered_job.job_id
-        if self.rundir is None:
-            self.rundir = str(Path(resolve_workdir()) / "runs" / self.job_id)
+            return None, None
         logger.info(
             "Local job registered. View job:\n  "
-            f"{self._job_tracking_url(client=tracking_client, job_id=self.job_id, workspace_slug=registered_job.workspace_slug)}"
+            f"{self._job_tracking_url(client=tracking_client, job_id=registered_job.job_id, workspace_slug=registered_job.workspace_slug)}"
         )
-        return tracking_client
+        return tracking_client, registered_job.job_id
 
     def _start_stage_heartbeat(
         self,
@@ -408,14 +417,11 @@ class LocalLauncher(BaseLauncher):
                 f"launch requested {self.num_workers} workers, but only {available_cpus} CPUs are available on this machine."
             )
         stages = self._planned_stages()
-        explicit_rundir = self.rundir
-        self.job_id = self._build_local_job_id(self.name)
-        self.rundir = None
-        tracking_client = self._register_tracked_job(stages=stages)
-        if explicit_rundir is None:
+        tracking_client, self.job_id = self._register_tracked_job(stages=stages)
+        if self.job_id is None:
+            self.job_id = self._build_local_job_id(self.name)
+        if self.rundir is None:
             self.rundir = str(Path(resolve_workdir()) / "runs" / self.job_id)
-        else:
-            self.rundir = str(Path(explicit_rundir).expanduser().resolve())
         if self.job_id is None or self.rundir is None:
             raise RuntimeError("local launcher did not initialize job state")
         logger.info(f"Starting local job {self.job_id} with rundir={self.rundir}")

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping, Sequence
 import threading
 import time
+from typing import cast
 import pytest
 
 from refiner.pipeline.data.shard import FilePart, Shard
@@ -232,6 +233,11 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
     monkeypatch.setattr(
         "refiner.launchers.local.MacrodataClient", lambda **kwargs: _FakeClient()
     )
+    monkeypatch.setattr(
+        LocalLauncher,
+        "_build_local_job_id",
+        staticmethod(lambda name: "job-local"),
+    )
 
     launcher = LocalLauncher(
         pipeline=pipeline,
@@ -266,6 +272,9 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
 
     assert create_calls
     assert create_calls[0]["executor"] == {"type": "refiner-local"}
+    manifest = cast(dict[str, object], create_calls[0]["manifest"])
+    environment = cast(dict[str, object], manifest["environment"])
+    assert environment["rundir"] == str(tmp_path / "runs" / "<jobid>")
     assert started == [("job-remote", 0)]
     assert finished == [("job-remote", 0, "completed")]
 
@@ -288,6 +297,11 @@ def test_local_launcher_warns_without_credentials(
         "refiner.launchers.local.logger.warning",
         lambda message: warnings.append(message),
     )
+    monkeypatch.setattr(
+        LocalLauncher,
+        "_build_local_job_id",
+        staticmethod(lambda name: "job-local"),
+    )
 
     launcher = LocalLauncher(
         pipeline=pipeline,
@@ -300,6 +314,28 @@ def test_local_launcher_warns_without_credentials(
     assert warnings == [
         "No valid Macrodata API key found. Run `macrodata login` to track local jobs."
     ]
+    assert launcher.job_id == "job-local"
+
+
+def test_local_launcher_normalizes_explicit_rundir_on_init(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "a.jsonl"
+    path.write_text('{"x": 1}\n')
+    pipeline = read_jsonl(str(path))
+    monkeypatch.chdir(tmp_path)
+
+    launcher = LocalLauncher(
+        pipeline=pipeline,
+        name="local-explicit-rundir-normalized",
+        num_workers=1,
+        rundir="custom-run",
+    )
+
+    monkeypatch.setattr(launcher, "_planned_stages", lambda: [])
+    launcher.launch()
+
+    assert launcher.rundir == str((tmp_path / "custom-run").resolve())
 
 
 def test_launch_local_runs_planned_stages_sequentially(

--- a/tests/platform/test_manifest.py
+++ b/tests/platform/test_manifest.py
@@ -96,6 +96,31 @@ def test_build_run_manifest_omits_stage_runtimes_by_default(
     assert manifest["environment"]["refiner_ref"] is None
 
 
+def test_build_run_manifest_environment_does_not_include_rundir_by_default(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_installed_version",
+        lambda: "0.2.0",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_direct_url_git_sha",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_local_repo_git_sha",
+        lambda: None,
+    )
+
+    manifest = build_run_manifest()
+
+    assert "rundir" not in manifest["environment"]
+
+
 def test_refiner_ref_exists_on_remote_returns_true_on_success(monkeypatch) -> None:
     monkeypatch.setattr(
         "refiner.platform.manifest.urllib_request.urlopen",


### PR DESCRIPTION
## What changed

This PR makes the local launcher's `job_id` and `rundir` initialization flow explicit and consistent.

- normalize an explicit `rundir` once during `LocalLauncher` initialization
- have tracked-job registration return `(tracking_client, registered_job_id)` instead of mutating `self.job_id` internally
- assign `self.job_id` directly in `launch()` and only fall back to a local job id when registration does not return one
- derive the default local `rundir` only after the final `job_id` has been chosen
- include the local launch `rundir` in the tracked manifest via the launcher path instead of changing the base manifest defaults
- add tests covering manifest behavior, explicit `rundir` normalization, and local `job_id` fallback

## Why

The previous flow spread `job_id` and `rundir` decisions across `__init__()`, `_register_tracked_job()`, and `launch()`, which made the control flow harder to follow. This version keeps the final ownership in `launch()` so the fallback order is obvious:

1. use the tracked job id when registration succeeds
2. otherwise create a local job id
3. if no explicit `rundir` was provided, derive it from the final chosen job id

## Impact

This does not change the intended local-launch behavior, but it makes the lifecycle easier to reason about and reduces hidden state mutation.

## Validation

- `ruff (uv)` via git commit hook
- `ruff format (uv)` via git commit hook
- `ty (uv)` via git commit hook
- `uv run python -m pytest tests/launchers/test_local_launcher.py` could not run in this environment because `pytest` is not installed in the resolved `uv` interpreter
