### PR TITLE
[codex] add cloud logs follow and mdr cli alias

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,12 +80,14 @@ Options:
 - `--kind local|cloud`
 - `--limit <count>`
 - `--me`
-- `--cursor <opaque_cursor>`
+- `--cursor <cursor>`
 - `--json`
 
 ```bash
 macrodata jobs list --kind cloud
 macrodata jobs list --me
+macrodata jobs list --json
+macrodata jobs list --cursor <next_cursor>
 ```
 
 ### `macrodata jobs get`
@@ -125,13 +127,14 @@ Options:
 
 - `--stage <stage_index>`
 - `--limit <count>`
-- `--cursor <opaque_cursor>`
+- `--cursor <cursor>`
 - `--json`
 
 ```bash
 macrodata jobs workers <job_id> --stage 0
 macrodata jobs workers <job_id> --limit 50
-macrodata jobs workers <job_id> --cursor <opaque_cursor>
+macrodata jobs workers <job_id> --json
+macrodata jobs workers <job_id> --cursor <next_cursor>
 ```
 
 ### `macrodata jobs logs`
@@ -150,6 +153,7 @@ Options:
 - `--search <text>`
 - `--start-ms <epoch_ms>`
 - `--end-ms <epoch_ms>`
+- `--cursor <cursor>`
 - `--limit <count>`
 - `--follow`
 - `--json`
@@ -159,11 +163,16 @@ Notes:
 - `--search` requires `--stage`
 - `--search` requires both `--start-ms` and `--end-ms`
 - `--search` supports at most 100 results per request
-- `--follow` polls for new log entries until interrupted
-- `--follow` cannot be combined with `--json` or `--search`
+- `--cursor` reuses `nextCursor` from a previous response to fetch the next page in the same window
+- one-shot log fetches default to `100` entries per request
+- `--follow` defaults to `500` entries per request
+- `--follow` may skip older backlog under sustained log volume to stay live; when it does, it prints the skipped timestamp range and recovery guidance
+- `--follow` cannot be combined with `--json`, `--cursor`, or `--search`
 
 ```bash
 macrodata jobs logs <job_id>
+macrodata jobs logs <job_id> --json
+macrodata jobs logs <job_id> --start-ms 1713340800000 --end-ms 1713341700000 --cursor <next_cursor>
 macrodata jobs logs <job_id> --follow
 macrodata jobs logs <job_id> --stage 0 --severity error
 macrodata jobs logs <job_id> --stage 0 --search retry --start-ms 1713340800000 --end-ms 1713341700000 --limit 50

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,7 @@ Options:
 - `--start-ms <epoch_ms>`
 - `--end-ms <epoch_ms>`
 - `--limit <count>`
+- `--follow`
 - `--json`
 
 Notes:
@@ -158,9 +159,12 @@ Notes:
 - `--search` requires `--stage`
 - `--search` requires both `--start-ms` and `--end-ms`
 - `--search` supports at most 100 results per request
+- `--follow` polls for new log entries until interrupted
+- `--follow` cannot be combined with `--json` or `--search`
 
 ```bash
 macrodata jobs logs <job_id>
+macrodata jobs logs <job_id> --follow
 macrodata jobs logs <job_id> --stage 0 --severity error
 macrodata jobs logs <job_id> --stage 0 --search retry --start-ms 1713340800000 --end-ms 1713341700000 --limit 50
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@ title: "CLI"
 description: "Macrodata CLI commands used with Refiner"
 ---
 
