### PR TITLE
[codex] add sink reducer stages for launched writers

### DIFF
--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -39,6 +39,7 @@ Returned stats include:
 - workers always run as subprocesses, even when `num_workers=1`
 - local launch does not pin worker CPUs; if `num_workers` exceeds available CPUs, Refiner logs a warning and still launches the requested worker count
 - `gpus_per_worker` optionally exposes a fixed number of visible GPU devices to each local worker
+- some sinks add a 1-worker reducer stage after the main writer stage to finalize or clean up shard outputs
 - `REFINER_LOCAL_LOGS` controls the live local console stream when set:
   - `all`: stream every worker log line
   - `none`: suppress live worker log output
@@ -48,6 +49,7 @@ Returned stats include:
 - when a local run fails or is interrupted, Refiner prints the `rundir` to reuse if you want to resume completed shards
 - local run files live under `<workdir>/runs/<job_id>/...`
 - worker Loguru output is written to `stage-<index>/logs/worker-<worker_id>.log` under the local rundir
+- for launched file sinks such as `write_jsonl(...)` and `write_parquet(...)`, the output prefix should be dedicated to Refiner-managed files so the reducer stage can safely remove stale shard/worker outputs
 - during local execution, the launcher tails per-worker log files
 - on interactive terminals, Refiner redraws a pinned terminal header with job metadata, live runtime, and the latest worker log lines beneath it
 - on non-interactive output, Refiner prints plain prefixed log lines
@@ -97,6 +99,11 @@ Returned result includes:
 - `env`: env vars sent as plain runtime environment values
 
 `secrets` and `env` are both mounted into the cloud runtime, but only `secrets` participate in captured-code redaction.
+
+### Cloud notes
+
+- some sinks add a 1-worker reducer stage after the main writer stage to finalize or clean up shard outputs
+- for launched file sinks such as `write_jsonl(...)` and `write_parquet(...)`, the output prefix should be dedicated to Refiner-managed files so the reducer stage can safely remove stale shard/worker outputs
 
 ## Authentication
 

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -39,7 +39,6 @@ Returned stats include:
 - workers always run as subprocesses, even when `num_workers=1`
 - local launch does not pin worker CPUs; if `num_workers` exceeds available CPUs, Refiner logs a warning and still launches the requested worker count
 - `gpus_per_worker` optionally exposes a fixed number of visible GPU devices to each local worker
-- some sinks add a 1-worker reducer stage after the main writer stage to finalize or clean up shard outputs
 - `REFINER_LOCAL_LOGS` controls the live local console stream when set:
   - `all`: stream every worker log line
   - `none`: suppress live worker log output
@@ -49,7 +48,6 @@ Returned stats include:
 - when a local run fails or is interrupted, Refiner prints the `rundir` to reuse if you want to resume completed shards
 - local run files live under `<workdir>/runs/<job_id>/...`
 - worker Loguru output is written to `stage-<index>/logs/worker-<worker_id>.log` under the local rundir
-- for launched file sinks such as `write_jsonl(...)` and `write_parquet(...)`, the output prefix should be dedicated to Refiner-managed files so the reducer stage can safely remove stale shard/worker outputs
 - during local execution, the launcher tails per-worker log files
 - on interactive terminals, Refiner redraws a pinned terminal header with job metadata, live runtime, and the latest worker log lines beneath it
 - on non-interactive output, Refiner prints plain prefixed log lines
@@ -100,7 +98,7 @@ Returned result includes:
 
 `secrets` and `env` are both mounted into the cloud runtime, but only `secrets` participate in captured-code redaction.
 
-### Cloud notes
+### Launched writer notes
 
 - some sinks add a 1-worker reducer stage after the main writer stage to finalize or clean up shard outputs
 - for launched file sinks such as `write_jsonl(...)` and `write_parquet(...)`, the output prefix should be dedicated to Refiner-managed files so the reducer stage can safely remove stale shard/worker outputs

