### PR TITLE
Harden terminal text sanitizer

### DIFF
--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -33,7 +33,11 @@ _USER_AGENT = (
 
 
 def sanitize_terminal_text(value: str) -> str:
-    return "".join(ch for ch in value if ch >= " " and ch != "\x7f")
+    return "".join(
+        ch
+        for ch in value
+        if ch >= " " and ch != "\x7f" and not (0x80 <= ord(ch) <= 0x9F)
+    )
 
 
 def resolve_platform_base_url() -> str:

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -33,11 +33,7 @@ _USER_AGENT = (
 
 
 def sanitize_terminal_text(value: str) -> str:
-    return "".join(
-        ch
-        for ch in value
-        if ch >= " " and ch != "\x7f" and not (0x80 <= ord(ch) <= 0x9F)
-    )
+    return "".join(ch for ch in value if " " <= ch < "\x7f" or ch >= "\xa0")
 
 
 def resolve_platform_base_url() -> str:

--- a/tests/launchers/test_base_launcher.py
+++ b/tests/launchers/test_base_launcher.py
@@ -31,7 +31,7 @@ def test_job_tracking_url_sanitizes_terminal_control_characters() -> None:
     launcher = _DummyLauncher(
         pipeline=cast(RefinerPipeline, object()), name="unit-test"
     )
-    client = MacrodataClient(api_key="md_test", base_url="https://app.example.com")
+    client = MacrodataClient(api_key="md_test", base_url="https://app.\x9bexample.com")
 
     url = launcher._job_tracking_url(
         client=client,
@@ -42,6 +42,7 @@ def test_job_tracking_url_sanitizes_terminal_control_characters() -> None:
     assert url == "https://app.example.com/jobs/macrodata/job-[31m"
     assert "\x07" not in url
     assert "\x1b" not in url
+    assert "\x9b" not in url
 
 
 def test_compiled_plan_includes_stage_worker_counts(monkeypatch) -> None:

--- a/tests/platform/test_http.py
+++ b/tests/platform/test_http.py
@@ -21,7 +21,7 @@ def test_http_error_message_uses_reason_phrase_for_html_body() -> None:
 def test_http_error_message_strips_control_chars() -> None:
     resp = httpx.Response(
         500,
-        json={"error": "\x1b[31mboom\x1b[0m"},
+        json={"error": "\x1b[31mboom\x9b[0m"},
         request=httpx.Request("GET", "https://macrodata.co/api/me"),
     )
 


### PR DESCRIPTION
## Summary
- strip C1 control bytes from the shared terminal text sanitizer
- cover the shared HTTP error path with a C1 regression test
- cover launcher job tracking URL sanitization with a C1 byte in the base URL

## Validation
- `uv run pytest tests/platform/test_http.py tests/launchers/test_base_launcher.py`
- `uv run ruff check src/refiner/platform/client/api.py tests/platform/test_http.py tests/launchers/test_base_launcher.py`