-Refiner installs the `macrodata` CLI.
+Refiner installs the `macrodata` CLI and the shorter `mdr` alias. They are equivalent, so `mdr jobs list` and `macrodata jobs list` run the same command.
 
 ## Auth
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ all = [
 
 [project.scripts]
 macrodata = "refiner.cli.main:main"
+mdr = "refiner.cli.main:main"
 
 [build-system]
 requires = ["setuptools>=77", "wheel"]

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from argparse import Namespace
 from datetime import datetime, timezone
 from typing import Any
@@ -13,6 +14,7 @@ from refiner.platform.client.api import sanitize_terminal_text
 _DEFAULT_LOG_WINDOW_MS = 60 * 60 * 1000
 _MAX_LOG_SEARCH_LIMIT = 100
 _MAX_METRICS_WORKER_IDS = 50
+_FOLLOW_LOG_POLL_INTERVAL_SECONDS = 1.0
 
 
 def _client() -> MacrodataClient:
@@ -248,17 +250,81 @@ def _render_logs(payload: dict[str, Any]) -> int:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        line = (
-            f"{_format_ts(entry.get('ts'))} "
-            f"{_safe_text(entry.get('severity')).upper():<7} "
-            f"{_safe_text(entry.get('workerId'))} "
-            f"{_safe_text(entry.get('sourceType'))}/{_safe_text(entry.get('sourceName'))} "
-            f"{_safe_text(entry.get('line'))}"
-        )
-        print(line)
+        print(_format_log_entry(entry))
     if payload.get("hasOlder") is True:
         print("\nMore logs are available before this window.")
     return 0
+
+
+def _format_log_entry(entry: dict[str, Any]) -> str:
+    return (
+        f"{_format_ts(entry.get('ts'))} "
+        f"{_safe_text(entry.get('severity')).upper():<7} "
+        f"{_safe_text(entry.get('workerId'))} "
+        f"{_safe_text(entry.get('sourceType'))}/{_safe_text(entry.get('sourceName'))} "
+        f"{_safe_text(entry.get('line'))}"
+    )
+
+
+def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    return (
+        _safe_text(entry.get("ts")),
+        _safe_text(entry.get("workerId")),
+        _safe_text(entry.get("sourceType")),
+        _safe_text(entry.get("sourceName")),
+        _safe_text(entry.get("line")),
+    )
+
+
+def _coerce_next_start_ms(value: Any, *, fallback: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _stream_logs(
+    *,
+    args: Namespace,
+    start_ms: int,
+    end_ms: int,
+) -> int:
+    seen_keys: set[tuple[str, str, str, str, str]] = set()
+    current_start_ms = start_ms
+    current_end_ms = end_ms
+
+    while True:
+        payload = _client().cli_get_job_logs(
+            job_id=args.job_id,
+            start_ms=current_start_ms,
+            end_ms=current_end_ms,
+            limit=args.limit,
+            stage_index=args.stage,
+            worker_id=args.worker,
+            source_type=args.source_type,
+            source_name=args.source_name,
+            severity=args.severity,
+            search=args.search,
+        )
+        entries = payload.get("entries")
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                key = _log_entry_key(entry)
+                if key in seen_keys:
+                    continue
+                print(_format_log_entry(entry))
+                seen_keys.add(key)
+        if len(seen_keys) > 10_000:
+            seen_keys.clear()
+        current_start_ms = _coerce_next_start_ms(
+            payload.get("nextStartMs"),
+            fallback=current_end_ms,
+        )
+        time.sleep(_FOLLOW_LOG_POLL_INTERVAL_SECONDS)
+        next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        current_end_ms = max(next_end_ms, current_start_ms + 1)
 
 
 def _render_resource_metrics(payload: dict[str, Any]) -> int:
@@ -502,6 +568,12 @@ def cmd_jobs_workers(args: Namespace) -> int:
 
 
 def cmd_jobs_logs(args: Namespace) -> int:
+    if args.follow and args.json:
+        print("--follow cannot be combined with --json.", file=sys.stderr)
+        return 1
+    if args.follow and args.search:
+        print("--follow cannot be combined with --search.", file=sys.stderr)
+        return 1
     if args.search:
         if args.stage is None:
             print("--search requires --stage.", file=sys.stderr)
@@ -532,6 +604,8 @@ def cmd_jobs_logs(args: Namespace) -> int:
             else end_ms - _DEFAULT_LOG_WINDOW_MS
         )
     try:
+        if args.follow:
+            return _stream_logs(args=args, start_ms=start_ms, end_ms=end_ms)
         payload = _client().cli_get_job_logs(
             job_id=args.job_id,
             start_ms=start_ms,
@@ -544,6 +618,9 @@ def cmd_jobs_logs(args: Namespace) -> int:
             severity=args.severity,
             search=args.search,
         )
+    except KeyboardInterrupt:
+        print("Stopped following logs.", file=sys.stderr)
+        return 130
     except (MacrodataApiError, MacrodataCredentialsError) as err:
         return _handle_error(err)
     return _print_json(payload) if args.json else _render_logs(payload)

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -274,7 +274,12 @@ def _format_log_entry(entry: dict[str, Any]) -> str:
 
 
 def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
-    message_hash = _safe_text(entry.get("messageHash"))
+    raw_message_hash = entry.get("messageHash")
+    message_hash = (
+        str(raw_message_hash)
+        if isinstance(raw_message_hash, (str, int, float)) and str(raw_message_hash)
+        else ""
+    )
     return (
         _safe_text(entry.get("ts")),
         _safe_text(entry.get("workerId")),

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -16,7 +16,11 @@ _DEFAULT_LOG_WINDOW_MS = 60 * 60 * 1000
 _MAX_LOG_SEARCH_LIMIT = 100
 _MAX_METRICS_WORKER_IDS = 50
 _FOLLOW_LOG_POLL_INTERVAL_SECONDS = 1.0
+_DEFAULT_LOG_PAGE_LIMIT = 100
+_DEFAULT_FOLLOW_LOG_PAGE_LIMIT = 500
 _FOLLOW_LOG_DEDUPE_LIMIT = 100_000
+_FOLLOW_LOG_MAX_DRAIN_POLLS = 5
+_FOLLOW_LOG_MAX_RETRYABLE_ERRORS = 5
 _TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
 
 
@@ -275,15 +279,13 @@ def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
         _safe_text(entry.get("workerId")),
         _safe_text(entry.get("sourceType")),
         _safe_text(entry.get("sourceName")),
-        _safe_text(entry.get("line")),
+        _safe_text(entry.get("messageHash")),
     )
 
 
-def _coerce_next_start_ms(value: Any, *, fallback: int) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return fallback
+def _next_log_cursor(payload: dict[str, Any]) -> str | None:
+    cursor = payload.get("nextCursor")
+    return cursor if isinstance(cursor, str) and cursor else None
 
 
 def _job_status(payload: dict[str, Any]) -> str:
@@ -291,6 +293,16 @@ def _job_status(payload: dict[str, Any]) -> str:
     if not isinstance(job, dict):
         return ""
     return _safe_text(job.get("status")).lower()
+
+
+def _is_retryable_api_error(err: Exception) -> bool:
+    if isinstance(err, MacrodataApiError):
+        return err.status in {0, 429} or err.status >= 500
+    return False
+
+
+def _follow_retry_delay(error_count: int) -> float:
+    return min(float(2 ** max(0, error_count - 1)), 5.0)
 
 
 def _remember_seen_key(
@@ -305,30 +317,65 @@ def _remember_seen_key(
         seen_keys.discard(seen_order.popleft())
 
 
+def _effective_log_limit(args: Namespace) -> int:
+    if isinstance(args.limit, int):
+        return args.limit
+    return _DEFAULT_FOLLOW_LOG_PAGE_LIMIT if args.follow else _DEFAULT_LOG_PAGE_LIMIT
+
+
+def _warn_follow_skip(*, start_ms: int, end_ms: int) -> None:
+    print(
+        "warning: log volume is high; skipped older backlog"
+        f" from {_format_ts(start_ms)} to {_format_ts(end_ms)} to stay live",
+        file=sys.stderr,
+    )
+    print(
+        "warning: request logs for fewer workers for better visibility,"
+        " or rerun with --start-ms/--end-ms for full coverage",
+        file=sys.stderr,
+    )
+
+
 def _stream_logs(
     *,
     args: Namespace,
     start_ms: int,
     end_ms: int,
+    limit: int,
 ) -> int:
+    client = _client()
     seen_keys: set[tuple[str, str, str, str, str]] = set()
     seen_order: deque[tuple[str, str, str, str, str]] = deque()
     current_start_ms = start_ms
     current_end_ms = end_ms
+    current_cursor: str | None = None
+    full_batch_polls = 0
+    retryable_error_count = 0
 
     while True:
-        payload = _client().cli_get_job_logs(
-            job_id=args.job_id,
-            start_ms=current_start_ms,
-            end_ms=current_end_ms,
-            limit=args.limit,
-            stage_index=args.stage,
-            worker_id=args.worker,
-            source_type=args.source_type,
-            source_name=args.source_name,
-            severity=args.severity,
-            search=args.search,
-        )
+        try:
+            payload = client.cli_get_job_logs(
+                job_id=args.job_id,
+                start_ms=current_start_ms,
+                end_ms=current_end_ms,
+                cursor=current_cursor,
+                limit=limit,
+                stage_index=args.stage,
+                worker_id=args.worker,
+                source_type=args.source_type,
+                source_name=args.source_name,
+                severity=args.severity,
+                search=args.search,
+            )
+        except MacrodataApiError as err:
+            if not _is_retryable_api_error(err):
+                raise
+            retryable_error_count += 1
+            if retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
+                raise
+            time.sleep(_follow_retry_delay(retryable_error_count))
+            continue
+        retryable_error_count = 0
         entries = payload.get("entries")
         if isinstance(entries, list):
             for entry in entries:
@@ -337,25 +384,56 @@ def _stream_logs(
                 key = _log_entry_key(entry)
                 if key in seen_keys:
                     continue
-                print(_format_log_entry(entry))
+                print(_format_log_entry(entry), flush=True)
                 _remember_seen_key(
                     key=key,
                     seen_keys=seen_keys,
                     seen_order=seen_order,
                 )
-        current_start_ms = _coerce_next_start_ms(
-            payload.get("nextStartMs"),
-            fallback=current_end_ms,
-        )
-        next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-        current_end_ms = max(next_end_ms, current_start_ms + 1)
-        if isinstance(entries, list) and len(entries) >= args.limit:
+        current_cursor = _next_log_cursor(payload)
+        if current_cursor is not None:
+            full_batch_polls += 1
+            if full_batch_polls < _FOLLOW_LOG_MAX_DRAIN_POLLS:
+                continue
+            oldest_entry = entries[0] if isinstance(entries, list) and entries else None
+            skipped_end_ms = (
+                int(oldest_entry.get("ts"))
+                if isinstance(oldest_entry, dict)
+                and isinstance(oldest_entry.get("ts"), (int, float, str))
+                else current_end_ms
+            )
+            _warn_follow_skip(start_ms=current_start_ms, end_ms=skipped_end_ms)
+            current_cursor = None
+            full_batch_polls = 0
+            current_start_ms = current_end_ms
+            next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+            current_end_ms = max(next_end_ms, current_start_ms + 1)
             continue
+        else:
+            full_batch_polls = 0
+        try:
+            job_payload = client.cli_get_job(job_id=args.job_id)
+        except MacrodataApiError as err:
+            if not _is_retryable_api_error(err):
+                raise
+            retryable_error_count += 1
+            if retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
+                raise
+            time.sleep(_follow_retry_delay(retryable_error_count))
+            job_payload = {}
+            continue
+        except MacrodataCredentialsError:
+            raise
+        retryable_error_count = 0
         if (
-            _job_status(_client().cli_get_job(job_id=args.job_id))
-            in _TERMINAL_JOB_STATUSES
+            current_cursor is None
+            and _job_status(job_payload) in _TERMINAL_JOB_STATUSES
         ):
             return 0
+        if current_cursor is None:
+            current_start_ms = current_end_ms
+            next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+            current_end_ms = max(next_end_ms, current_start_ms + 1)
         time.sleep(_FOLLOW_LOG_POLL_INTERVAL_SECONDS)
 
 
@@ -603,6 +681,9 @@ def cmd_jobs_logs(args: Namespace) -> int:
     if args.follow and args.json:
         print("--follow cannot be combined with --json.", file=sys.stderr)
         return 1
+    if args.follow and args.cursor:
+        print("--follow cannot be combined with --cursor.", file=sys.stderr)
+        return 1
     if args.follow and args.search:
         print("--follow cannot be combined with --search.", file=sys.stderr)
         return 1
@@ -622,9 +703,11 @@ def cmd_jobs_logs(args: Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+        limit = _effective_log_limit(args)
         start_ms = args.start_ms
         end_ms = args.end_ms
     else:
+        limit = _effective_log_limit(args)
         end_ms = (
             args.end_ms
             if args.end_ms is not None
@@ -635,14 +718,23 @@ def cmd_jobs_logs(args: Namespace) -> int:
             if args.start_ms is not None
             else end_ms - _DEFAULT_LOG_WINDOW_MS
         )
+    if args.follow:
+        try:
+            return _stream_logs(
+                args=args, start_ms=start_ms, end_ms=end_ms, limit=limit
+            )
+        except KeyboardInterrupt:
+            print("Stopped following logs.", file=sys.stderr)
+            return 130
+        except (MacrodataApiError, MacrodataCredentialsError) as err:
+            return _handle_error(err)
     try:
-        if args.follow:
-            return _stream_logs(args=args, start_ms=start_ms, end_ms=end_ms)
         payload = _client().cli_get_job_logs(
             job_id=args.job_id,
             start_ms=start_ms,
             end_ms=end_ms,
-            limit=args.limit,
+            cursor=args.cursor,
+            limit=limit,
             stage_index=args.stage,
             worker_id=args.worker,
             source_type=args.source_type,
@@ -651,7 +743,6 @@ def cmd_jobs_logs(args: Namespace) -> int:
             search=args.search,
         )
     except KeyboardInterrupt:
-        print("Stopped following logs.", file=sys.stderr)
         return 130
     except (MacrodataApiError, MacrodataCredentialsError) as err:
         return _handle_error(err)

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 import json
 import sys
 import time
@@ -15,6 +16,8 @@ _DEFAULT_LOG_WINDOW_MS = 60 * 60 * 1000
 _MAX_LOG_SEARCH_LIMIT = 100
 _MAX_METRICS_WORKER_IDS = 50
 _FOLLOW_LOG_POLL_INTERVAL_SECONDS = 1.0
+_FOLLOW_LOG_DEDUPE_LIMIT = 100_000
+_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
 
 
 def _client() -> MacrodataClient:
@@ -283,6 +286,25 @@ def _coerce_next_start_ms(value: Any, *, fallback: int) -> int:
         return fallback
 
 
+def _job_status(payload: dict[str, Any]) -> str:
+    job = payload.get("job")
+    if not isinstance(job, dict):
+        return ""
+    return _safe_text(job.get("status")).lower()
+
+
+def _remember_seen_key(
+    *,
+    key: tuple[str, str, str, str, str],
+    seen_keys: set[tuple[str, str, str, str, str]],
+    seen_order: deque[tuple[str, str, str, str, str]],
+) -> None:
+    seen_keys.add(key)
+    seen_order.append(key)
+    while len(seen_order) > _FOLLOW_LOG_DEDUPE_LIMIT:
+        seen_keys.discard(seen_order.popleft())
+
+
 def _stream_logs(
     *,
     args: Namespace,
@@ -290,6 +312,7 @@ def _stream_logs(
     end_ms: int,
 ) -> int:
     seen_keys: set[tuple[str, str, str, str, str]] = set()
+    seen_order: deque[tuple[str, str, str, str, str]] = deque()
     current_start_ms = start_ms
     current_end_ms = end_ms
 
@@ -315,16 +338,25 @@ def _stream_logs(
                 if key in seen_keys:
                     continue
                 print(_format_log_entry(entry))
-                seen_keys.add(key)
-        if len(seen_keys) > 10_000:
-            seen_keys.clear()
+                _remember_seen_key(
+                    key=key,
+                    seen_keys=seen_keys,
+                    seen_order=seen_order,
+                )
         current_start_ms = _coerce_next_start_ms(
             payload.get("nextStartMs"),
             fallback=current_end_ms,
         )
-        time.sleep(_FOLLOW_LOG_POLL_INTERVAL_SECONDS)
         next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         current_end_ms = max(next_end_ms, current_start_ms + 1)
+        if isinstance(entries, list) and len(entries) >= args.limit:
+            continue
+        if (
+            _job_status(_client().cli_get_job(job_id=args.job_id))
+            in _TERMINAL_JOB_STATUSES
+        ):
+            return 0
+        time.sleep(_FOLLOW_LOG_POLL_INTERVAL_SECONDS)
 
 
 def _render_resource_metrics(payload: dict[str, Any]) -> int:

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -274,12 +274,13 @@ def _format_log_entry(entry: dict[str, Any]) -> str:
 
 
 def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    message_hash = _safe_text(entry.get("messageHash"))
     return (
         _safe_text(entry.get("ts")),
         _safe_text(entry.get("workerId")),
         _safe_text(entry.get("sourceType")),
         _safe_text(entry.get("sourceName")),
-        _safe_text(entry.get("messageHash")),
+        message_hash or _safe_text(entry.get("line")),
     )
 
 
@@ -350,7 +351,8 @@ def _stream_logs(
     current_end_ms = end_ms
     current_cursor: str | None = None
     full_batch_polls = 0
-    retryable_error_count = 0
+    log_retryable_error_count = 0
+    status_retryable_error_count = 0
 
     while True:
         try:
@@ -370,12 +372,12 @@ def _stream_logs(
         except MacrodataApiError as err:
             if not _is_retryable_api_error(err):
                 raise
-            retryable_error_count += 1
-            if retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
+            log_retryable_error_count += 1
+            if log_retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
                 raise
-            time.sleep(_follow_retry_delay(retryable_error_count))
+            time.sleep(_follow_retry_delay(log_retryable_error_count))
             continue
-        retryable_error_count = 0
+        log_retryable_error_count = 0
         entries = payload.get("entries")
         if isinstance(entries, list):
             for entry in entries:
@@ -416,15 +418,15 @@ def _stream_logs(
         except MacrodataApiError as err:
             if not _is_retryable_api_error(err):
                 raise
-            retryable_error_count += 1
-            if retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
+            status_retryable_error_count += 1
+            if status_retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
                 raise
-            time.sleep(_follow_retry_delay(retryable_error_count))
+            time.sleep(_follow_retry_delay(status_retryable_error_count))
             job_payload = {}
             continue
         except MacrodataCredentialsError:
             raise
-        retryable_error_count = 0
+        status_retryable_error_count = 0
         if (
             current_cursor is None
             and _job_status(job_payload) in _TERMINAL_JOB_STATUSES
@@ -697,13 +699,13 @@ def cmd_jobs_logs(args: Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        if args.limit > _MAX_LOG_SEARCH_LIMIT:
+        limit = _effective_log_limit(args)
+        if limit > _MAX_LOG_SEARCH_LIMIT:
             print(
                 f"--search supports at most {_MAX_LOG_SEARCH_LIMIT} results.",
                 file=sys.stderr,
             )
             return 1
-        limit = _effective_log_limit(args)
         start_ms = args.start_ms
         end_ms = args.end_ms
     else:

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -143,6 +143,11 @@ def build_parser() -> argparse.ArgumentParser:
     jobs_logs.add_argument("--end-ms", type=int, help="Window end time in epoch ms")
     jobs_logs.add_argument("--limit", type=int, default=100, help="Maximum log entries")
     jobs_logs.add_argument(
+        "--follow",
+        action="store_true",
+        help="Poll continuously for new log entries",
+    )
+    jobs_logs.add_argument(
         "--json", action="store_true", help="Print raw JSON response"
     )
     jobs_logs.set_defaults(handler=cmd_jobs_logs)

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -82,7 +82,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Only include jobs started by the authenticated user",
     )
-    jobs_list.add_argument("--cursor", help="Opaque pagination cursor")
+    jobs_list.add_argument(
+        "--cursor", help="Pagination cursor from a previous response"
+    )
     jobs_list.add_argument(
         "--json", action="store_true", help="Print raw JSON response"
     )
@@ -121,7 +123,9 @@ def build_parser() -> argparse.ArgumentParser:
     jobs_workers.add_argument(
         "--limit", type=int, default=20, help="Maximum workers to return"
     )
-    jobs_workers.add_argument("--cursor", help="Opaque pagination cursor")
+    jobs_workers.add_argument(
+        "--cursor", help="Pagination cursor from a previous response"
+    )
     jobs_workers.add_argument(
         "--json", action="store_true", help="Print raw JSON response"
     )
@@ -141,7 +145,10 @@ def build_parser() -> argparse.ArgumentParser:
     jobs_logs.add_argument("--search", help="Case-insensitive substring filter")
     jobs_logs.add_argument("--start-ms", type=int, help="Window start time in epoch ms")
     jobs_logs.add_argument("--end-ms", type=int, help="Window end time in epoch ms")
-    jobs_logs.add_argument("--limit", type=int, default=100, help="Maximum log entries")
+    jobs_logs.add_argument(
+        "--cursor", help="Pagination cursor from a previous response"
+    )
+    jobs_logs.add_argument("--limit", type=int, help="Maximum log entries")
     jobs_logs.add_argument(
         "--follow",
         action="store_true",

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -327,6 +327,7 @@ class MacrodataClient:
         job_id: str,
         start_ms: int,
         end_ms: int,
+        cursor: str | None = None,
         limit: int | None = None,
         stage_index: int | None = None,
         worker_id: str | None = None,
@@ -341,6 +342,7 @@ class MacrodataClient:
             query_params={
                 "startMs": start_ms,
                 "endMs": end_ms,
+                "cursor": cursor,
                 "limit": limit,
                 "stageIndex": stage_index,
                 "workerId": worker_id,

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -123,6 +123,7 @@ class _FakeClient:
                 }
             ],
             "hasOlder": False,
+            "nextStartMs": 1_700_000_001_000,
         }
 
     def cli_get_job_metrics(self, **_: object) -> dict[str, object]:
@@ -217,6 +218,7 @@ def test_jobs_logs_json_output(monkeypatch, capsys) -> None:
             start_ms=1,
             end_ms=2,
             limit=10,
+            follow=False,
             json=True,
         )
     )
@@ -225,6 +227,104 @@ def test_jobs_logs_json_output(monkeypatch, capsys) -> None:
     assert rc == 0
     assert '"entries"' in out.out
     assert '"retrying shard"' in out.out
+
+
+def test_jobs_logs_follow_rejects_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(jobs, "_client", lambda: _FakeClient())
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            limit=10,
+            follow=True,
+            json=True,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 1
+    assert "--follow cannot be combined with --json." in out.err
+
+
+def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None:
+    class _FollowClient(_FakeClient):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.calls += 1
+            if self.calls == 1:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_001_000,
+                            "severity": "warning",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "retrying shard",
+                        }
+                    ],
+                    "hasOlder": False,
+                    "nextStartMs": 1_700_000_001_000,
+                }
+            return {
+                "entries": [
+                    {
+                        "ts": 1_700_000_002_000,
+                        "severity": "error",
+                        "workerId": "worker-2",
+                        "sourceType": "worker",
+                        "sourceName": "runner",
+                        "line": "shard failed",
+                    }
+                ],
+                "hasOlder": False,
+                "nextStartMs": 1_700_000_002_000,
+            }
+
+    client = _FollowClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+
+    sleep_calls = {"count": 0}
+
+    def _fake_sleep(_: float) -> None:
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] >= 2:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(jobs.time, "sleep", _fake_sleep)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            limit=10,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 130
+    assert "retrying shard" in out.out
+    assert "shard failed" in out.out
+    assert "Stopped following logs." in out.err
 
 
 def test_jobs_resource_metrics_plain_output_accepts_second_timestamps(
@@ -531,6 +631,7 @@ def test_jobs_logs_search_requires_explicit_scope(monkeypatch, capsys) -> None:
             start_ms=None,
             end_ms=None,
             limit=10,
+            follow=False,
             json=False,
         )
     )
@@ -556,6 +657,7 @@ def test_jobs_logs_search_rejects_large_limits(monkeypatch, capsys) -> None:
             start_ms=1,
             end_ms=2,
             limit=101,
+            follow=False,
             json=False,
         )
     )
@@ -581,6 +683,7 @@ def test_jobs_logs_search_requires_explicit_window(monkeypatch, capsys) -> None:
             start_ms=1,
             end_ms=None,
             limit=10,
+            follow=False,
             json=False,
         )
     )

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import builtins
 from argparse import Namespace
 from typing import Any, cast
 