--- a/docs/reading-and-writing.md
+++ b/docs/reading-and-writing.md
@@ -155,6 +155,12 @@ Example:
 pipeline = pipeline.write_parquet("s3://my-bucket/clean-output/")
 ```
 
+When you run a writer through `launch_local(...)` or `launch_cloud(...)`, some
+sinks add a reducer stage after the main writer stage. For `write_jsonl(...)`
+and `write_parquet(...)`, that reducer removes stale shard/worker files and
+keeps only finalized outputs. The output prefix should therefore be dedicated to
+Refiner-managed files.
+
 ## What Python Functions Actually See
 
 Reader output eventually flows into Python UDFs as `Row` objects:

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -450,27 +450,32 @@ def plan_pipeline_stages(
         raise ValueError("default_num_workers must be > 0")
 
     from refiner.pipeline.pipeline import RefinerPipeline
-    from refiner.pipeline.sinks.lerobot import LeRobotWriterSink
-    from refiner.pipeline.sinks.lerobot_reducer import LeRobotMetaReduceSink
     from refiner.pipeline.sources.task import TaskSource
 
-    if isinstance(pipeline.sink, LeRobotWriterSink):
+    sink = pipeline.sink
+    reducer = sink.build_reducer() if sink is not None else None
+    if reducer is not None:
+        assert sink is not None
         reducer_stage = RefinerPipeline(
             source=TaskSource(num_tasks=1),
             pipeline_steps=(),
             max_vectorized_block_bytes=pipeline.max_vectorized_block_bytes,
-            sink=LeRobotMetaReduceSink(output=pipeline.sink.output),
+            sink=reducer,
+        )
+        sink_description = sink.describe()
+        stage_base_name = (
+            sink_description[0] if sink_description is not None else "writer"
         )
         return [
             PlannedStage(
                 index=0,
-                name="write_lerobot_stage_1",
+                name=f"{stage_base_name}_stage_0",
                 pipeline=pipeline,
                 compute=StageComputeRequirements(num_workers=default_num_workers),
             ),
             PlannedStage(
                 index=1,
-                name="write_lerobot_stage_2",
+                name=f"{stage_base_name}_stage_1",
                 pipeline=reducer_stage,
                 compute=StageComputeRequirements(num_workers=1),
             ),

--- a/src/refiner/pipeline/sinks/__init__.py
+++ b/src/refiner/pipeline/sinks/__init__.py
@@ -1,10 +1,11 @@
 from refiner.pipeline.sinks.base import BaseSink, NullSink
 from refiner.pipeline.sinks.jsonl import JsonlSink
-from refiner.pipeline.sinks.lerobot_reducer import LeRobotMetaReduceSink
 from refiner.pipeline.sinks.parquet import ParquetSink
+from refiner.pipeline.sinks.reducer import FileCleanupReducerSink, LeRobotMetaReduceSink
 
 __all__ = [
     "BaseSink",
+    "FileCleanupReducerSink",
     "NullSink",
     "JsonlSink",
     "LeRobotMetaReduceSink",

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -49,6 +49,20 @@ class BaseSink(ABC):
         """
         return None
 
+    def build_reducer(self) -> "BaseSink | None":
+        """Return an optional 1-worker reducer sink for launched execution.
+
+        Reducers run as a follow-up stage after the main writer stage. Use this
+        when a sink needs a final cleanup or reduction pass once all shard-local
+        writer outputs are known.
+        """
+        return None
+
+    @property
+    def counts_output_rows(self) -> bool:
+        """Whether blocks written into this sink should count toward output_rows."""
+        return True
+
     def on_shard_complete(self, shard_id: str) -> None:
         """Flush or finalize state for one shard after upstream completion.
 

--- a/src/refiner/pipeline/sinks/jsonl.py
+++ b/src/refiner/pipeline/sinks/jsonl.py
@@ -10,6 +10,7 @@ from refiner.io.datafolder import DataFolder, DataFolderLike
 from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sinks.base import BaseSink
+from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
 from refiner.worker.metrics.api import log_throughput
 
@@ -75,6 +76,13 @@ class JsonlSink(BaseSink):
                 "path": self.output.abs_path(),
                 "filename_template": self.filename_template,
             },
+        )
+
+    def build_reducer(self) -> BaseSink:
+        return FileCleanupReducerSink(
+            output=self.output,
+            filename_template=self.filename_template,
+            reducer_name="write_jsonl_reduce",
         )
 
 

--- a/src/refiner/pipeline/sinks/lerobot.py
+++ b/src/refiner/pipeline/sinks/lerobot.py
@@ -18,6 +18,7 @@ from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
 from refiner.pipeline.sinks.base import BaseSink
+from refiner.pipeline.sinks.reducer.lerobot import LeRobotMetaReduceSink
 from refiner.robotics.lerobot_format import (
     LeRobotFeatureInfo,
     LeRobotFeatureStats,
@@ -548,6 +549,9 @@ class LeRobotWriterSink(BaseSink):
                 "max_video_prepare_in_flight": self.max_video_prepare_in_flight,
             },
         )
+
+    def build_reducer(self) -> BaseSink:
+        return LeRobotMetaReduceSink(output=self.output)
 
 
 __all__ = [

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -8,6 +8,7 @@ from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.shard import SHARD_ID_COLUMN
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sinks.base import BaseSink
+from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
 from refiner.worker.metrics.api import log_throughput
 
@@ -73,6 +74,13 @@ class ParquetSink(BaseSink):
         if self.compression is not None:
             args["compression"] = self.compression
         return ("write_parquet", "writer", args)
+
+    def build_reducer(self) -> BaseSink:
+        return FileCleanupReducerSink(
+            output=self.output,
+            filename_template=self.filename_template,
+            reducer_name="write_parquet_reduce",
+        )
 
 
 __all__ = ["ParquetSink"]

--- a/src/refiner/pipeline/sinks/reducer/__init__.py
+++ b/src/refiner/pipeline/sinks/reducer/__init__.py
@@ -1,0 +1,7 @@
+from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
+from refiner.pipeline.sinks.reducer.lerobot import LeRobotMetaReduceSink
+
+__all__ = [
+    "FileCleanupReducerSink",
+    "LeRobotMetaReduceSink",
+]

--- a/src/refiner/pipeline/sinks/reducer/file.py
+++ b/src/refiner/pipeline/sinks/reducer/file.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+from string import Formatter
+
+from refiner.io.datafolder import DataFolder, DataFolderLike
+from refiner.pipeline.sinks.base import BaseSink
+from refiner.worker.context import get_active_stage_index, get_finalized_workers
+
+_REQUIRED_TEMPLATE_FIELDS = {"shard_id", "worker_id"}
+_TOKEN_PATTERN = r"[0-9a-f]{12}"
+_FIELD_PATTERNS = {
+    # row.shard_id is not theoretically restricted to the planned Shard.id format,
+    # but launched deterministic file sinks are expected to name outputs from
+    # planned shard ids in practice, so cleanup matches that 12-hex shape here.
+    "shard_id": _TOKEN_PATTERN,
+    "worker_id": _TOKEN_PATTERN,
+}
+_DEFAULT_FIELD_PATTERN = r"[^/]+"
+
+
+def _compile_managed_path_pattern(filename_template: str) -> re.Pattern[str]:
+    parts: list[str] = []
+    seen_fields: set[str] = set()
+
+    for literal_text, field_name, format_spec, conversion in Formatter().parse(
+        filename_template
+    ):
+        parts.append(re.escape(literal_text))
+        if field_name is None:
+            continue
+        if conversion is not None or format_spec:
+            raise ValueError(
+                "filename_template reducer matching only supports plain "
+                "named fields without conversion or format specifiers"
+            )
+        if not field_name.isidentifier():
+            raise ValueError(
+                "filename_template reducer matching only supports plain named fields"
+            )
+        if field_name in seen_fields:
+            # Repeated fields in the template must resolve to the same path segment.
+            parts.append(f"(?P={field_name})")
+            continue
+        pattern = _FIELD_PATTERNS.get(field_name, _DEFAULT_FIELD_PATTERN)
+        parts.append(f"(?P<{field_name}>{pattern})")
+        seen_fields.add(field_name)
+
+    missing_fields = sorted(_REQUIRED_TEMPLATE_FIELDS.difference(seen_fields))
+    if missing_fields:
+        raise ValueError(
+            "filename_template reducer matching requires fields: "
+            + ", ".join(f"{{{field_name}}}" for field_name in missing_fields)
+        )
+
+    return re.compile("^" + "".join(parts) + "$")
+
+
+class FileCleanupReducerSink(BaseSink):
+    """Delete non-finalized deterministic file-sink outputs."""
+
+    def __init__(
+        self,
+        output: DataFolderLike,
+        *,
+        filename_template: str,
+        reducer_name: str,
+    ) -> None:
+        self.output = DataFolder.resolve(output)
+        self.filename_template = filename_template
+        self.reducer_name = reducer_name
+        self._managed_path_pattern = _compile_managed_path_pattern(filename_template)
+        self._cleanup_ran = False
+
+    def write_shard_block(self, shard_id, block) -> None:
+        del shard_id, block
+        self._run_cleanup()
+
+    @property
+    def counts_output_rows(self) -> bool:
+        return False
+
+    def describe(self) -> tuple[str, str, dict[str, object]]:
+        return (
+            self.reducer_name,
+            "writer",
+            {
+                "path": self.output.abs_path(),
+                "filename_template": self.filename_template,
+            },
+        )
+
+    def _run_cleanup(self) -> None:
+        if self._cleanup_ran:
+            return
+        self._cleanup_ran = True
+
+        stage_index = get_active_stage_index()
+        if stage_index is None or stage_index <= 0:
+            raise ValueError(
+                f"{self.reducer_name} requires an active reducer stage with a prior writer stage"
+            )
+
+        keep_pairs = {
+            (
+                row.shard_id,
+                row.worker_token,
+            )
+            for row in get_finalized_workers(stage_index=stage_index - 1)
+        }
+
+        try:
+            listed_paths = self.output.find("")
+        except FileNotFoundError:
+            return
+
+        # Extra template fields are treated as structure only. Authority is decided
+        # solely from the finalized (shard_id, worker_id) pair extracted from each
+        # managed path.
+        managed_matches = sorted(
+            (
+                path,
+                match,
+            )
+            for path in listed_paths
+            if isinstance(path, str)
+            and path
+            and path != "."
+            and (match := self._managed_path_pattern.fullmatch(path)) is not None
+        )
+        for rel_path, match in managed_matches:
+            if (match.group("shard_id"), match.group("worker_id")) in keep_pairs:
+                continue
+            try:
+                self.output.rm(rel_path)
+            except FileNotFoundError:
+                continue
+
+
+__all__ = ["FileCleanupReducerSink"]

--- a/src/refiner/pipeline/sinks/reducer/file.py
+++ b/src/refiner/pipeline/sinks/reducer/file.py
@@ -117,18 +117,20 @@ class FileCleanupReducerSink(BaseSink):
         # Extra template fields are treated as structure only. Authority is decided
         # solely from the finalized (shard_id, worker_id) pair extracted from each
         # managed path.
-        managed_matches = sorted(
-            (
-                path,
-                match,
-            )
-            for path in listed_paths
-            if isinstance(path, str)
-            and path
-            and path != "."
-            and (match := self._managed_path_pattern.fullmatch(path)) is not None
+        managed_paths = sorted(
+            {
+                path
+                for path in listed_paths
+                if isinstance(path, str)
+                and path
+                and path != "."
+                and self._managed_path_pattern.fullmatch(path) is not None
+            }
         )
-        for rel_path, match in managed_matches:
+        for rel_path in managed_paths:
+            match = self._managed_path_pattern.fullmatch(rel_path)
+            if match is None:
+                continue
             if (match.group("shard_id"), match.group("worker_id")) in keep_pairs:
                 continue
             try:

--- a/src/refiner/pipeline/sinks/reducer/lerobot.py
+++ b/src/refiner/pipeline/sinks/reducer/lerobot.py
@@ -31,9 +31,21 @@ class LeRobotMetaReduceSink(BaseSink):
 
     def __init__(self, output: DataFolderLike):
         self.output = DataFolder.resolve(output)
+        self._reduce_ran = False
 
     def write_shard_block(self, shard_id: str, block: Block) -> None:
         del shard_id, block
+        self._reduce()
+
+    @property
+    def counts_output_rows(self) -> bool:
+        return False
+
+    def _reduce(self) -> None:
+        if self._reduce_ran:
+            return
+        self._reduce_ran = True
+
         finalized_chunk_keys = self._finalized_chunk_keys()
         finalized_chunk_key_set = set(finalized_chunk_keys)
 

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -256,7 +256,8 @@ class Worker:
                                 if count
                             }
                         )
-                        output_rows += block_num_rows(block)
+                        if sink.counts_output_rows:
+                            output_rows += block_num_rows(block)
                 except Exception as e:
                     execution_error = e
                     failed_error = str(e).strip() or type(e).__name__

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -118,8 +118,8 @@ def test_launch_local_coalesces_writer_shards(tmp_path) -> None:
         rundir=str(tmp_path / "run"),
     )
 
-    assert stats.claimed == 1
-    assert stats.completed == 1
+    assert stats.claimed == 2
+    assert stats.completed == 2
 
 
 def test_build_gpu_sets_partitions_gpus(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -19,7 +19,7 @@ from refiner.video.transcode import VideoTranscodeConfig
 from refiner.video.writer import VideoStreamWriter
 from refiner.pipeline.data.row import DictRow
 from refiner.pipeline.sinks.lerobot import LeRobotWriterSink
-from refiner.pipeline.sinks.lerobot_reducer import LeRobotMetaReduceSink
+from refiner.pipeline.sinks.reducer.lerobot import LeRobotMetaReduceSink
 from refiner.robotics.lerobot_format import (
     LeRobotInfo,
     LeRobotMetadata,

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -190,6 +190,26 @@ def test_compile_pipeline_plan_includes_lerobot_writer_steps() -> None:
     )
 
 
+def test_compile_pipeline_plan_includes_jsonl_reducer_steps() -> None:
+    pipeline = RefinerPipeline(FakeReader()).write_jsonl("/tmp/output")
+
+    stages = compile_pipeline_plan(pipeline)["stages"]
+
+    assert len(stages) == 2
+    assert stages[0]["name"] == "write_jsonl_stage_0"
+    assert stages[1]["name"] == "write_jsonl_stage_1"
+    assert [step["name"] for step in stages[1]["steps"]] == [
+        "task",
+        "write_jsonl_reduce",
+    ]
+    assert stages[1]["steps"][1]["type"] == "writer"
+    assert stages[1]["steps"][1]["args"]["path"] == "/tmp/output"
+    assert (
+        stages[1]["steps"][1]["args"]["filename_template"]
+        == "{shard_id}__w{worker_id}.jsonl"
+    )
+
+
 def test_compile_pipeline_plan_includes_sink_without_describe() -> None:
     pipeline = RefinerPipeline(FakeReader(), sink=UndescribedSink())
 
@@ -249,3 +269,18 @@ def test_plan_pipeline_stages_returns_single_placeholder_stage() -> None:
     assert stages[0].name == "stage_0"
     assert stages[0].pipeline is pipeline
     assert stages[0].compute.num_workers == 3
+
+
+def test_plan_pipeline_stages_adds_writer_reducer_stage() -> None:
+    pipeline = from_items([{"x": 1}]).write_parquet("/tmp/output")
+    stages = plan_pipeline_stages(pipeline, default_num_workers=3)
+
+    assert len(stages) == 2
+    assert stages[0].index == 0
+    assert stages[0].name == "write_parquet_stage_0"
+    assert stages[0].pipeline is pipeline
+    assert stages[0].compute.num_workers == 3
+    assert stages[1].index == 1
+    assert stages[1].name == "write_parquet_stage_1"
+    assert stages[1].compute.num_workers == 1
+    assert stages[1].pipeline.source.name == "task"

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -243,3 +243,47 @@ def test_file_cleanup_reducer_ignores_extra_template_fields(tmp_path) -> None:
     assert all(path.exists() for path in winner_files)
     assert not loser_file.exists()
     assert unmanaged_file.exists()
+
+
+def test_file_cleanup_reducer_tolerates_duplicate_listed_paths(
+    tmp_path, monkeypatch
+) -> None:
+    output_dir = tmp_path / "jsonl-cleanup-duplicates"
+    shard_id = "0123456789ab"
+    winner_worker_id = "worker-2"
+    loser_worker_id = "worker-1"
+    winner_path = (
+        output_dir / f"{shard_id}__w{worker_token_for(winner_worker_id)}.jsonl"
+    )
+    loser_path = output_dir / f"{shard_id}__w{worker_token_for(loser_worker_id)}.jsonl"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    winner_path.write_text("{}", encoding="utf-8")
+    loser_path.write_text("{}", encoding="utf-8")
+
+    reducer = FileCleanupReducerSink(
+        output_dir,
+        filename_template="{shard_id}__w{worker_id}.jsonl",
+        reducer_name="cleanup_jsonl",
+    )
+    monkeypatch.setattr(
+        reducer.output,
+        "find",
+        lambda _: [winner_path.name, winner_path.name, loser_path.name],
+    )
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="reducer",
+        worker_name=None,
+        runtime_lifecycle=cast(
+            RuntimeLifecycle,
+            _FinalizedWorkersRuntime(
+                [FinalizedShardWorker(shard_id=shard_id, worker_id=winner_worker_id)]
+            ),
+        ),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    assert winner_path.exists()
+    assert not loser_path.exists()

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import pyarrow.parquet as pq
 
@@ -8,7 +9,22 @@ from refiner import col
 from refiner.pipeline.data.row import DictRow
 from refiner.pipeline import from_items
 from refiner.pipeline.sinks import JsonlSink
+from refiner.pipeline.sinks.parquet import ParquetSink
+from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
+from refiner.worker.context import set_active_run_context
+from refiner.worker.lifecycle import FinalizedShardWorker, RuntimeLifecycle
 from refiner.worker.context import worker_token_for
+
+
+class _FinalizedWorkersRuntime:
+    def __init__(self, rows: list[FinalizedShardWorker]) -> None:
+        self._rows = rows
+
+    def finalized_workers(
+        self, *, stage_index: int | None = None
+    ) -> list[FinalizedShardWorker]:
+        assert stage_index == 0
+        return self._rows
 
 
 def test_iter_rows_ignores_sink(tmp_path) -> None:
@@ -30,7 +46,9 @@ def test_launch_local_writes_jsonl_per_shard(tmp_path) -> None:
         name="jsonl-sink", num_workers=1, rundir=str(tmp_path / "run")
     )
 
-    assert stats.completed == 2
+    assert stats.claimed == 3
+    assert stats.completed == 3
+    assert stats.output_rows == 3
     written = sorted(path.name for path in output_dir.iterdir())
     assert len(written) == 2
     assert all("__w" in name for name in written)
@@ -49,7 +67,9 @@ def test_launch_local_writes_parquet_per_shard(tmp_path) -> None:
         name="parquet-sink", num_workers=1, rundir=str(tmp_path / "run")
     )
 
-    assert stats.completed == 2
+    assert stats.claimed == 3
+    assert stats.completed == 3
+    assert stats.output_rows == 3
     written = sorted(path for path in output_dir.iterdir() if path.suffix == ".parquet")
     assert len(written) == 2
     assert all("__w" in path.name for path in written)
@@ -74,7 +94,9 @@ def test_launch_local_vectorized_filter_with_sink_completes_shards(tmp_path) -> 
         rundir=str(tmp_path / "run"),
     )
 
-    assert stats.completed == 2
+    assert stats.claimed == 3
+    assert stats.completed == 3
+    assert stats.output_rows == 2
     written = sorted(path for path in output_dir.iterdir() if path.suffix == ".jsonl")
     assert len(written) == 2
     assert all("__w" in path.name for path in written)
@@ -90,3 +112,134 @@ def test_jsonl_sink_uses_local_worker_suffix_outside_runtime(tmp_path) -> None:
         f"abc__w{worker_token_for('local')}.jsonl"
     ]
     assert json.loads(written[0].read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_jsonl_reducer_keeps_only_finalized_worker_outputs(tmp_path) -> None:
+    output_dir = tmp_path / "jsonl-cleanup"
+    shard_id = "0123456789ab"
+    worker_ids = ["worker-1", "worker-2"]
+
+    for worker_id, value in zip(worker_ids, [1, 9], strict=True):
+        sink = JsonlSink(output_dir)
+        with set_active_run_context(
+            job_id="job",
+            stage_index=0,
+            worker_id=worker_id,
+            worker_name=None,
+            runtime_lifecycle=cast(
+                RuntimeLifecycle,
+                _FinalizedWorkersRuntime(
+                    [FinalizedShardWorker(shard_id=shard_id, worker_id=worker_ids[1])]
+                ),
+            ),
+        ):
+            sink.write_block([DictRow({"x": value}, shard_id=shard_id)])
+            sink.on_shard_complete(shard_id)
+
+    reducer = JsonlSink(output_dir).build_reducer()
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="reducer",
+        worker_name=None,
+        runtime_lifecycle=cast(
+            RuntimeLifecycle,
+            _FinalizedWorkersRuntime(
+                [FinalizedShardWorker(shard_id=shard_id, worker_id=worker_ids[1])]
+            ),
+        ),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    kept = output_dir / f"{shard_id}__w{worker_token_for(worker_ids[1])}.jsonl"
+    deleted = output_dir / f"{shard_id}__w{worker_token_for(worker_ids[0])}.jsonl"
+    assert kept.exists()
+    assert not deleted.exists()
+    assert json.loads(kept.read_text(encoding="utf-8")) == {"x": 9}
+
+
+def test_parquet_reducer_keeps_only_finalized_worker_outputs(tmp_path) -> None:
+    output_dir = tmp_path / "parquet-cleanup"
+    shard_id = "0123456789ab"
+    worker_ids = ["worker-1", "worker-2"]
+
+    for worker_id, value in zip(worker_ids, [1, 9], strict=True):
+        sink = ParquetSink(output_dir)
+        with set_active_run_context(
+            job_id="job",
+            stage_index=0,
+            worker_id=worker_id,
+            worker_name=None,
+            runtime_lifecycle=cast(
+                RuntimeLifecycle,
+                _FinalizedWorkersRuntime(
+                    [FinalizedShardWorker(shard_id=shard_id, worker_id=worker_ids[1])]
+                ),
+            ),
+        ):
+            sink.write_block([DictRow({"x": value}, shard_id=shard_id)])
+            sink.on_shard_complete(shard_id)
+
+    reducer = ParquetSink(output_dir).build_reducer()
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="reducer",
+        worker_name=None,
+        runtime_lifecycle=cast(
+            RuntimeLifecycle,
+            _FinalizedWorkersRuntime(
+                [FinalizedShardWorker(shard_id=shard_id, worker_id=worker_ids[1])]
+            ),
+        ),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    kept = output_dir / f"{shard_id}__w{worker_token_for(worker_ids[1])}.parquet"
+    deleted = output_dir / f"{shard_id}__w{worker_token_for(worker_ids[0])}.parquet"
+    assert kept.exists()
+    assert not deleted.exists()
+    assert pq.read_table(kept).column("x").to_pylist() == [9]
+
+
+def test_file_cleanup_reducer_ignores_extra_template_fields(tmp_path) -> None:
+    output_dir = tmp_path / "jsonl-cleanup-extra"
+    shard_id = "0123456789ab"
+    winner_worker_id = "worker-2"
+    loser_worker_id = "worker-1"
+    winner_token = worker_token_for(winner_worker_id)
+    loser_token = worker_token_for(loser_worker_id)
+
+    winner_files = [
+        output_dir / f"{shard_id}__w{winner_token}__part0.jsonl",
+        output_dir / f"{shard_id}__w{winner_token}__part1.jsonl",
+    ]
+    loser_file = output_dir / f"{shard_id}__w{loser_token}__part0.jsonl"
+    unmanaged_file = output_dir / "notes.txt"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for path in winner_files + [loser_file]:
+        path.write_text("{}", encoding="utf-8")
+    unmanaged_file.write_text("keep me", encoding="utf-8")
+
+    reducer = FileCleanupReducerSink(
+        output_dir,
+        filename_template="{shard_id}__w{worker_id}__{part}.jsonl",
+        reducer_name="cleanup_jsonl",
+    )
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="reducer",
+        worker_name=None,
+        runtime_lifecycle=cast(
+            RuntimeLifecycle,
+            _FinalizedWorkersRuntime(
+                [FinalizedShardWorker(shard_id=shard_id, worker_id=winner_worker_id)]
+            ),
+        ),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    assert all(path.exists() for path in winner_files)
+    assert not loser_file.exists()
+    assert unmanaged_file.exists()


### PR DESCRIPTION
## Purpose

Add a sink-owned reducer stage hook so launched writer pipelines can run a final cleanup or reduction pass after the main shard-writing stage.

This gives `write_jsonl(...)`, `write_parquet(...)`, and `write_lerobot(...)` a shared writer-finalization model for both local and cloud-style planning.

## What changed

- added `BaseSink.build_reducer()` for optional 1-worker reducer stages
- updated shared planning to append a reducer stage automatically when a sink provides one
- added a generic file cleanup reducer for deterministic file sinks under `src/refiner/pipeline/sinks/reducer/`
- wired `JsonlSink` and `ParquetSink` to use that reducer
- wired `LeRobotWriterSink` to return its metadata reducer through the same sink hook
- added `counts_output_rows` on sinks so reducer control rows do not inflate launched `output_rows`
- updated docs to explain reducer stages and the expectation that cleanup-managed output prefixes are Refiner-owned

## Behavior

For launched `write_jsonl(...)` and `write_parquet(...)` pipelines, execution now has:

1. a writer stage
2. a 1-worker reducer stage

The generic file reducer:

- lists files under the sink output root
- matches only paths that fit the sink filename template
- extracts `(shard_id, worker_id)` from each matched path
- keeps files whose pair is finalized for the writer stage
- deletes matched loser files

Extra filename-template fields are treated as structure only. Authority is decided by finalized `(shard_id, worker_id)` pairs.

## Design notes

- finalization stays sink-owned instead of planner-special-casing individual writers
- local and cloud use the same stage shape because this lives in shared planning
- this is intentionally narrower than Spark or Beam/Dataflow-style manifest commit protocols; v1 is cleanup/finalization for deterministic sinks, not a generic artifact ledger
- compared with Ray/Ray Data and Daft, this adds an explicit sink finalization contract instead of relying on retries alone
- Hugging Face Datasets is not the model here because the problem is output finalization semantics rather than dataset fingerprinting

## Validation

- `uv run ruff check --force-exclude src/refiner/pipeline/sinks src/refiner/worker/runner.py tests/pipeline/test_sinks.py tests/pipeline/test_lerobot_sink.py`
- `uv run pytest tests/pipeline/test_sinks.py tests/pipeline/test_planning.py tests/launchers/test_local_launcher.py`
- `uv run pytest tests/pipeline/test_sinks.py tests/pipeline/test_planning.py tests/launchers/test_local_launcher.py tests/pipeline/test_lerobot_sink.py -k "reducer or write_lerobot_launch_local_runs_stage1_then_stage2"`

## Follow-up

- use the same reducer-stage contract in cloud resume flows
- decide whether more complex sinks need custom reducers or a richer cleanup contract
- add broader rerun coverage against existing output directories