+
 from refiner.cli import jobs
+from refiner.platform.client.api import MacrodataApiError
 
 
 class _FakeClient:
@@ -120,10 +123,11 @@ class _FakeClient:
                     "sourceType": "worker",
                     "sourceName": "runner",
                     "line": "retrying shard",
+                    "messageHash": "1",
                 }
             ],
             "hasOlder": False,
-            "nextStartMs": 1_700_000_001_000,
+            "nextCursor": None,
         }
 
     def cli_get_job_metrics(self, **_: object) -> dict[str, object]:
@@ -217,7 +221,8 @@ def test_jobs_logs_json_output(monkeypatch, capsys) -> None:
             search=None,
             start_ms=1,
             end_ms=2,
-            limit=10,
+            cursor=None,
+            limit=None,
             follow=False,
             json=True,
         )
@@ -243,7 +248,8 @@ def test_jobs_logs_follow_rejects_json(monkeypatch, capsys) -> None:
             search=None,
             start_ms=1,
             end_ms=2,
-            limit=10,
+            cursor=None,
+            limit=None,
             follow=True,
             json=True,
         )
@@ -252,6 +258,66 @@ def test_jobs_logs_follow_rejects_json(monkeypatch, capsys) -> None:
 
     assert rc == 1
     assert "--follow cannot be combined with --json." in out.err
+
+
+def test_jobs_logs_follow_rejects_cursor(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(jobs, "_client", lambda: _FakeClient())
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor="cursor-1",
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 1
+    assert "--follow cannot be combined with --cursor." in out.err
+
+
+def test_jobs_logs_passes_cursor_to_client(monkeypatch, capsys) -> None:
+    captured: dict[str, object] = {}
+
+    class _CursorClient(_FakeClient):
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            captured.update(kwargs)
+            return super().cli_get_job_logs(**kwargs)
+
+    monkeypatch.setattr(jobs, "_client", lambda: _CursorClient())
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor="cursor-1",
+            limit=None,
+            follow=False,
+            json=False,
+        )
+    )
+    _ = capsys.readouterr()
+
+    assert rc == 0
+    assert captured["cursor"] == "cursor-1"
+    assert captured["limit"] == jobs._DEFAULT_LOG_PAGE_LIMIT
 
 
 def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None:
@@ -271,10 +337,11 @@ def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None
                             "sourceType": "worker",
                             "sourceName": "runner",
                             "line": "retrying shard",
+                            "messageHash": "1",
                         }
                     ],
                     "hasOlder": False,
-                    "nextStartMs": 1_700_000_001_000,
+                    "nextCursor": None,
                 }
             return {
                 "entries": [
@@ -285,10 +352,11 @@ def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None
                         "sourceType": "worker",
                         "sourceName": "runner",
                         "line": "shard failed",
+                        "messageHash": "2",
                     }
                 ],
                 "hasOlder": False,
-                "nextStartMs": 1_700_000_002_000,
+                "nextCursor": None,
             }
 
     client = _FollowClient()
@@ -314,7 +382,8 @@ def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None
             search=None,
             start_ms=1,
             end_ms=2,
-            limit=10,
+            cursor=None,
+            limit=None,
             follow=True,
             json=False,
         )
@@ -344,12 +413,13 @@ def test_jobs_logs_follow_returns_when_job_is_terminal(monkeypatch, capsys) -> N
                             "sourceType": "worker",
                             "sourceName": "runner",
                             "line": "done",
+                            "messageHash": "1",
                         }
                     ],
                     "hasOlder": False,
-                    "nextStartMs": 1_700_000_001_000,
+                    "nextCursor": None,
                 }
-            return {"entries": [], "hasOlder": False, "nextStartMs": 1_700_000_001_000}
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
 
         def cli_get_job(self, *, job_id: str) -> dict[str, object]:
             payload = super().cli_get_job(job_id=job_id)
@@ -378,7 +448,8 @@ def test_jobs_logs_follow_returns_when_job_is_terminal(monkeypatch, capsys) -> N
             search=None,
             start_ms=1,
             end_ms=2,
-            limit=10,
+            cursor=None,
+            limit=None,
             follow=True,
             json=False,
         )
@@ -389,6 +460,81 @@ def test_jobs_logs_follow_returns_when_job_is_terminal(monkeypatch, capsys) -> N
     assert "done" in out.out
     assert out.err == ""
     assert sleep_calls["count"] == 0
+
+
+def test_jobs_logs_follow_drains_backlog_before_terminal_exit(
+    monkeypatch, capsys
+) -> None:
+    class _BacklogClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls == 1:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_001_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "first",
+                            "messageHash": "1",
+                        }
+                    ],
+                    "hasOlder": True,
+                    "nextCursor": "cursor-1",
+                }
+            return {
+                "entries": [
+                    {
+                        "ts": 1_700_000_002_000,
+                        "severity": "info",
+                        "workerId": "worker-1",
+                        "sourceType": "worker",
+                        "sourceName": "runner",
+                        "line": "second",
+                        "messageHash": "2",
+                    }
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            if self.log_calls >= 2:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _BacklogClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=1,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "first" in out.out
+    assert "second" in out.out
 
 
 def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
@@ -411,6 +557,7 @@ def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
                             "sourceType": "worker",
                             "sourceName": "runner",
                             "line": "first",
+                            "messageHash": "1",
                         },
                         {
                             "ts": 1_700_000_002_000,
@@ -419,12 +566,13 @@ def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
                             "sourceType": "worker",
                             "sourceName": "runner",
                             "line": "second",
+                            "messageHash": "2",
                         },
                     ],
-                    "hasOlder": False,
-                    "nextStartMs": 1_700_000_002_000,
+                    "hasOlder": True,
+                    "nextCursor": "cursor-1",
                 }
-            return {"entries": [], "hasOlder": False, "nextStartMs": 1_700_000_002_000}
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
 
         def cli_get_job(self, *, job_id: str) -> dict[str, object]:
             self.job_calls += 1
@@ -454,6 +602,7 @@ def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
             search=None,
             start_ms=1,
             end_ms=2,
+            cursor=None,
             limit=2,
             follow=True,
             json=False,
@@ -466,6 +615,451 @@ def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
     assert "second" in out.out
     assert sleep_calls["count"] == 0
     assert client.job_calls == 1
+
+
+def test_jobs_logs_follow_skips_backlog_to_stay_live(monkeypatch, capsys) -> None:
+    class _SkippingClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            self.log_calls += 1
+            cursor = kwargs.get("cursor")
+            if self.log_calls <= jobs._FOLLOW_LOG_MAX_DRAIN_POLLS:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_000_000 + self.log_calls,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": f"backlog-{self.log_calls}",
+                            "messageHash": str(self.log_calls),
+                        }
+                    ],
+                    "hasOlder": True,
+                    "nextCursor": f"cursor-{self.log_calls}",
+                }
+            if cursor is None:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_010_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "live-now",
+                            "messageHash": "live",
+                        }
+                    ],
+                    "hasOlder": False,
+                    "nextCursor": None,
+                }
+            raise AssertionError("expected cursor reset after backlog skip")
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            if self.log_calls > jobs._FOLLOW_LOG_MAX_DRAIN_POLLS:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    monkeypatch.setattr(jobs, "_client", lambda: _SkippingClient())
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=1,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "backlog-1" in out.out
+    assert "live-now" in out.out
+    assert "skipped older backlog" in out.err
+    assert "request logs for fewer workers" in out.err
+
+
+def test_jobs_logs_follow_sleeps_after_bounded_drain_polls(monkeypatch, capsys) -> None:
+    class _HotClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+            self.job_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls > jobs._FOLLOW_LOG_MAX_DRAIN_POLLS:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_000_000 + self.log_calls,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": f"line-{self.log_calls}",
+                            "messageHash": str(self.log_calls),
+                        }
+                    ],
+                    "hasOlder": False,
+                    "nextCursor": None,
+                }
+            return {
+                "entries": [
+                    {
+                        "ts": 1_700_000_000_000 + self.log_calls,
+                        "severity": "info",
+                        "workerId": "worker-1",
+                        "sourceType": "worker",
+                        "sourceName": "runner",
+                        "line": f"line-{self.log_calls}",
+                        "messageHash": str(self.log_calls),
+                    }
+                ],
+                "hasOlder": True,
+                "nextCursor": f"cursor-{self.log_calls}",
+            }
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            self.job_calls += 1
+            payload = super().cli_get_job(job_id=job_id)
+            if self.job_calls >= 2:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _HotClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+
+    sleep_calls = {"count": 0}
+
+    def _fake_sleep(_: float) -> None:
+        sleep_calls["count"] += 1
+
+    monkeypatch.setattr(jobs.time, "sleep", _fake_sleep)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=1,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "line-1" in out.out
+    assert f"line-{jobs._FOLLOW_LOG_MAX_DRAIN_POLLS}" in out.out
+    assert sleep_calls["count"] == 1
+    assert client.job_calls == 2
+
+
+def test_jobs_logs_follow_ignores_transient_status_probe_errors(
+    monkeypatch, capsys
+) -> None:
+    class _FlakyStatusClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+            self.job_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls == 1:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_001_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "first",
+                            "messageHash": "1",
+                        }
+                    ],
+                    "hasOlder": False,
+                    "nextCursor": None,
+                }
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            self.job_calls += 1
+            if self.job_calls == 1:
+                raise MacrodataApiError(status=503, message="temporary")
+            payload = super().cli_get_job(job_id=job_id)
+            cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    monkeypatch.setattr(jobs, "_client", lambda: _FlakyStatusClient())
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "first" in out.out
+
+
+def test_jobs_logs_follow_retries_transient_log_fetch_errors(
+    monkeypatch, capsys
+) -> None:
+    class _FlakyLogsClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls == 1:
+                raise MacrodataApiError(status=503, message="temporary")
+            return {
+                "entries": [
+                    {
+                        "ts": 1_700_000_001_000,
+                        "severity": "info",
+                        "workerId": "worker-1",
+                        "sourceType": "worker",
+                        "sourceName": "runner",
+                        "line": "recovered",
+                        "messageHash": "1",
+                    }
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            if self.log_calls >= 2:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    monkeypatch.setattr(jobs, "_client", lambda: _FlakyLogsClient())
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "recovered" in out.out
+
+
+def test_jobs_logs_follow_flushes_stream_output(monkeypatch) -> None:
+    class _TerminalClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            return {
+                "entries": [
+                    {
+                        "ts": 1_700_000_001_000,
+                        "severity": "info",
+                        "workerId": "worker-1",
+                        "sourceType": "worker",
+                        "sourceName": "runner",
+                        "line": "flushed",
+                        "messageHash": "1",
+                    }
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _TerminalClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+
+    recorded_flushes: list[bool] = []
+    original_print = builtins.print
+
+    def _recording_print(*args: Any, **kwargs: Any) -> None:
+        recorded_flushes.append(bool(kwargs.get("flush")))
+        original_print(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "print", _recording_print)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+
+    assert rc == 0
+    assert True in recorded_flushes
+
+
+def test_jobs_logs_non_follow_returns_clean_interrupt_exit(monkeypatch) -> None:
+    class _InterruptClient(_FakeClient):
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(jobs, "_client", lambda: _InterruptClient())
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=False,
+            json=False,
+        )
+    )
+
+    assert rc == 130
+
+
+def test_jobs_logs_follow_surfaces_permanent_status_probe_errors(monkeypatch) -> None:
+    class _PermanentStatusErrorClient(_FakeClient):
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            raise MacrodataApiError(status=404, message="missing")
+
+    monkeypatch.setattr(jobs, "_client", lambda: _PermanentStatusErrorClient())
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+
+    assert rc == 1
+
+
+def test_jobs_logs_follow_uses_larger_default_limit(monkeypatch, capsys) -> None:
+    captured: dict[str, object] = {}
+
+    class _LimitClient(_FakeClient):
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            captured.update(kwargs)
+            return {
+                "entries": [],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    monkeypatch.setattr(jobs, "_client", lambda: _LimitClient())
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+    _ = capsys.readouterr()
+
+    assert rc == 0
+    assert captured["limit"] == jobs._DEFAULT_FOLLOW_LOG_PAGE_LIMIT
 
 
 def test_jobs_resource_metrics_plain_output_accepts_second_timestamps(

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -327,6 +327,147 @@ def test_jobs_logs_follow_streams_until_interrupted(monkeypatch, capsys) -> None
     assert "Stopped following logs." in out.err
 
 
+def test_jobs_logs_follow_returns_when_job_is_terminal(monkeypatch, capsys) -> None:
+    class _TerminalClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls == 1:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_001_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "done",
+                        }
+                    ],
+                    "hasOlder": False,
+                    "nextStartMs": 1_700_000_001_000,
+                }
+            return {"entries": [], "hasOlder": False, "nextStartMs": 1_700_000_001_000}
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            if self.log_calls >= 1:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _TerminalClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+
+    sleep_calls = {"count": 0}
+
+    def _fake_sleep(_: float) -> None:
+        sleep_calls["count"] += 1
+
+    monkeypatch.setattr(jobs.time, "sleep", _fake_sleep)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            limit=10,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "done" in out.out
+    assert out.err == ""
+    assert sleep_calls["count"] == 0
+
+
+def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
+    monkeypatch, capsys
+) -> None:
+    class _BusyClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls = 0
+            self.job_calls = 0
+
+        def cli_get_job_logs(self, **_: object) -> dict[str, object]:
+            self.log_calls += 1
+            if self.log_calls == 1:
+                return {
+                    "entries": [
+                        {
+                            "ts": 1_700_000_001_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "first",
+                        },
+                        {
+                            "ts": 1_700_000_002_000,
+                            "severity": "info",
+                            "workerId": "worker-1",
+                            "sourceType": "worker",
+                            "sourceName": "runner",
+                            "line": "second",
+                        },
+                    ],
+                    "hasOlder": False,
+                    "nextStartMs": 1_700_000_002_000,
+                }
+            return {"entries": [], "hasOlder": False, "nextStartMs": 1_700_000_002_000}
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            self.job_calls += 1
+            payload = super().cli_get_job(job_id=job_id)
+            if self.log_calls >= 2:
+                cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _BusyClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+
+    sleep_calls = {"count": 0}
+
+    def _fake_sleep(_: float) -> None:
+        sleep_calls["count"] += 1
+
+    monkeypatch.setattr(jobs.time, "sleep", _fake_sleep)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            limit=2,
+            follow=True,
+            json=False,
+        )
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "first" in out.out
+    assert "second" in out.out
+    assert sleep_calls["count"] == 0
+    assert client.job_calls == 1
+
+
 def test_jobs_resource_metrics_plain_output_accepts_second_timestamps(
     monkeypatch, capsys
 ) -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -38,6 +38,15 @@ def test_parser_has_jobs_logs_follow_flag() -> None:
     assert args.follow is True
 
 
+def test_parser_has_jobs_logs_cursor_flag() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["jobs", "logs", "job-1", "--cursor", "cursor-1"])
+    assert args.command == "jobs"
+    assert args.jobs_command == "logs"
+    assert args.job_id == "job-1"
+    assert args.cursor == "cursor-1"
+
+
 def test_parser_has_jobs_cancel_command() -> None:
     parser = build_parser()
     args = parser.parse_args(["jobs", "cancel", "job-1"])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -29,6 +29,15 @@ def test_parser_has_jobs_commands() -> None:
     assert args.me is True
 
 
+def test_parser_has_jobs_logs_follow_flag() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["jobs", "logs", "job-1", "--follow"])
+    assert args.command == "jobs"
+    assert args.jobs_command == "logs"
+    assert args.job_id == "job-1"
+    assert args.follow is True
+
+
 def test_parser_has_jobs_cancel_command() -> None:
     parser = build_parser()
     args = parser.parse_args(["jobs", "cancel", "job-1"])


### PR DESCRIPTION
## What changed
- add `--follow` to `macrodata jobs logs`
- make `jobs list`, `jobs workers`, and `jobs logs` accept `--cursor` so paginated CLI calls can round-trip `nextCursor`
- make `jobs logs --follow` stay live under heavy backlog by skipping older pages when needed and warning with the skipped timestamp range
- add the `mdr` CLI alias alongside `macrodata`
- document the new CLI behavior and cover the parser/follow loop with focused tests

## Why
This is the smallest CLI-side piece needed for an attached cloud-job experience. It reuses the existing `jobs logs` command shape instead of introducing a separate tail command, and it gives agents a consistent cursor-based pagination model across CLI inspection commands.

## Impact
- humans can keep a cloud job log view open from the CLI without rerunning the command manually
- agents can page `jobs list`, `jobs workers`, and `jobs logs` using `--json` plus `nextCursor`
- users can invoke the CLI as either `macrodata ...` or `mdr ...`

## Validation
- `uv run pytest tests/cli/test_main.py tests/cli/test_job_commands.py`
