### PR TITLE
[codex] add cloud attach cli

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,8 @@ Use `macrodata run` to run a Macrodata Refiner pipeline script.
 
 Options:
 
-- `--attach auto|attach|detach`
+- `--attach`
+- `--detach`
 - `--logs all|none|one|errors`
 - script arguments after `--`
 
@@ -54,8 +55,9 @@ Behavior:
 - `Ctrl+C` exits with code `130`
 - local launcher resume/failure messages are printed cleanly, while ordinary script exceptions still surface normally
 - the script directory is added to `sys.path`, so sibling imports work the same way they do with `python script.py`
-- `--attach` only applies to cloud launches; passing it to a script that launches local jobs exits with an error
 - cloud launches default to attach in interactive terminals and detach in non-interactive output
+- `--attach` forces attached mode for cloud launches and is accepted for local launches
+- `--detach` forces detached mode for cloud launches and errors for local launches
 - detached cloud launches print the exact follow-up commands to inspect, attach, or cancel the job
 - attached cloud launches exit automatically when the job reaches a terminal state
 - `Ctrl+C` during an attached cloud launch detaches the local CLI only; the cloud job keeps running and the CLI prints the job URL plus reattach and cancel commands
@@ -66,7 +68,8 @@ macrodata run path/to/pipeline.py
 
 ```bash
 macrodata run --logs one path/to/pipeline.py -- --workers 4 --rows 20
-macrodata run --attach detach path/to/cloud_pipeline.py
+macrodata run --detach path/to/cloud_pipeline.py
+macrodata run --attach path/to/cloud_pipeline.py
 ```
 
 ## Credential Lookup

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,7 @@ Use `macrodata run` to run a Macrodata Refiner pipeline script.
 
 Options:
 
+- `--attach auto|attach|detach`
 - `--logs all|none|one|errors`
 - script arguments after `--`
 
@@ -53,6 +54,11 @@ Behavior:
 - `Ctrl+C` exits with code `130`
 - local launcher resume/failure messages are printed cleanly, while ordinary script exceptions still surface normally
 - the script directory is added to `sys.path`, so sibling imports work the same way they do with `python script.py`
+- `--attach` only applies to cloud launches; passing it to a script that launches local jobs exits with an error
+- cloud launches default to attach in interactive terminals and detach in non-interactive output
+- detached cloud launches print the exact follow-up commands to inspect, attach, or cancel the job
+- attached cloud launches exit automatically when the job reaches a terminal state
+- `Ctrl+C` during an attached cloud launch detaches the local CLI only; the cloud job keeps running and the CLI prints the job URL plus reattach and cancel commands
 
 ```bash
 macrodata run path/to/pipeline.py
@@ -60,6 +66,7 @@ macrodata run path/to/pipeline.py
 
 ```bash
 macrodata run --logs one path/to/pipeline.py -- --workers 4 --rows 20
+macrodata run --attach detach path/to/cloud_pipeline.py
 ```
 
 ## Credential Lookup
@@ -100,6 +107,14 @@ Options:
 
 ```bash
 macrodata jobs get <job_id>
+```
+
+### `macrodata jobs attach`
+
+Reattaches the cloud job console for an existing cloud job. The attached view shows the current job summary header, a capped live worker log view, and exits automatically when the remote job reaches a terminal state.
+
+```bash
+macrodata jobs attach <job_id>
 ```
 
 ### `macrodata jobs manifest`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,10 +55,11 @@ Behavior:
 - `Ctrl+C` exits with code `130`
 - local launcher resume/failure messages are printed cleanly, while ordinary script exceptions still surface normally
 - the script directory is added to `sys.path`, so sibling imports work the same way they do with `python script.py`
-- cloud launches default to attach in interactive terminals and detach in non-interactive output
+- `macrodata run` defaults cloud launches to attach in interactive terminals and detach in non-interactive output
 - `--attach` forces attached mode for cloud launches and is accepted for local launches
 - `--detach` forces detached mode for cloud launches and errors for local launches
 - `--logs` applies to attached local and cloud launches; `all` is the default, `one` shows a single worker at a time, `none` keeps the header live without log lines, and `errors` only shows error log lines
+- direct Python `launch_cloud(...)` calls remain detached by default unless `REFINER_ATTACH` is explicitly set
 - detached cloud launches print the exact follow-up commands to inspect, attach, or cancel the job
 - attached cloud launches exit automatically when the job reaches a terminal state
 - `Ctrl+C` during an attached cloud launch detaches the local CLI only; the cloud job keeps running and the CLI prints the job URL plus reattach and cancel commands

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,6 +58,7 @@ Behavior:
 - cloud launches default to attach in interactive terminals and detach in non-interactive output
 - `--attach` forces attached mode for cloud launches and is accepted for local launches
 - `--detach` forces detached mode for cloud launches and errors for local launches
+- `--logs` applies to attached local and cloud launches; `all` is the default, `one` shows a single worker at a time, `none` keeps the header live without log lines, and `errors` only shows error log lines
 - detached cloud launches print the exact follow-up commands to inspect, attach, or cancel the job
 - attached cloud launches exit automatically when the job reaches a terminal state
 - `Ctrl+C` during an attached cloud launch detaches the local CLI only; the cloud job keeps running and the CLI prints the job URL plus reattach and cancel commands

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -79,6 +79,15 @@ def resolve_attach_mode() -> str:
     return "attach" if stdout_is_interactive() else "detach"
 
 
+def resolve_launcher_attach_mode() -> str:
+    override = attach_mode_override()
+    if override is None:
+        return "detach"
+    if override == "auto":
+        return "attach" if stdout_is_interactive() else "detach"
+    return override
+
+
 def require_cloud_attach_supported(executor_kind: str) -> None:
     override = attach_mode_override()
     if override is None:

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, TextIO, cast
 
@@ -21,6 +21,8 @@ from refiner.cli.job_utils import (
 from refiner.cli.local_run import (
     LocalStageConsole,
     LocalStageSnapshot,
+    resolve_log_mode,
+    should_emit_worker_line,
     stdout_is_interactive,
 )
 from refiner.job_urls import build_job_tracking_url
@@ -133,6 +135,14 @@ def _warn_follow_skip(
         )
 
 
+def _context_for_stage(
+    context: CloudAttachContext, *, stage_index: int
+) -> CloudAttachContext:
+    if context.stage_index == stage_index:
+        return context
+    return replace(context, stage_index=stage_index)
+
+
 def _log_worker_label(entry: dict[str, Any]) -> str:
     worker_id = entry.get("workerId")
     if isinstance(worker_id, str) and worker_id.strip():
@@ -150,6 +160,29 @@ def _format_attach_log_line(entry: dict[str, Any]) -> str:
         f"{_safe_text(entry.get('sourceType'))}/{_safe_text(entry.get('sourceName'))} "
         f"{_safe_text(entry.get('line'))}"
     )
+
+
+def _emit_cloud_log_mode_banner(
+    *,
+    console: LocalStageConsole,
+    log_mode: str,
+    running_workers: int,
+) -> None:
+    if log_mode == "none":
+        console.emit_system("live log lines are hidden; updating header only")
+        return
+    if log_mode == "one" and running_workers > 1:
+        console.emit_system("showing one running worker at a time to stay live")
+        return
+    if log_mode in {"all", "errors"} and running_workers > _ATTACH_MAX_LOGGED_WORKERS:
+        if log_mode == "errors":
+            console.emit_system(
+                f"showing error logs from up to {_ATTACH_MAX_LOGGED_WORKERS} of {running_workers} running workers to stay live"
+            )
+            return
+        console.emit_system(
+            f"showing up to {_ATTACH_MAX_LOGGED_WORKERS} of {running_workers} running workers to stay live"
+        )
 
 
 def _active_stage(job: dict[str, Any]) -> tuple[int, int]:
@@ -210,7 +243,7 @@ def _build_snapshot(
     return LocalStageSnapshot(
         job_id=context.job_id,
         job_name=context.job_name,
-        rundir="cloud",
+        rundir=None,
         stage_index=stage_index,
         total_stages=max(1, total_stages),
         stage_workers=stage_workers,
@@ -273,8 +306,9 @@ def attach_to_cloud_job(
     job_id: str,
     initial_job_payload: dict[str, Any] | None = None,
     stage_index_hint: int | None = None,
+    force_attach: bool = False,
 ) -> int:
-    if not stdout_is_interactive():
+    if not force_attach and not stdout_is_interactive():
         payload = initial_job_payload or client.cli_get_job(job_id=job_id)
         context = _cloud_context_from_job_payload(
             client=client,
@@ -295,19 +329,21 @@ def attach_to_cloud_job(
     console = LocalStageConsole(
         job_id=context.job_id,
         job_name=context.job_name,
-        rundir="cloud",
+        rundir=None,
         stage_index=snapshot.stage_index,
         total_stages=snapshot.total_stages,
         stage_workers=snapshot.stage_workers,
         tracking_url=context.tracking_url,
     )
     console.emit_system(f"attached to cloud job {context.job_id}")
+    log_mode = resolve_log_mode(None)
     selected_worker_ids: tuple[str, ...] = ()
     current_stage_index = snapshot.stage_index
-    if snapshot.worker_running > _ATTACH_MAX_LOGGED_WORKERS:
-        console.emit_system(
-            f"showing up to {_ATTACH_MAX_LOGGED_WORKERS} of {snapshot.worker_running} running workers to stay live"
-        )
+    _emit_cloud_log_mode_banner(
+        console=console,
+        log_mode=log_mode,
+        running_workers=snapshot.worker_running,
+    )
     closed = False
     try:
         console.apply_snapshot(snapshot)
@@ -347,7 +383,8 @@ def attach_to_cloud_job(
                     job_payload=job_payload,
                     stage_index_hint=stage_index_hint,
                 )
-                if snapshot.stage_index != current_stage_index:
+                stage_changed = snapshot.stage_index != current_stage_index
+                if stage_changed:
                     selected_worker_ids = ()
                     current_cursor = None
                     full_batch_polls = 0
@@ -359,12 +396,21 @@ def attach_to_cloud_job(
                     next_logs_at = now
                 console.apply_snapshot(snapshot)
                 current_stage_index = snapshot.stage_index
+                context = _context_for_stage(context, stage_index=current_stage_index)
+                if stage_changed:
+                    _emit_cloud_log_mode_banner(
+                        console=console,
+                        log_mode=log_mode,
+                        running_workers=snapshot.worker_running,
+                    )
                 terminal_seen = _job_status(job_payload) in _TERMINAL_JOB_STATUSES
                 next_summary_at = now + _ATTACH_SUMMARY_INTERVAL_SECONDS
 
             logs_available = isinstance(job_payload.get("job"), dict) and bool(
                 cast(dict[str, Any], job_payload["job"]).get("logsAvailable", True)
             )
+            if log_mode == "none":
+                logs_available = False
             if not logs_available:
                 next_logs_at = now + _ATTACH_LOGS_INTERVAL_SECONDS
             if logs_available and now >= next_logs_at:
@@ -397,17 +443,39 @@ def attach_to_cloud_job(
                         if not isinstance(entry, dict):
                             continue
                         worker_id = _safe_text(entry.get("workerId"))
+                        selected_worker_id = (
+                            selected_worker_ids[0] if selected_worker_ids else None
+                        )
+                        should_emit = should_emit_worker_line(
+                            log_mode=log_mode,
+                            worker_id=worker_id,
+                            selected_worker_id=selected_worker_id,
+                            line=_safe_text(entry.get("line")),
+                            severity=_safe_text(entry.get("severity")),
+                        )
                         if (
-                            worker_id != "-"
+                            log_mode == "one"
+                            and worker_id != "-"
+                            and not selected_worker_ids
+                        ):
+                            selected_worker_ids = (worker_id,)
+                            selected_worker_id = worker_id
+                            should_emit = should_emit_worker_line(
+                                log_mode=log_mode,
+                                worker_id=worker_id,
+                                selected_worker_id=selected_worker_id,
+                                line=_safe_text(entry.get("line")),
+                                severity=_safe_text(entry.get("severity")),
+                            )
+                        elif (
+                            log_mode in {"all", "errors"}
+                            and should_emit
+                            and worker_id != "-"
                             and worker_id not in selected_worker_ids
                             and len(selected_worker_ids) < _ATTACH_MAX_LOGGED_WORKERS
                         ):
                             selected_worker_ids = (*selected_worker_ids, worker_id)
-                        if (
-                            selected_worker_ids
-                            and worker_id != "-"
-                            and worker_id not in selected_worker_ids
-                        ):
+                        if not should_emit:
                             continue
                         key = _log_entry_key(entry)
                         if key in seen_keys:

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -39,6 +39,7 @@ _ATTACH_DEDUPE_LIMIT = 100_000
 _ATTACH_MAX_DRAIN_POLLS = 5
 _ATTACH_DRAIN_POLL_DELAY_SECONDS = 0.1
 _ATTACH_MAX_RETRYABLE_ERRORS = 5
+_STAGE_NOT_STARTED_STATUSES = {"queued", "pending"}
 
 
 class CloudAttachDetached(KeyboardInterrupt):
@@ -198,6 +199,15 @@ def _active_stage(job: dict[str, Any]) -> tuple[int, int]:
     stages = job.get("stages")
     if not isinstance(stages, list) or not stages:
         return 0, 1
+    job_status = _safe_text(job.get("status")).lower()
+    if job_status in _TERMINAL_JOB_STATUSES and job_status != "completed":
+        for index in range(len(stages) - 1, -1, -1):
+            stage = stages[index]
+            if not isinstance(stage, dict):
+                continue
+            status = _safe_text(stage.get("status")).lower()
+            if status not in _STAGE_NOT_STARTED_STATUSES:
+                return int(stage.get("index", index) or index), len(stages)
     for stage in stages:
         if not isinstance(stage, dict):
             continue
@@ -481,8 +491,9 @@ def attach_to_cloud_job(
                             and should_emit
                             and worker_id != "-"
                             and worker_id not in selected_worker_ids
-                            and len(selected_worker_ids) < _ATTACH_MAX_LOGGED_WORKERS
                         ):
+                            if len(selected_worker_ids) >= _ATTACH_MAX_LOGGED_WORKERS:
+                                continue
                             selected_worker_ids = (*selected_worker_ids, worker_id)
                         if not should_emit:
                             continue

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -393,7 +393,7 @@ def attach_to_cloud_job(
                     status_retryable_error_count += 1
                     if status_retryable_error_count > _ATTACH_MAX_RETRYABLE_ERRORS:
                         raise
-                    time.sleep(_retry_delay(status_retryable_error_count))
+                    next_summary_at = now + _retry_delay(status_retryable_error_count)
                     continue
                 status_retryable_error_count = 0
                 context, snapshot = _snapshot_and_context(

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -7,6 +7,17 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, TextIO, cast
 
+from refiner.cli.job_utils import (
+    TERMINAL_JOB_STATUSES as _TERMINAL_JOB_STATUSES,
+    format_ts as _format_ts,
+    is_retryable_api_error as _is_retryable_api_error,
+    job_status as _job_status,
+    log_entry_key as _log_entry_key,
+    next_log_cursor as _next_log_cursor,
+    parse_epoch_ms,
+    remember_seen_key as _remember_seen_key,
+    safe_text as _safe_text,
+)
 from refiner.cli.local_run import (
     LocalStageConsole,
     LocalStageSnapshot,
@@ -14,7 +25,6 @@ from refiner.cli.local_run import (
 )
 from refiner.job_urls import build_job_tracking_url
 from refiner.platform.client import MacrodataApiError, MacrodataClient
-from refiner.platform.client.api import sanitize_terminal_text
 
 _ATTACH_MODE_ENV_VAR = "REFINER_ATTACH"
 _VALID_ATTACH_MODES = {"auto", "attach", "detach"}
@@ -27,7 +37,6 @@ _ATTACH_DEDUPE_LIMIT = 100_000
 _ATTACH_MAX_DRAIN_POLLS = 5
 _ATTACH_DRAIN_POLL_DELAY_SECONDS = 0.1
 _ATTACH_MAX_RETRYABLE_ERRORS = 5
-_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
 
 
 class CloudAttachDetached(KeyboardInterrupt):
@@ -72,8 +81,8 @@ def require_cloud_attach_supported(executor_kind: str) -> None:
     override = attach_mode_override()
     if override is None:
         return
-    if executor_kind != "cloud":
-        raise SystemExit("--attach is only supported for cloud launches.")
+    if executor_kind != "cloud" and override == "detach":
+        raise SystemExit("--detach is only supported for cloud launches.")
 
 
 def emit_cloud_followup_commands(
@@ -97,71 +106,8 @@ def emit_cloud_followup_commands(
     print(f"Cancel: macrodata jobs cancel {context.job_id}", file=file)
 
 
-def _safe_text(value: Any) -> str:
-    if value is None:
-        return "-"
-    return sanitize_terminal_text(str(value))
-
-
-def _format_ts(value: Any) -> str:
-    if not isinstance(value, (int, float)):
-        return "-"
-    timestamp_ms = value * 1000 if value < 100_000_000_000 else value
-    try:
-        dt = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return "-"
-    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
-
-
-def _job_status(payload: dict[str, Any]) -> str:
-    job = payload.get("job")
-    if not isinstance(job, dict):
-        return ""
-    return _safe_text(job.get("status")).lower()
-
-
-def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
-    raw_message_hash = entry.get("messageHash")
-    message_hash = (
-        str(raw_message_hash)
-        if isinstance(raw_message_hash, (str, int, float)) and str(raw_message_hash)
-        else ""
-    )
-    return (
-        _safe_text(entry.get("ts")),
-        _safe_text(entry.get("workerId")),
-        _safe_text(entry.get("sourceType")),
-        _safe_text(entry.get("sourceName")),
-        message_hash or _safe_text(entry.get("line")),
-    )
-
-
-def _remember_seen_key(
-    *,
-    key: tuple[str, str, str, str, str],
-    seen_keys: set[tuple[str, str, str, str, str]],
-    seen_order: deque[tuple[str, str, str, str, str]],
-) -> None:
-    seen_keys.add(key)
-    seen_order.append(key)
-    while len(seen_order) > _ATTACH_DEDUPE_LIMIT:
-        seen_keys.discard(seen_order.popleft())
-
-
-def _is_retryable_api_error(err: Exception) -> bool:
-    if isinstance(err, MacrodataApiError):
-        return err.status in {0, 429} or err.status >= 500
-    return False
-
-
 def _retry_delay(error_count: int) -> float:
     return min(float(2 ** max(0, error_count - 1)), 5.0)
-
-
-def _next_log_cursor(payload: dict[str, Any]) -> str | None:
-    cursor = payload.get("nextCursor")
-    return cursor if isinstance(cursor, str) and cursor else None
 
 
 def _warn_follow_skip(
@@ -403,6 +349,14 @@ def attach_to_cloud_job(
                 )
                 if snapshot.stage_index != current_stage_index:
                     selected_worker_ids = ()
+                    current_cursor = None
+                    full_batch_polls = 0
+                    seen_keys.clear()
+                    seen_order.clear()
+                    reset_now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+                    current_start_ms = max(0, reset_now_ms - _DEFAULT_LOG_WINDOW_MS)
+                    current_end_ms = max(current_start_ms + 1, reset_now_ms)
+                    next_logs_at = now
                 console.apply_snapshot(snapshot)
                 current_stage_index = snapshot.stage_index
                 terminal_seen = _job_status(job_payload) in _TERMINAL_JOB_STATUSES
@@ -411,6 +365,8 @@ def attach_to_cloud_job(
             logs_available = isinstance(job_payload.get("job"), dict) and bool(
                 cast(dict[str, Any], job_payload["job"]).get("logsAvailable", True)
             )
+            if not logs_available:
+                next_logs_at = now + _ATTACH_LOGS_INTERVAL_SECONDS
             if logs_available and now >= next_logs_at:
                 try:
                     payload = client.cli_get_job_logs(
@@ -464,6 +420,7 @@ def attach_to_cloud_job(
                             key=key,
                             seen_keys=seen_keys,
                             seen_order=seen_order,
+                            limit=_ATTACH_DEDUPE_LIMIT,
                         )
                 current_cursor = _next_log_cursor(payload)
                 if current_cursor is not None:
@@ -476,12 +433,11 @@ def attach_to_cloud_job(
                     oldest_entry = (
                         entries[0] if isinstance(entries, list) and entries else None
                     )
-                    skipped_end_ms = (
-                        int(oldest_entry.get("ts"))
-                        if isinstance(oldest_entry, dict)
-                        and isinstance(oldest_entry.get("ts"), (int, float, str))
-                        else current_end_ms
-                    )
+                    skipped_end_ms = current_end_ms
+                    if isinstance(oldest_entry, dict):
+                        parsed_oldest_ms = parse_epoch_ms(oldest_entry.get("ts"))
+                        if parsed_oldest_ms is not None:
+                            skipped_end_ms = parsed_oldest_ms
                     _warn_follow_skip(
                         context=context,
                         start_ms=current_start_ms,

--- a/src/refiner/cli/cloud_run.py
+++ b/src/refiner/cli/cloud_run.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, TextIO, cast
+
+from refiner.cli.local_run import (
+    LocalStageConsole,
+    LocalStageSnapshot,
+    stdout_is_interactive,
+)
+from refiner.job_urls import build_job_tracking_url
+from refiner.platform.client import MacrodataApiError, MacrodataClient
+from refiner.platform.client.api import sanitize_terminal_text
+
+_ATTACH_MODE_ENV_VAR = "REFINER_ATTACH"
+_VALID_ATTACH_MODES = {"auto", "attach", "detach"}
+_DEFAULT_LOG_WINDOW_MS = 60 * 60 * 1000
+_DEFAULT_ATTACH_LOG_LIMIT = 500
+_ATTACH_SUMMARY_INTERVAL_SECONDS = 2.0
+_ATTACH_LOGS_INTERVAL_SECONDS = 1.0
+_ATTACH_MAX_LOGGED_WORKERS = 4
+_ATTACH_DEDUPE_LIMIT = 100_000
+_ATTACH_MAX_DRAIN_POLLS = 5
+_ATTACH_DRAIN_POLL_DELAY_SECONDS = 0.1
+_ATTACH_MAX_RETRYABLE_ERRORS = 5
+_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
+
+
+class CloudAttachDetached(KeyboardInterrupt):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class CloudAttachContext:
+    job_id: str
+    job_name: str
+    tracking_url: str
+    stage_index: int | None
+
+
+def normalize_attach_mode(mode: str) -> str:
+    normalized = mode.strip().lower()
+    if normalized not in _VALID_ATTACH_MODES:
+        allowed = ", ".join(sorted(_VALID_ATTACH_MODES))
+        raise ValueError(
+            f"unsupported attach mode {mode!r}; expected one of: {allowed}"
+        )
+    return normalized
+
+
+def attach_mode_override() -> str | None:
+    import os
+
+    value = os.environ.get(_ATTACH_MODE_ENV_VAR)
+    if value is None:
+        return None
+    return normalize_attach_mode(value)
+
+
+def resolve_attach_mode() -> str:
+    override = attach_mode_override()
+    if override is not None and override != "auto":
+        return override
+    return "attach" if stdout_is_interactive() else "detach"
+
+
+def require_cloud_attach_supported(executor_kind: str) -> None:
+    override = attach_mode_override()
+    if override is None:
+        return
+    if executor_kind != "cloud":
+        raise SystemExit("--attach is only supported for cloud launches.")
+
+
+def emit_cloud_followup_commands(
+    *,
+    context: CloudAttachContext,
+    file: TextIO = sys.stdout,
+) -> None:
+    print("Cloud job submitted.", file=file)
+    print(f"Job ID: {context.job_id}", file=file)
+    print(f"URL: {context.tracking_url}", file=file)
+    print(f"Attach: macrodata jobs attach {context.job_id}", file=file)
+    print(f"Summary: macrodata jobs get {context.job_id}", file=file)
+    if context.stage_index is None:
+        print(f"Logs: macrodata jobs logs {context.job_id}", file=file)
+    else:
+        print(
+            f"Logs: macrodata jobs logs {context.job_id} --stage {context.stage_index}",
+            file=file,
+        )
+    print(f"Workers: macrodata jobs workers {context.job_id}", file=file)
+    print(f"Cancel: macrodata jobs cancel {context.job_id}", file=file)
+
+
+def _safe_text(value: Any) -> str:
+    if value is None:
+        return "-"
+    return sanitize_terminal_text(str(value))
+
+
+def _format_ts(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return "-"
+    timestamp_ms = value * 1000 if value < 100_000_000_000 else value
+    try:
+        dt = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return "-"
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _job_status(payload: dict[str, Any]) -> str:
+    job = payload.get("job")
+    if not isinstance(job, dict):
+        return ""
+    return _safe_text(job.get("status")).lower()
+
+
+def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    raw_message_hash = entry.get("messageHash")
+    message_hash = (
+        str(raw_message_hash)
+        if isinstance(raw_message_hash, (str, int, float)) and str(raw_message_hash)
+        else ""
+    )
+    return (
+        _safe_text(entry.get("ts")),
+        _safe_text(entry.get("workerId")),
+        _safe_text(entry.get("sourceType")),
+        _safe_text(entry.get("sourceName")),
+        message_hash or _safe_text(entry.get("line")),
+    )
+
+
+def _remember_seen_key(
+    *,
+    key: tuple[str, str, str, str, str],
+    seen_keys: set[tuple[str, str, str, str, str]],
+    seen_order: deque[tuple[str, str, str, str, str]],
+) -> None:
+    seen_keys.add(key)
+    seen_order.append(key)
+    while len(seen_order) > _ATTACH_DEDUPE_LIMIT:
+        seen_keys.discard(seen_order.popleft())
+
+
+def _is_retryable_api_error(err: Exception) -> bool:
+    if isinstance(err, MacrodataApiError):
+        return err.status in {0, 429} or err.status >= 500
+    return False
+
+
+def _retry_delay(error_count: int) -> float:
+    return min(float(2 ** max(0, error_count - 1)), 5.0)
+
+
+def _next_log_cursor(payload: dict[str, Any]) -> str | None:
+    cursor = payload.get("nextCursor")
+    return cursor if isinstance(cursor, str) and cursor else None
+
+
+def _warn_follow_skip(
+    *,
+    context: CloudAttachContext,
+    start_ms: int,
+    end_ms: int,
+    console: LocalStageConsole,
+) -> None:
+    console.emit_system(
+        "log volume is high; skipped older backlog from "
+        f"{_format_ts(start_ms)} to {_format_ts(end_ms)} to stay live"
+    )
+    if context.stage_index is None:
+        console.emit_system(
+            f"request logs for fewer workers for better visibility, or rerun with "
+            f"`macrodata jobs logs {context.job_id} --start-ms <ms> --end-ms <ms>` for full coverage"
+        )
+    else:
+        console.emit_system(
+            f"request logs for fewer workers for better visibility, or rerun with "
+            f"`macrodata jobs logs {context.job_id} --stage {context.stage_index} --start-ms <ms> --end-ms <ms>` for full coverage"
+        )
+
+
+def _log_worker_label(entry: dict[str, Any]) -> str:
+    worker_id = entry.get("workerId")
+    if isinstance(worker_id, str) and worker_id.strip():
+        return worker_id.strip()
+    source_name = entry.get("sourceName")
+    if isinstance(source_name, str) and source_name.strip():
+        return source_name.strip()
+    return "cloud"
+
+
+def _format_attach_log_line(entry: dict[str, Any]) -> str:
+    return (
+        f"{_format_ts(entry.get('ts'))} "
+        f"{_safe_text(entry.get('severity')).upper():<7} "
+        f"{_safe_text(entry.get('sourceType'))}/{_safe_text(entry.get('sourceName'))} "
+        f"{_safe_text(entry.get('line'))}"
+    )
+
+
+def _active_stage(job: dict[str, Any]) -> tuple[int, int]:
+    stages = job.get("stages")
+    if not isinstance(stages, list) or not stages:
+        return 0, 1
+    for stage in stages:
+        if not isinstance(stage, dict):
+            continue
+        status = _safe_text(stage.get("status")).lower()
+        if status not in _TERMINAL_JOB_STATUSES:
+            return int(stage.get("index", 0) or 0), len(stages)
+    last_stage = stages[-1]
+    if isinstance(last_stage, dict):
+        return int(last_stage.get("index", len(stages) - 1) or 0), len(stages)
+    return len(stages) - 1, len(stages)
+
+
+def _elapsed_seconds(job: dict[str, Any]) -> float:
+    started_at = job.get("startedAt") or job.get("createdAt")
+    if not isinstance(started_at, (int, float)):
+        return 0.0
+    timestamp_ms = started_at * 1000 if started_at < 100_000_000_000 else started_at
+    return max(0.0, time.time() - (timestamp_ms / 1000))
+
+
+def _build_snapshot(
+    *,
+    context: CloudAttachContext,
+    job_payload: dict[str, Any],
+) -> LocalStageSnapshot:
+    job = job_payload.get("job")
+    if not isinstance(job, dict):
+        raise RuntimeError("job details unavailable")
+    stage_index, total_stages = _active_stage(job)
+    current_stage = None
+    stages = job.get("stages")
+    if isinstance(stages, list):
+        for stage in stages:
+            if (
+                isinstance(stage, dict)
+                and int(stage.get("index", -1) or -1) == stage_index
+            ):
+                current_stage = stage
+                break
+    total_workers = int(job.get("totalWorkers", 0) or 0)
+    running_workers = int(job.get("runningWorkers", 0) or 0)
+    completed_workers = (
+        int(current_stage.get("completedWorkers", 0) or 0)
+        if isinstance(current_stage, dict)
+        else 0
+    )
+    stage_workers = (
+        int(current_stage.get("totalWorkers", total_workers) or total_workers)
+        if isinstance(current_stage, dict)
+        else total_workers
+    )
+    return LocalStageSnapshot(
+        job_id=context.job_id,
+        job_name=context.job_name,
+        rundir="cloud",
+        stage_index=stage_index,
+        total_stages=max(1, total_stages),
+        stage_workers=stage_workers,
+        tracking_url=context.tracking_url,
+        status=_job_status(job_payload),
+        worker_total=max(total_workers, stage_workers),
+        worker_running=running_workers,
+        worker_completed=completed_workers,
+        worker_failed=0,
+        elapsed_seconds=_elapsed_seconds(job),
+    )
+
+
+def _cloud_context_from_job_payload(
+    *,
+    client: MacrodataClient,
+    job_id: str,
+    payload: dict[str, Any],
+    stage_index_hint: int | None = None,
+) -> CloudAttachContext:
+    job = payload.get("job")
+    if not isinstance(job, dict):
+        raise RuntimeError("job details unavailable")
+    workspace_slug = job.get("workspaceSlug")
+    return CloudAttachContext(
+        job_id=job_id,
+        job_name=_safe_text(job.get("name")),
+        tracking_url=build_job_tracking_url(
+            client=client,
+            job_id=job_id,
+            workspace_slug=workspace_slug if isinstance(workspace_slug, str) else None,
+        ),
+        stage_index=stage_index_hint,
+    )
+
+
+def _snapshot_and_context(
+    *,
+    client: MacrodataClient,
+    job_id: str,
+    job_payload: dict[str, Any],
+    stage_index_hint: int | None,
+) -> tuple[CloudAttachContext, LocalStageSnapshot]:
+    context = _cloud_context_from_job_payload(
+        client=client,
+        job_id=job_id,
+        payload=job_payload,
+        stage_index_hint=stage_index_hint,
+    )
+    snapshot = _build_snapshot(
+        context=context,
+        job_payload=job_payload,
+    )
+    return context, snapshot
+
+
+def attach_to_cloud_job(
+    *,
+    client: MacrodataClient,
+    job_id: str,
+    initial_job_payload: dict[str, Any] | None = None,
+    stage_index_hint: int | None = None,
+) -> int:
+    if not stdout_is_interactive():
+        payload = initial_job_payload or client.cli_get_job(job_id=job_id)
+        context = _cloud_context_from_job_payload(
+            client=client,
+            job_id=job_id,
+            payload=payload,
+            stage_index_hint=stage_index_hint,
+        )
+        emit_cloud_followup_commands(context=context)
+        return 0
+
+    job_payload = initial_job_payload or client.cli_get_job(job_id=job_id)
+    context, snapshot = _snapshot_and_context(
+        client=client,
+        job_id=job_id,
+        job_payload=job_payload,
+        stage_index_hint=stage_index_hint,
+    )
+    console = LocalStageConsole(
+        job_id=context.job_id,
+        job_name=context.job_name,
+        rundir="cloud",
+        stage_index=snapshot.stage_index,
+        total_stages=snapshot.total_stages,
+        stage_workers=snapshot.stage_workers,
+        tracking_url=context.tracking_url,
+    )
+    console.emit_system(f"attached to cloud job {context.job_id}")
+    selected_worker_ids: tuple[str, ...] = ()
+    current_stage_index = snapshot.stage_index
+    if snapshot.worker_running > _ATTACH_MAX_LOGGED_WORKERS:
+        console.emit_system(
+            f"showing up to {_ATTACH_MAX_LOGGED_WORKERS} of {snapshot.worker_running} running workers to stay live"
+        )
+    closed = False
+    try:
+        console.apply_snapshot(snapshot)
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        current_start_ms = max(
+            0,
+            now_ms - _DEFAULT_LOG_WINDOW_MS,
+        )
+        current_end_ms = max(current_start_ms + 1, now_ms)
+        current_cursor: str | None = None
+        seen_keys: set[tuple[str, str, str, str, str]] = set()
+        seen_order: deque[tuple[str, str, str, str, str]] = deque()
+        full_batch_polls = 0
+        log_retryable_error_count = 0
+        status_retryable_error_count = 0
+        next_summary_at = time.monotonic() + _ATTACH_SUMMARY_INTERVAL_SECONDS
+        next_logs_at = 0.0
+        terminal_seen = False
+
+        while True:
+            now = time.monotonic()
+            if now >= next_summary_at:
+                try:
+                    job_payload = client.cli_get_job(job_id=job_id)
+                except MacrodataApiError as err:
+                    if not _is_retryable_api_error(err):
+                        raise
+                    status_retryable_error_count += 1
+                    if status_retryable_error_count > _ATTACH_MAX_RETRYABLE_ERRORS:
+                        raise
+                    time.sleep(_retry_delay(status_retryable_error_count))
+                    continue
+                status_retryable_error_count = 0
+                context, snapshot = _snapshot_and_context(
+                    client=client,
+                    job_id=job_id,
+                    job_payload=job_payload,
+                    stage_index_hint=stage_index_hint,
+                )
+                if snapshot.stage_index != current_stage_index:
+                    selected_worker_ids = ()
+                console.apply_snapshot(snapshot)
+                current_stage_index = snapshot.stage_index
+                terminal_seen = _job_status(job_payload) in _TERMINAL_JOB_STATUSES
+                next_summary_at = now + _ATTACH_SUMMARY_INTERVAL_SECONDS
+
+            logs_available = isinstance(job_payload.get("job"), dict) and bool(
+                cast(dict[str, Any], job_payload["job"]).get("logsAvailable", True)
+            )
+            if logs_available and now >= next_logs_at:
+                try:
+                    payload = client.cli_get_job_logs(
+                        job_id=job_id,
+                        start_ms=current_start_ms,
+                        end_ms=current_end_ms,
+                        cursor=current_cursor,
+                        limit=_DEFAULT_ATTACH_LOG_LIMIT,
+                        stage_index=current_stage_index,
+                        worker_id=None,
+                        source_type=None,
+                        source_name=None,
+                        severity=None,
+                        search=None,
+                    )
+                except MacrodataApiError as err:
+                    if not _is_retryable_api_error(err):
+                        raise
+                    log_retryable_error_count += 1
+                    if log_retryable_error_count > _ATTACH_MAX_RETRYABLE_ERRORS:
+                        raise
+                    time.sleep(_retry_delay(log_retryable_error_count))
+                    continue
+                log_retryable_error_count = 0
+                entries = payload.get("entries")
+                if isinstance(entries, list):
+                    for entry in entries:
+                        if not isinstance(entry, dict):
+                            continue
+                        worker_id = _safe_text(entry.get("workerId"))
+                        if (
+                            worker_id != "-"
+                            and worker_id not in selected_worker_ids
+                            and len(selected_worker_ids) < _ATTACH_MAX_LOGGED_WORKERS
+                        ):
+                            selected_worker_ids = (*selected_worker_ids, worker_id)
+                        if (
+                            selected_worker_ids
+                            and worker_id != "-"
+                            and worker_id not in selected_worker_ids
+                        ):
+                            continue
+                        key = _log_entry_key(entry)
+                        if key in seen_keys:
+                            continue
+                        console.emit_lines(
+                            worker_id=_log_worker_label(entry),
+                            lines=[_format_attach_log_line(entry)],
+                        )
+                        _remember_seen_key(
+                            key=key,
+                            seen_keys=seen_keys,
+                            seen_order=seen_order,
+                        )
+                current_cursor = _next_log_cursor(payload)
+                if current_cursor is not None:
+                    full_batch_polls += 1
+                    if full_batch_polls < _ATTACH_MAX_DRAIN_POLLS:
+                        next_logs_at = (
+                            time.monotonic() + _ATTACH_DRAIN_POLL_DELAY_SECONDS
+                        )
+                        continue
+                    oldest_entry = (
+                        entries[0] if isinstance(entries, list) and entries else None
+                    )
+                    skipped_end_ms = (
+                        int(oldest_entry.get("ts"))
+                        if isinstance(oldest_entry, dict)
+                        and isinstance(oldest_entry.get("ts"), (int, float, str))
+                        else current_end_ms
+                    )
+                    _warn_follow_skip(
+                        context=context,
+                        start_ms=current_start_ms,
+                        end_ms=skipped_end_ms,
+                        console=console,
+                    )
+                    current_cursor = None
+                    full_batch_polls = 0
+                    current_start_ms = current_end_ms
+                    next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+                    current_end_ms = max(next_end_ms, current_start_ms + 1)
+                    next_logs_at = time.monotonic()
+                    continue
+                full_batch_polls = 0
+                current_start_ms = current_end_ms
+                next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+                current_end_ms = max(next_end_ms, current_start_ms + 1)
+                next_logs_at = now + _ATTACH_LOGS_INTERVAL_SECONDS
+
+            if terminal_seen and current_cursor is None:
+                console.emit_system(
+                    f"cloud job {context.job_id} finished with status {_job_status(job_payload)}"
+                )
+                return 0
+
+            deadline = min(next_summary_at, next_logs_at)
+            time.sleep(max(0.05, deadline - time.monotonic()))
+    except KeyboardInterrupt:
+        console.emit_system(
+            f"detached from cloud job {context.job_id}. The cloud job is still running."
+        )
+        closed = True
+        console.close()
+        print(f"View job: {context.tracking_url}", file=sys.stderr)
+        print(f"Reattach: macrodata jobs attach {context.job_id}", file=sys.stderr)
+        print(f"Cancel: macrodata jobs cancel {context.job_id}", file=sys.stderr)
+        raise CloudAttachDetached()
+    finally:
+        if not closed:
+            console.close()

--- a/src/refiner/cli/job_utils.py
+++ b/src/refiner/cli/job_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any
+
+from refiner.platform.client import MacrodataApiError
+from refiner.platform.client.api import sanitize_terminal_text
+
+TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
+
+
+def safe_text(value: Any) -> str:
+    if value is None:
+        return "-"
+    return sanitize_terminal_text(str(value))
+
+
+def format_ts(value: Any) -> str:
+    timestamp_ms = parse_epoch_ms(value)
+    if timestamp_ms is None:
+        return "-"
+    try:
+        dt = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return "-"
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def parse_epoch_ms(value: Any) -> int | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    timestamp_ms = numeric * 1000 if numeric < 100_000_000_000 else numeric
+    try:
+        return int(timestamp_ms)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def job_status(payload: dict[str, Any]) -> str:
+    job = payload.get("job")
+    if not isinstance(job, dict):
+        return ""
+    return safe_text(job.get("status")).lower()
+
+
+def log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    raw_message_hash = entry.get("messageHash")
+    message_hash = (
+        str(raw_message_hash)
+        if isinstance(raw_message_hash, (str, int, float)) and str(raw_message_hash)
+        else ""
+    )
+    return (
+        safe_text(entry.get("ts")),
+        safe_text(entry.get("workerId")),
+        safe_text(entry.get("sourceType")),
+        safe_text(entry.get("sourceName")),
+        message_hash or safe_text(entry.get("line")),
+    )
+
+
+def remember_seen_key(
+    *,
+    key: tuple[str, str, str, str, str],
+    seen_keys: set[tuple[str, str, str, str, str]],
+    seen_order: deque[tuple[str, str, str, str, str]],
+    limit: int,
+) -> None:
+    seen_keys.add(key)
+    seen_order.append(key)
+    while len(seen_order) > limit:
+        seen_keys.discard(seen_order.popleft())
+
+
+def is_retryable_api_error(err: Exception) -> bool:
+    if isinstance(err, MacrodataApiError):
+        return err.status in {0, 429} or err.status >= 500
+    return False
+
+
+def next_log_cursor(payload: dict[str, Any]) -> str | None:
+    cursor = payload.get("nextCursor")
+    return cursor if isinstance(cursor, str) and cursor else None

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -8,9 +8,19 @@ from argparse import Namespace
 from datetime import datetime, timezone
 from typing import Any
 
+from refiner.cli.job_utils import (
+    TERMINAL_JOB_STATUSES,
+    format_ts as _format_ts,
+    is_retryable_api_error as _is_retryable_api_error,
+    job_status as _job_status,
+    log_entry_key as _log_entry_key,
+    next_log_cursor as _next_log_cursor,
+    parse_epoch_ms,
+    remember_seen_key as _remember_seen_key,
+    safe_text as _safe_text,
+)
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import MacrodataApiError, MacrodataClient
-from refiner.platform.client.api import sanitize_terminal_text
 
 _DEFAULT_LOG_WINDOW_MS = 60 * 60 * 1000
 _MAX_LOG_SEARCH_LIMIT = 100
@@ -22,7 +32,6 @@ _FOLLOW_LOG_DEDUPE_LIMIT = 100_000
 _FOLLOW_LOG_MAX_DRAIN_POLLS = 5
 _FOLLOW_LOG_DRAIN_POLL_DELAY_SECONDS = 0.1
 _FOLLOW_LOG_MAX_RETRYABLE_ERRORS = 5
-_TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
 
 
 def _client() -> MacrodataClient:
@@ -32,23 +41,6 @@ def _client() -> MacrodataClient:
 def _print_json(payload: dict[str, Any]) -> int:
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
-
-
-def _format_ts(value: Any) -> str:
-    if not isinstance(value, (int, float)):
-        return "-"
-    timestamp_ms = value * 1000 if value < 100_000_000_000 else value
-    try:
-        dt = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return "-"
-    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
-
-
-def _safe_text(value: Any) -> str:
-    if value is None:
-        return "-"
-    return sanitize_terminal_text(str(value))
 
 
 def _progress_text(progress: Any) -> str:
@@ -274,54 +266,8 @@ def _format_log_entry(entry: dict[str, Any]) -> str:
     )
 
 
-def _log_entry_key(entry: dict[str, Any]) -> tuple[str, str, str, str, str]:
-    raw_message_hash = entry.get("messageHash")
-    message_hash = (
-        str(raw_message_hash)
-        if isinstance(raw_message_hash, (str, int, float)) and str(raw_message_hash)
-        else ""
-    )
-    return (
-        _safe_text(entry.get("ts")),
-        _safe_text(entry.get("workerId")),
-        _safe_text(entry.get("sourceType")),
-        _safe_text(entry.get("sourceName")),
-        message_hash or _safe_text(entry.get("line")),
-    )
-
-
-def _next_log_cursor(payload: dict[str, Any]) -> str | None:
-    cursor = payload.get("nextCursor")
-    return cursor if isinstance(cursor, str) and cursor else None
-
-
-def _job_status(payload: dict[str, Any]) -> str:
-    job = payload.get("job")
-    if not isinstance(job, dict):
-        return ""
-    return _safe_text(job.get("status")).lower()
-
-
-def _is_retryable_api_error(err: Exception) -> bool:
-    if isinstance(err, MacrodataApiError):
-        return err.status in {0, 429} or err.status >= 500
-    return False
-
-
 def _follow_retry_delay(error_count: int) -> float:
     return min(float(2 ** max(0, error_count - 1)), 5.0)
-
-
-def _remember_seen_key(
-    *,
-    key: tuple[str, str, str, str, str],
-    seen_keys: set[tuple[str, str, str, str, str]],
-    seen_order: deque[tuple[str, str, str, str, str]],
-) -> None:
-    seen_keys.add(key)
-    seen_order.append(key)
-    while len(seen_order) > _FOLLOW_LOG_DEDUPE_LIMIT:
-        seen_keys.discard(seen_order.popleft())
 
 
 def _effective_log_limit(args: Namespace) -> int:
@@ -397,6 +343,7 @@ def _stream_logs(
                     key=key,
                     seen_keys=seen_keys,
                     seen_order=seen_order,
+                    limit=_FOLLOW_LOG_DEDUPE_LIMIT,
                 )
         current_cursor = _next_log_cursor(payload)
         if current_cursor is not None:
@@ -405,12 +352,11 @@ def _stream_logs(
                 time.sleep(_FOLLOW_LOG_DRAIN_POLL_DELAY_SECONDS)
                 continue
             oldest_entry = entries[0] if isinstance(entries, list) and entries else None
-            skipped_end_ms = (
-                int(oldest_entry.get("ts"))
-                if isinstance(oldest_entry, dict)
-                and isinstance(oldest_entry.get("ts"), (int, float, str))
-                else current_end_ms
-            )
+            skipped_end_ms = current_end_ms
+            if isinstance(oldest_entry, dict):
+                parsed_oldest_ms = parse_epoch_ms(oldest_entry.get("ts"))
+                if parsed_oldest_ms is not None:
+                    skipped_end_ms = parsed_oldest_ms
             _warn_follow_skip(start_ms=current_start_ms, end_ms=skipped_end_ms)
             current_cursor = None
             full_batch_polls = 0
@@ -434,10 +380,7 @@ def _stream_logs(
         except MacrodataCredentialsError:
             raise
         status_retryable_error_count = 0
-        if (
-            current_cursor is None
-            and _job_status(job_payload) in _TERMINAL_JOB_STATUSES
-        ):
+        if current_cursor is None and _job_status(job_payload) in TERMINAL_JOB_STATUSES:
             return 0
         if current_cursor is None:
             current_start_ms = current_end_ms

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -20,6 +20,7 @@ _DEFAULT_LOG_PAGE_LIMIT = 100
 _DEFAULT_FOLLOW_LOG_PAGE_LIMIT = 500
 _FOLLOW_LOG_DEDUPE_LIMIT = 100_000
 _FOLLOW_LOG_MAX_DRAIN_POLLS = 5
+_FOLLOW_LOG_DRAIN_POLL_DELAY_SECONDS = 0.1
 _FOLLOW_LOG_MAX_RETRYABLE_ERRORS = 5
 _TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "canceled"})
 
@@ -401,6 +402,7 @@ def _stream_logs(
         if current_cursor is not None:
             full_batch_polls += 1
             if full_batch_polls < _FOLLOW_LOG_MAX_DRAIN_POLLS:
+                time.sleep(_FOLLOW_LOG_DRAIN_POLL_DELAY_SECONDS)
                 continue
             oldest_entry = entries[0] if isinstance(entries, list) and entries else None
             skipped_end_ms = (
@@ -652,6 +654,37 @@ def cmd_jobs_get(args: Namespace) -> int:
     except (MacrodataApiError, MacrodataCredentialsError) as err:
         return _handle_error(err)
     return _print_json(payload) if args.json else _render_job(payload)
+
+
+def cmd_jobs_attach(args: Namespace) -> int:
+    from refiner.cli.cloud_run import CloudAttachDetached, attach_to_cloud_job
+
+    try:
+        client = _client()
+        payload = client.cli_get_job(job_id=args.job_id)
+    except (MacrodataApiError, MacrodataCredentialsError) as err:
+        return _handle_error(err)
+
+    job = payload.get("job")
+    if not isinstance(job, dict):
+        print("Job details unavailable.", file=sys.stderr)
+        return 1
+    if _executor_text(job.get("executorKind")) != "cloud":
+        print(
+            "`macrodata jobs attach` is only supported for cloud jobs.", file=sys.stderr
+        )
+        return 1
+
+    try:
+        return attach_to_cloud_job(
+            client=client,
+            job_id=args.job_id,
+            initial_job_payload=payload,
+        )
+    except CloudAttachDetached:
+        return 130
+    except (MacrodataApiError, MacrodataCredentialsError) as err:
+        return _handle_error(err)
 
 
 def cmd_jobs_manifest(args: Namespace) -> int:

--- a/src/refiner/cli/jobs.py
+++ b/src/refiner/cli/jobs.py
@@ -366,6 +366,14 @@ def _stream_logs(
             continue
         else:
             full_batch_polls = 0
+        next_start_ms = current_start_ms
+        next_end_ms = current_end_ms
+        if current_cursor is None:
+            next_start_ms = current_end_ms
+            next_end_ms = max(
+                int(datetime.now(tz=timezone.utc).timestamp() * 1000),
+                next_start_ms + 1,
+            )
         try:
             job_payload = client.cli_get_job(job_id=args.job_id)
         except MacrodataApiError as err:
@@ -374,6 +382,8 @@ def _stream_logs(
             status_retryable_error_count += 1
             if status_retryable_error_count > _FOLLOW_LOG_MAX_RETRYABLE_ERRORS:
                 raise
+            current_start_ms = next_start_ms
+            current_end_ms = next_end_ms
             time.sleep(_follow_retry_delay(status_retryable_error_count))
             job_payload = {}
             continue
@@ -383,9 +393,8 @@ def _stream_logs(
         if current_cursor is None and _job_status(job_payload) in TERMINAL_JOB_STATUSES:
             return 0
         if current_cursor is None:
-            current_start_ms = current_end_ms
-            next_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-            current_end_ms = max(next_end_ms, current_start_ms + 1)
+            current_start_ms = next_start_ms
+            current_end_ms = next_end_ms
         time.sleep(_FOLLOW_LOG_POLL_INTERVAL_SECONDS)
 
 
@@ -623,6 +632,7 @@ def cmd_jobs_attach(args: Namespace) -> int:
             client=client,
             job_id=args.job_id,
             initial_job_payload=payload,
+            force_attach=True,
         )
     except CloudAttachDetached:
         return 130

--- a/src/refiner/cli/local_run.py
+++ b/src/refiner/cli/local_run.py
@@ -115,7 +115,7 @@ class LaunchStats:
 class LocalStageSnapshot:
     job_id: str
     job_name: str
-    rundir: str
+    rundir: str | None
     stage_index: int
     total_stages: int
     stage_workers: int
@@ -207,6 +207,7 @@ def should_emit_worker_line(
     worker_id: str,
     selected_worker_id: str | None,
     line: str,
+    severity: str | None = None,
 ) -> bool:
     if log_mode == "all":
         return True
@@ -215,6 +216,8 @@ def should_emit_worker_line(
     if log_mode == "one":
         return selected_worker_id is None or worker_id == selected_worker_id
     if log_mode == "errors":
+        if severity is not None:
+            return severity.strip().lower() == "error"
         match = _LOGURU_LINE_RE.match(line)
         return match is not None and match.group("level").upper() in {
             "ERROR",
@@ -564,7 +567,7 @@ class LocalStageConsole:
         *,
         job_id: str,
         job_name: str,
-        rundir: str,
+        rundir: str | None,
         stage_index: int,
         total_stages: int,
         stage_workers: int,
@@ -694,14 +697,6 @@ class LocalStageConsole:
                 "",
             ),
             (
-                "Rundir",
-                self._rundir,
-                _VALUE_COLOR,
-                "Runtime",
-                _format_elapsed_seconds(self._elapsed_seconds),
-                "",
-            ),
-            (
                 "URL" if self._tracking_url is not None else "",
                 self._tracking_url or "",
                 _URL_COLOR,
@@ -710,6 +705,21 @@ class LocalStageConsole:
                 _STATUS_COLORS.get(self._status, _VALUE_COLOR),
             ),
         ]
+        row_specs.insert(
+            2,
+            (
+                "Rundir" if self._rundir is not None else "Runtime",
+                self._rundir
+                if self._rundir is not None
+                else _format_elapsed_seconds(self._elapsed_seconds),
+                _VALUE_COLOR,
+                "Runtime" if self._rundir is not None else "",
+                _format_elapsed_seconds(self._elapsed_seconds)
+                if self._rundir is not None
+                else "",
+                "",
+            ),
+        )
 
         def build_row(
             left_label: str,

--- a/src/refiner/cli/local_run.py
+++ b/src/refiner/cli/local_run.py
@@ -626,12 +626,16 @@ class LocalStageConsole:
         self._render(force=True)
 
     def apply_snapshot(self, snapshot: LocalStageSnapshot) -> None:
+        previous_stage_index = self._stage_index
+        previous_total_stages = self._total_stages
         previous_status = self._status
         previous_total = self._worker_total
         previous_running = self._worker_running
         previous_completed = self._worker_completed
         previous_failed = self._worker_failed
         previous_elapsed_seconds = int(self._elapsed_seconds)
+        self._stage_index = snapshot.stage_index
+        self._total_stages = snapshot.total_stages
         self._status = snapshot.status
         self._worker_total = snapshot.worker_total
         self._worker_running = snapshot.worker_running
@@ -639,7 +643,9 @@ class LocalStageConsole:
         self._worker_failed = snapshot.worker_failed
         self._elapsed_seconds = snapshot.elapsed_seconds
         if (
-            self._status != previous_status
+            self._stage_index != previous_stage_index
+            or self._total_stages != previous_total_stages
+            or self._status != previous_status
             or self._worker_total != previous_total
             or self._worker_running != previous_running
             or self._worker_completed != previous_completed

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -5,6 +5,7 @@ import sys
 
 from refiner.cli.auth import cmd_login, cmd_logout, cmd_whoami
 from refiner.cli.jobs import (
+    cmd_jobs_attach,
     cmd_jobs_cancel,
     cmd_jobs_get,
     cmd_jobs_list,
@@ -48,6 +49,12 @@ def build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser(
         "run",
         help="Run a Macrodata Refiner pipeline script",
+    )
+    run.add_argument(
+        "--attach",
+        choices=("auto", "attach", "detach"),
+        default=None,
+        help="Override cloud attach mode via REFINER_ATTACH",
     )
     run.add_argument(
         "--logs",
@@ -94,6 +101,12 @@ def build_parser() -> argparse.ArgumentParser:
     jobs_get.add_argument("job_id", help="Job identifier")
     jobs_get.add_argument("--json", action="store_true", help="Print raw JSON response")
     jobs_get.set_defaults(handler=cmd_jobs_get)
+
+    jobs_attach = jobs_subparsers.add_parser(
+        "attach", help="Attach to a running cloud job"
+    )
+    jobs_attach.add_argument("job_id", help="Job identifier")
+    jobs_attach.set_defaults(handler=cmd_jobs_attach)
 
     jobs_manifest = jobs_subparsers.add_parser("manifest", help="Get job manifest")
     jobs_manifest.add_argument("job_id", help="Job identifier")

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -65,7 +65,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--logs",
         choices=("all", "none", "one", "errors"),
         default=None,
-        help="Override local live log display mode via REFINER_LOCAL_LOGS",
+        help="Override attached live log display mode via REFINER_LOCAL_LOGS",
     )
     run.add_argument("script", help="Python script to execute")
     run.add_argument(

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -50,11 +50,16 @@ def build_parser() -> argparse.ArgumentParser:
         "run",
         help="Run a Macrodata Refiner pipeline script",
     )
-    run.add_argument(
+    attach_mode = run.add_mutually_exclusive_group()
+    attach_mode.add_argument(
         "--attach",
-        choices=("auto", "attach", "detach"),
-        default=None,
-        help="Override cloud attach mode via REFINER_ATTACH",
+        action="store_true",
+        help="Force attached mode for cloud launches",
+    )
+    attach_mode.add_argument(
+        "--detach",
+        action="store_true",
+        help="Force detached mode for cloud launches",
     )
     run.add_argument(
         "--logs",

--- a/src/refiner/cli/run.py
+++ b/src/refiner/cli/run.py
@@ -14,12 +14,12 @@ from refiner.cli.cloud_run import (
 from refiner.cli.local_run import LocalLaunchResumeError
 
 
-def _attach_mode_arg(args: argparse.Namespace) -> str | None:
+def _attach_mode_arg(args: argparse.Namespace) -> str:
     if getattr(args, "attach", False):
         return "attach"
     if getattr(args, "detach", False):
         return "detach"
-    return None
+    return "auto"
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -40,11 +40,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     original_attach = os.environ.get(_ATTACH_MODE_ENV_VAR)
     cwd_entries = {"", str(Path.cwd())}
     try:
-        attach_mode = _attach_mode_arg(args)
-        if attach_mode is not None:
-            os.environ[_ATTACH_MODE_ENV_VAR] = normalize_attach_mode(attach_mode)
-        elif original_attach is None:
-            os.environ.pop(_ATTACH_MODE_ENV_VAR, None)
+        os.environ[_ATTACH_MODE_ENV_VAR] = normalize_attach_mode(_attach_mode_arg(args))
         if args.logs is not None:
             os.environ["REFINER_LOCAL_LOGS"] = args.logs
         elif original_logs is None:

--- a/src/refiner/cli/run.py
+++ b/src/refiner/cli/run.py
@@ -14,6 +14,14 @@ from refiner.cli.cloud_run import (
 from refiner.cli.local_run import LocalLaunchResumeError
 
 
+def _attach_mode_arg(args: argparse.Namespace) -> str | None:
+    if getattr(args, "attach", False):
+        return "attach"
+    if getattr(args, "detach", False):
+        return "detach"
+    return None
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     script = Path(args.script).expanduser()
     if not script.exists():
@@ -32,8 +40,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     original_attach = os.environ.get(_ATTACH_MODE_ENV_VAR)
     cwd_entries = {"", str(Path.cwd())}
     try:
-        if args.attach is not None:
-            os.environ[_ATTACH_MODE_ENV_VAR] = normalize_attach_mode(args.attach)
+        attach_mode = _attach_mode_arg(args)
+        if attach_mode is not None:
+            os.environ[_ATTACH_MODE_ENV_VAR] = normalize_attach_mode(attach_mode)
         elif original_attach is None:
             os.environ.pop(_ATTACH_MODE_ENV_VAR, None)
         if args.logs is not None:

--- a/src/refiner/cli/run.py
+++ b/src/refiner/cli/run.py
@@ -6,6 +6,11 @@ import runpy
 import sys
 from pathlib import Path
 
+from refiner.cli.cloud_run import (
+    CloudAttachDetached,
+    _ATTACH_MODE_ENV_VAR,
+    normalize_attach_mode,
+)
 from refiner.cli.local_run import LocalLaunchResumeError
 
 
@@ -24,8 +29,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     original_argv = sys.argv
     original_sys_path = list(sys.path)
     original_logs = os.environ.get("REFINER_LOCAL_LOGS")
+    original_attach = os.environ.get(_ATTACH_MODE_ENV_VAR)
     cwd_entries = {"", str(Path.cwd())}
     try:
+        if args.attach is not None:
+            os.environ[_ATTACH_MODE_ENV_VAR] = normalize_attach_mode(args.attach)
+        elif original_attach is None:
+            os.environ.pop(_ATTACH_MODE_ENV_VAR, None)
         if args.logs is not None:
             os.environ["REFINER_LOCAL_LOGS"] = args.logs
         elif original_logs is None:
@@ -39,6 +49,8 @@ def cmd_run(args: argparse.Namespace) -> int:
             runpy.run_path(str(script), run_name="__main__")
         except BrokenPipeError:
             return 141
+        except CloudAttachDetached:
+            return 130
         except KeyboardInterrupt as err:
             if err.args and not sys.stdout.isatty():
                 print(str(err), file=sys.stderr)
@@ -64,4 +76,8 @@ def cmd_run(args: argparse.Namespace) -> int:
             os.environ.pop("REFINER_LOCAL_LOGS", None)
         else:
             os.environ["REFINER_LOCAL_LOGS"] = original_logs
+        if original_attach is None:
+            os.environ.pop(_ATTACH_MODE_ENV_VAR, None)
+        else:
+            os.environ[_ATTACH_MODE_ENV_VAR] = original_attach
     return 0

--- a/src/refiner/job_urls.py
+++ b/src/refiner/job_urls.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from refiner.platform.client.api import MacrodataClient, sanitize_terminal_text
+
+
+def build_job_tracking_url(
+    *, client: MacrodataClient, job_id: str, workspace_slug: str | None = None
+) -> str:
+    safe_base_url = sanitize_terminal_text(client.base_url).strip().rstrip("/")
+    safe_job_id = sanitize_terminal_text(job_id).strip() or job_id
+    safe_workspace_slug = (
+        sanitize_terminal_text(workspace_slug).strip() if workspace_slug else None
+    )
+    if safe_workspace_slug:
+        return f"{safe_base_url}/jobs/{safe_workspace_slug}/{safe_job_id}"
+    return f"{safe_base_url}/jobs/{safe_job_id}"

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -13,7 +13,6 @@ from refiner.pipeline.planning import (
     compile_planned_stages,
     plan_pipeline_stages,
 )
-from refiner.platform.client.api import MacrodataClient, sanitize_terminal_text
 from refiner.platform.manifest import build_run_manifest
 
 if TYPE_CHECKING:
@@ -48,18 +47,6 @@ class BaseLauncher(ABC):
     def _build_local_job_id(name: str) -> str:
         slug = re.sub(r"[^a-zA-Z0-9]+", "-", name.strip().lower()).strip("-") or "job"
         return f"{slug}-{int(time.time())}-{uuid4().hex[:8]}"
-
-    def _job_tracking_url(
-        self, *, client: MacrodataClient, job_id: str, workspace_slug: str | None = None
-    ) -> str:
-        safe_base_url = sanitize_terminal_text(client.base_url).strip().rstrip("/")
-        safe_job_id = sanitize_terminal_text(job_id).strip() or job_id
-        safe_workspace_slug = (
-            sanitize_terminal_text(workspace_slug).strip() if workspace_slug else None
-        )
-        if safe_workspace_slug:
-            return f"{safe_base_url}/jobs/{safe_workspace_slug}/{safe_job_id}"
-        return f"{safe_base_url}/jobs/{safe_job_id}"
 
     def _planned_stages(self) -> list[PlannedStage]:
         requested_workers = getattr(self, "num_workers", None)

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from refiner.cli.cloud_run import (
+    CloudAttachContext,
+    attach_to_cloud_job,
+    emit_cloud_followup_commands,
+    resolve_attach_mode,
+)
 from refiner.cli.ui import stdin_is_interactive
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
@@ -15,6 +22,7 @@ from refiner.platform.client import (
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
 
+from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
 from refiner.worker.context import logger
 
@@ -201,10 +209,34 @@ class CloudLauncher(BaseLauncher):
                 "Your Macrodata API key is invalid. Run `macrodata login` "
                 "or set MACRODATA_API_KEY with a valid key."
             ) from err
-        logger.info(
-            "Cloud job launched. View job:\n  "
-            f"{self._job_tracking_url(client=client, job_id=resp.job_id, workspace_slug=resp.workspace_slug)}"
+        tracking_url = build_job_tracking_url(
+            client=client,
+            job_id=resp.job_id,
+            workspace_slug=resp.workspace_slug,
         )
+        context = CloudAttachContext(
+            job_id=resp.job_id,
+            job_name=self.name,
+            tracking_url=tracking_url,
+            stage_index=resp.stage_index,
+        )
+        logger.info(f"Cloud job launched. View job:\n  {tracking_url}")
+        attach_mode = resolve_attach_mode()
+        if attach_mode == "detach":
+            emit_cloud_followup_commands(context=context)
+        else:
+            try:
+                attach_to_cloud_job(
+                    client=client,
+                    job_id=resp.job_id,
+                    stage_index_hint=resp.stage_index,
+                )
+            except Exception:
+                print(
+                    "Cloud job submitted, but attach failed. Continue with:",
+                    file=sys.stderr,
+                )
+                emit_cloud_followup_commands(context=context, file=sys.stderr)
         return CloudLaunchResult(
             job_id=resp.job_id,
             stage_index=resp.stage_index,

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -9,7 +9,7 @@ from refiner.cli.cloud_run import (
     CloudAttachContext,
     attach_to_cloud_job,
     emit_cloud_followup_commands,
-    resolve_attach_mode,
+    resolve_launcher_attach_mode,
 )
 from refiner.cli.ui import stdin_is_interactive
 from refiner.platform.auth import MacrodataCredentialsError
@@ -222,7 +222,7 @@ class CloudLauncher(BaseLauncher):
             stage_index=resp.stage_index,
         )
         logger.info(f"Cloud job launched. View job:\n  {tracking_url}")
-        attach_mode = resolve_attach_mode()
+        attach_mode = resolve_launcher_attach_mode()
         if attach_mode == "detach":
             emit_cloud_followup_commands(context=context)
         else:

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -16,6 +16,7 @@ from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
     CloudRunCreateRequest,
     CloudRuntimeConfig,
+    MacrodataApiError,
     MacrodataClient,
     StagePayload,
     serialize_pipeline_inline,
@@ -230,8 +231,9 @@ class CloudLauncher(BaseLauncher):
                     client=client,
                     job_id=resp.job_id,
                     stage_index_hint=resp.stage_index,
+                    force_attach=True,
                 )
-            except Exception:
+            except (MacrodataApiError, MacrodataCredentialsError):
                 print(
                     "Cloud job submitted, but attach failed. Continue with:",
                     file=sys.stderr,

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import cloudpickle
 
+from refiner.cli.cloud_run import require_cloud_attach_supported
 from refiner.cli.local_run import (
     LaunchStats,
     collect_local_stage_results,
@@ -18,6 +19,7 @@ from refiner.cli.local_run import (
     LocalLaunchResumeError,
     stdout_is_interactive,
 )
+from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
 from refiner.pipeline.planning import PlannedStage
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
@@ -216,7 +218,7 @@ class LocalLauncher(BaseLauncher):
         except Exception as err:
             logger.warning(f"Failed to register local job with Macrodata: {err}")
             return None, None
-        job_tracking_url = self._job_tracking_url(
+        job_tracking_url = build_job_tracking_url(
             client=tracking_client,
             job_id=registered_job.job_id,
             workspace_slug=registered_job.workspace_slug,
@@ -363,6 +365,7 @@ class LocalLauncher(BaseLauncher):
         )
 
     def launch(self) -> LaunchStats:
+        require_cloud_attach_supported("local")
         available_cpus = len(available_cpu_ids())
         if self.num_workers > available_cpus:
             logger.warning(

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -94,22 +94,31 @@ def request_json(
     path: str,
     api_key: str | None = None,
     base_url: str | None = None,
+    http_client: httpx.Client | None = None,
     json_payload: dict[str, Any] | None = None,
     timeout_s: float = 10.0,
 ) -> dict[str, Any]:
     resolved_base_url = resolve_platform_base_url() if base_url is None else base_url
     url = f"{resolved_base_url.rstrip('/')}{path}"
-    headers = {"User-Agent": _USER_AGENT}
-    if api_key is not None and api_key.strip():
-        headers["Authorization"] = f"Bearer {api_key}"
     try:
-        resp = httpx.request(
-            method,
-            url,
-            headers=headers,
-            json=json_payload,
-            timeout=timeout_s,
-        )
+        if http_client is not None:
+            resp = http_client.request(
+                method,
+                url,
+                json=json_payload,
+                timeout=timeout_s,
+            )
+        else:
+            headers = {"User-Agent": _USER_AGENT}
+            if api_key is not None and api_key.strip():
+                headers["Authorization"] = f"Bearer {api_key}"
+            resp = httpx.request(
+                method,
+                url,
+                headers=headers,
+                json=json_payload,
+                timeout=timeout_s,
+            )
     except httpx.RequestError as err:
         raise MacrodataApiError(status=0, message=str(err)) from err
 
@@ -141,6 +150,19 @@ class MacrodataClient:
     def __init__(self, *, api_key: str | None = None, base_url: str | None = None):
         self.api_key = api_key if api_key is not None else current_api_key()
         self.base_url = (base_url or resolve_platform_base_url()).rstrip("/")
+        headers = {"User-Agent": _USER_AGENT}
+        if self.api_key.strip():
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        self._http_client = httpx.Client(headers=headers)
+
+    def close(self) -> None:
+        self._http_client.close()
+
+    def __del__(self) -> None:  # pragma: no cover
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _request_raw(
         self,
@@ -164,8 +186,8 @@ class MacrodataClient:
         return request_json(
             method=method,
             path=resolved_path,
-            api_key=self.api_key,
             base_url=self.base_url,
+            http_client=self._http_client,
             json_payload=json_payload,
             timeout_s=timeout_s,
         )
@@ -410,8 +432,8 @@ class MacrodataClient:
         response_data = request_json(
             method="POST",
             path=f"/api/jobs/{job_id}/stages/{stage_index}/workers/{worker_id}/services/start",
-            api_key=self.api_key,
             base_url=self.base_url,
+            http_client=self._http_client,
             json_payload={"services": services},
             timeout_s=60.0,
         )
@@ -430,8 +452,8 @@ class MacrodataClient:
         response_data = request_json(
             method="GET",
             path=f"/api/jobs/{job_id}/stages/{stage_index}/workers/{worker_id}/services/{service_id}",
-            api_key=self.api_key,
             base_url=self.base_url,
+            http_client=self._http_client,
         )
         if not isinstance(response_data, dict):
             raise ValueError("runtime service response must be a JSON object")

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -60,6 +60,22 @@ def _job_payload(*, stage_index: int, status: str) -> dict[str, object]:
     }
 
 
+def test_active_stage_prefers_failed_started_stage_over_later_queued_stage() -> None:
+    stage_index, total_stages = cloud_run._active_stage(
+        {
+            "status": "failed",
+            "stages": [
+                {"index": 0, "status": "completed"},
+                {"index": 1, "status": "failed"},
+                {"index": 2, "status": "queued"},
+            ],
+        }
+    )
+
+    assert stage_index == 1
+    assert total_stages == 3
+
+
 def _log_entry(
     *, ts: int, worker_id: str, severity: str, line: str
 ) -> dict[str, object]:
@@ -532,3 +548,61 @@ def test_attach_to_cloud_job_errors_mode_does_not_spend_worker_cap_on_info_only_
 
     assert rc == 0
     assert [worker_id for worker_id, _ in fake_console.emitted_lines] == ["worker-5"]
+
+
+def test_attach_to_cloud_job_all_mode_suppresses_workers_beyond_cap(
+    monkeypatch,
+) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            payload = _job_payload(stage_index=0, status="completed")
+            job = cast(dict[str, object], payload["job"])
+            worker_count = cloud_run._ATTACH_MAX_LOGGED_WORKERS + 1
+            job["runningWorkers"] = worker_count
+            job["totalWorkers"] = worker_count
+            stage = cast(list[dict[str, object]], job["stages"])[0]
+            stage["runningWorkers"] = worker_count
+            stage["totalWorkers"] = worker_count
+            return payload
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            entries = [
+                _log_entry(
+                    ts=1_700_000_002_000 + index,
+                    worker_id=f"worker-{index}",
+                    severity="info",
+                    line=f"line-{index}",
+                )
+                for index in range(1, cloud_run._ATTACH_MAX_LOGGED_WORKERS + 2)
+            ]
+            return {"entries": entries, "hasOlder": False, "nextCursor": None}
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "all")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert [worker_id for worker_id, _ in fake_console.emitted_lines] == [
+        f"worker-{index}"
+        for index in range(1, cloud_run._ATTACH_MAX_LOGGED_WORKERS + 1)
+    ]

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -4,7 +4,7 @@ import itertools
 from typing import cast
 
 from refiner.cli import cloud_run
-from refiner.platform.client import MacrodataClient
+from refiner.platform.client import MacrodataApiError, MacrodataClient
 
 
 class _FakeConsole:
@@ -606,3 +606,55 @@ def test_attach_to_cloud_job_all_mode_suppresses_workers_beyond_cap(
         f"worker-{index}"
         for index in range(1, cloud_run._ATTACH_MAX_LOGGED_WORKERS + 1)
     ]
+
+
+def test_attach_to_cloud_job_keeps_polling_logs_when_status_refresh_retries(
+    monkeypatch,
+) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.job_calls = 0
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            self.job_calls += 1
+            if self.job_calls == 1:
+                raise MacrodataApiError(status=503, message="temporary")
+            return _job_payload(stage_index=0, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="hello",
+                    )
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert [worker_id for worker_id, _ in fake_console.emitted_lines] == ["worker-1"]

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import itertools
+from typing import cast
+
+from refiner.cli import cloud_run
+from refiner.platform.client import MacrodataClient
+
+
+class _FakeConsole:
+    def __init__(self, **_: object) -> None:
+        self.snapshots: list[object] = []
+        self.system_messages: list[str] = []
+        self.closed = 0
+
+    def emit_lines(self, *, worker_id: str, lines: list[str]) -> None:
+        del worker_id, lines
+
+    def emit_system(self, message: str) -> None:
+        self.system_messages.append(message)
+
+    def apply_snapshot(self, snapshot: object) -> None:
+        self.snapshots.append(snapshot)
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def _job_payload(*, stage_index: int, status: str) -> dict[str, object]:
+    return {
+        "job": {
+            "id": "job-1",
+            "name": "cloud pipeline",
+            "status": status,
+            "executorKind": "cloud",
+            "createdAt": 1_700_000_000_000,
+            "startedAt": 1_700_000_001_000,
+            "runningWorkers": 1,
+            "totalWorkers": 1,
+            "logsAvailable": True,
+            "stages": [
+                {
+                    "index": 0,
+                    "status": "completed" if stage_index > 0 else status,
+                    "completedWorkers": 1 if stage_index > 0 else 0,
+                    "runningWorkers": 0 if stage_index > 0 else 1,
+                    "totalWorkers": 1,
+                },
+                {
+                    "index": 1,
+                    "status": status if stage_index > 0 else "queued",
+                    "completedWorkers": 0,
+                    "runningWorkers": 1 if stage_index > 0 else 0,
+                    "totalWorkers": 1,
+                },
+            ],
+        }
+    }
+
+
+def test_attach_to_cloud_job_follows_active_stage(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.logged_stage_indexes: list[int | None] = []
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=1, status="completed")
+
+        def cli_get_job_workers(
+            self,
+            *,
+            job_id: str,
+            stage_index: int | None,
+            limit: int | None = None,
+            cursor: str | None = None,
+        ) -> dict[str, object]:
+            del job_id, stage_index, limit, cursor
+            return {"items": []}
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            self.logged_stage_indexes.append(
+                cast(int | None, kwargs.get("stage_index"))
+            )
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    client = _Client()
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, client),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert client.logged_stage_indexes[-1] == 1
+    assert fake_console.closed == 1

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -103,3 +103,86 @@ def test_attach_to_cloud_job_follows_active_stage(monkeypatch) -> None:
     assert rc == 0
     assert client.logged_stage_indexes[-1] == 1
     assert fake_console.closed == 1
+
+
+def test_attach_to_cloud_job_resets_cursor_on_stage_switch(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls: list[dict[str, object]] = []
+            self.job_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            self.job_calls += 1
+            if self.job_calls == 1:
+                return _job_payload(stage_index=1, status="running")
+            return _job_payload(stage_index=1, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            self.log_calls.append(dict(kwargs))
+            if len(self.log_calls) == 1:
+                return {"entries": [], "hasOlder": True, "nextCursor": "cursor-1"}
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    client = _Client()
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, client),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert client.log_calls[0]["stage_index"] == 0
+    assert client.log_calls[0]["cursor"] is None
+    assert client.log_calls[1]["stage_index"] == 1
+    assert client.log_calls[1]["cursor"] is None
+
+
+def test_attach_to_cloud_job_without_logs_does_not_busy_loop(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=0, status="running")
+
+    sleep_calls: list[float] = []
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: 0.0)
+
+    def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        raise cloud_run.CloudAttachDetached()
+
+    monkeypatch.setattr(cloud_run.time, "sleep", _fake_sleep)
+
+    payload = _job_payload(stage_index=0, status="running")
+    job = cast(dict[str, object], payload["job"])
+    job["logsAvailable"] = False
+
+    try:
+        cloud_run.attach_to_cloud_job(
+            client=cast(MacrodataClient, _Client()),
+            job_id="job-1",
+            initial_job_payload=payload,
+            stage_index_hint=0,
+        )
+    except cloud_run.CloudAttachDetached:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected CloudAttachDetached")
+
+    assert sleep_calls
+    assert sleep_calls[0] >= cloud_run._ATTACH_LOGS_INTERVAL_SECONDS

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -9,12 +9,14 @@ from refiner.platform.client import MacrodataClient
 
 class _FakeConsole:
     def __init__(self, **_: object) -> None:
+        self.kwargs = dict(_)
         self.snapshots: list[object] = []
         self.system_messages: list[str] = []
+        self.emitted_lines: list[tuple[str, list[str]]] = []
         self.closed = 0
 
     def emit_lines(self, *, worker_id: str, lines: list[str]) -> None:
-        del worker_id, lines
+        self.emitted_lines.append((worker_id, list(lines)))
 
     def emit_system(self, message: str) -> None:
         self.system_messages.append(message)
@@ -58,10 +60,25 @@ def _job_payload(*, stage_index: int, status: str) -> dict[str, object]:
     }
 
 
+def _log_entry(
+    *, ts: int, worker_id: str, severity: str, line: str
+) -> dict[str, object]:
+    return {
+        "ts": ts,
+        "severity": severity,
+        "line": line,
+        "workerId": worker_id,
+        "sourceType": "worker",
+        "sourceName": "runner",
+        "messageHash": f"{worker_id}-{ts}-{severity}-{line}",
+    }
+
+
 def test_attach_to_cloud_job_follows_active_stage(monkeypatch) -> None:
     class _Client:
         def __init__(self) -> None:
             self.base_url = "https://example.com"
+            self.log_calls = 0
             self.logged_stage_indexes: list[int | None] = []
 
         def cli_get_job(self, *, job_id: str) -> dict[str, object]:
@@ -86,9 +103,15 @@ def test_attach_to_cloud_job_follows_active_stage(monkeypatch) -> None:
             return {"entries": [], "hasOlder": False, "nextCursor": None}
 
     monotonic_values = itertools.count(0.0, 1.0)
-    fake_console = _FakeConsole()
     monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
-    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    created_consoles: list[_FakeConsole] = []
+    monkeypatch.setattr(
+        cloud_run,
+        "LocalStageConsole",
+        lambda **kwargs: (
+            created_consoles.append(_FakeConsole(**kwargs)) or created_consoles[-1]
+        ),
+    )
     monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
     monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
 
@@ -102,7 +125,55 @@ def test_attach_to_cloud_job_follows_active_stage(monkeypatch) -> None:
 
     assert rc == 0
     assert client.logged_stage_indexes[-1] == 1
-    assert fake_console.closed == 1
+    assert created_consoles[-1].closed == 1
+    assert created_consoles[-1].kwargs["rundir"] is None
+
+
+def test_attach_to_cloud_job_force_attach_uses_console_without_tty(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=0, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="hello",
+                    )
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: False)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+        force_attach=True,
+    )
+
+    assert rc == 0
+    assert fake_console.emitted_lines
 
 
 def test_attach_to_cloud_job_resets_cursor_on_stage_switch(monkeypatch) -> None:
@@ -186,3 +257,278 @@ def test_attach_to_cloud_job_without_logs_does_not_busy_loop(monkeypatch) -> Non
 
     assert sleep_calls
     assert sleep_calls[0] >= cloud_run._ATTACH_LOGS_INTERVAL_SECONDS
+
+
+def test_attach_to_cloud_job_hides_lines_for_none_mode(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=0, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="hello",
+                    )
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "none")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert fake_console.emitted_lines == []
+
+
+def test_attach_to_cloud_job_none_mode_skips_log_requests(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=0, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    client = _Client()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "none")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, client),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert client.log_calls == 0
+
+
+def test_attach_to_cloud_job_limits_to_one_worker_in_one_mode(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            payload = _job_payload(stage_index=0, status="completed")
+            job = cast(dict[str, object], payload["job"])
+            job["runningWorkers"] = 2
+            job["totalWorkers"] = 2
+            stage = cast(list[dict[str, object]], job["stages"])[0]
+            stage["runningWorkers"] = 2
+            stage["totalWorkers"] = 2
+            return payload
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="first",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_001,
+                        worker_id="worker-2",
+                        severity="info",
+                        line="second",
+                    ),
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "one")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert [worker_id for worker_id, _ in fake_console.emitted_lines] == ["worker-1"]
+
+
+def test_attach_to_cloud_job_shows_only_errors_in_errors_mode(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            return _job_payload(stage_index=0, status="completed")
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="info line",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_001,
+                        worker_id="worker-2",
+                        severity="error",
+                        line="error line",
+                    ),
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "errors")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert [worker_id for worker_id, _ in fake_console.emitted_lines] == ["worker-2"]
+
+
+def test_attach_to_cloud_job_errors_mode_does_not_spend_worker_cap_on_info_only_workers(
+    monkeypatch,
+) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.base_url = "https://example.com"
+            self.log_calls = 0
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            del job_id
+            payload = _job_payload(stage_index=0, status="completed")
+            job = cast(dict[str, object], payload["job"])
+            job["runningWorkers"] = 6
+            job["totalWorkers"] = 6
+            stage = cast(list[dict[str, object]], job["stages"])[0]
+            stage["runningWorkers"] = 6
+            stage["totalWorkers"] = 6
+            return payload
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            self.log_calls += 1
+            if self.log_calls > 1:
+                return {"entries": [], "hasOlder": False, "nextCursor": None}
+            return {
+                "entries": [
+                    _log_entry(
+                        ts=1_700_000_002_000,
+                        worker_id="worker-1",
+                        severity="info",
+                        line="info",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_001,
+                        worker_id="worker-2",
+                        severity="info",
+                        line="info",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_002,
+                        worker_id="worker-3",
+                        severity="info",
+                        line="info",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_003,
+                        worker_id="worker-4",
+                        severity="info",
+                        line="info",
+                    ),
+                    _log_entry(
+                        ts=1_700_000_002_004,
+                        worker_id="worker-5",
+                        severity="error",
+                        line="boom",
+                    ),
+                ],
+                "hasOlder": False,
+                "nextCursor": None,
+            }
+
+    monotonic_values = itertools.count(0.0, 1.0)
+    fake_console = _FakeConsole()
+    monkeypatch.setenv("REFINER_LOCAL_LOGS", "errors")
+    monkeypatch.setattr(cloud_run, "stdout_is_interactive", lambda: True)
+    monkeypatch.setattr(cloud_run, "LocalStageConsole", lambda **_: fake_console)
+    monkeypatch.setattr(cloud_run.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(cloud_run.time, "sleep", lambda _: None)
+
+    rc = cloud_run.attach_to_cloud_job(
+        client=cast(MacrodataClient, _Client()),
+        job_id="job-1",
+        initial_job_payload=_job_payload(stage_index=0, status="running"),
+        stage_index_hint=0,
+    )
+
+    assert rc == 0
+    assert [worker_id for worker_id, _ in fake_console.emitted_lines] == ["worker-5"]

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import builtins
 from argparse import Namespace
+from datetime import datetime
 from typing import Any, cast
-
 
 from refiner.cli import jobs
 from refiner.platform.client.api import MacrodataApiError
@@ -224,6 +224,7 @@ def test_jobs_attach_calls_cloud_attach(monkeypatch) -> None:
 
     assert rc == 0
     assert captured["job_id"] == "job-1"
+    assert captured["force_attach"] is True
     payload = cast(dict[str, object], captured["initial_job_payload"])
     job = cast(dict[str, object], payload["job"])
     assert job["executorKind"] == "cloud"
@@ -893,6 +894,62 @@ def test_jobs_logs_follow_ignores_transient_status_probe_errors(
 
     assert rc == 0
     assert "first" in out.out
+
+
+def test_jobs_logs_follow_advances_window_after_transient_status_probe_error(
+    monkeypatch,
+) -> None:
+    class _FlakyStatusClient(_FakeClient):
+        def __init__(self) -> None:
+            self.log_calls: list[tuple[int, int]] = []
+            self.job_calls = 0
+
+        def cli_get_job_logs(self, **kwargs: object) -> dict[str, object]:
+            self.log_calls.append(
+                (cast(int, kwargs["start_ms"]), cast(int, kwargs["end_ms"]))
+            )
+            return {"entries": [], "hasOlder": False, "nextCursor": None}
+
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            self.job_calls += 1
+            if self.job_calls == 1:
+                raise MacrodataApiError(status=503, message="temporary")
+            payload = super().cli_get_job(job_id=job_id)
+            cast(dict[str, object], payload["job"])["status"] = "completed"
+            return payload
+
+    client = _FlakyStatusClient()
+    monkeypatch.setattr(jobs, "_client", lambda: client)
+    now_values = iter([10, 15])
+
+    class _FakeDateTime:
+        @staticmethod
+        def now(*, tz=None):
+            return datetime.fromtimestamp(next(now_values), tz=tz)
+
+    monkeypatch.setattr(jobs, "datetime", _FakeDateTime)
+    monkeypatch.setattr(jobs.time, "sleep", lambda _: None)
+
+    rc = jobs.cmd_jobs_logs(
+        Namespace(
+            job_id="job-1",
+            stage=None,
+            worker=None,
+            source_type=None,
+            source_name=None,
+            severity=None,
+            search=None,
+            start_ms=1,
+            end_ms=2,
+            cursor=None,
+            limit=None,
+            follow=True,
+            json=False,
+        )
+    )
+
+    assert rc == 0
+    assert client.log_calls == [(1, 2), (2, 10000)]
 
 
 def test_jobs_logs_follow_retries_transient_log_fetch_errors(

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -207,6 +207,62 @@ def test_jobs_get_plain_output(monkeypatch, capsys) -> None:
     assert "2/1/4" in out.out
 
 
+def test_jobs_attach_calls_cloud_attach(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_attach_to_cloud_job(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(jobs, "_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "refiner.cli.cloud_run.attach_to_cloud_job",
+        _fake_attach_to_cloud_job,
+    )
+
+    rc = jobs.cmd_jobs_attach(Namespace(job_id="job-1"))
+
+    assert rc == 0
+    assert captured["job_id"] == "job-1"
+    payload = cast(dict[str, object], captured["initial_job_payload"])
+    job = cast(dict[str, object], payload["job"])
+    assert job["executorKind"] == "cloud"
+
+
+def test_jobs_attach_rejects_non_cloud_job(monkeypatch, capsys) -> None:
+    class _LocalClient(_FakeClient):
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            cast(dict[str, object], payload["job"])["executorKind"] = "local"
+            return payload
+
+    monkeypatch.setattr(jobs, "_client", lambda: _LocalClient())
+
+    rc = jobs.cmd_jobs_attach(Namespace(job_id="job-1"))
+    out = capsys.readouterr()
+
+    assert rc == 1
+    assert "only supported for cloud jobs" in out.err
+
+
+def test_jobs_attach_routes_attach_api_errors_through_cli_handler(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(jobs, "_client", lambda: _FakeClient())
+    monkeypatch.setattr(
+        "refiner.cli.cloud_run.attach_to_cloud_job",
+        lambda **_: (_ for _ in ()).throw(
+            MacrodataApiError(status=503, message="temporary")
+        ),
+    )
+
+    rc = jobs.cmd_jobs_attach(Namespace(job_id="job-1"))
+    out = capsys.readouterr()
+
+    assert rc == 1
+    assert "temporary" in out.err
+
+
 def test_jobs_logs_json_output(monkeypatch, capsys) -> None:
     monkeypatch.setattr(jobs, "_client", lambda: _FakeClient())
 
@@ -613,7 +669,7 @@ def test_jobs_logs_follow_skips_sleep_while_draining_full_batches(
     assert rc == 0
     assert "first" in out.out
     assert "second" in out.out
-    assert sleep_calls["count"] == 0
+    assert sleep_calls["count"] == 1
     assert client.job_calls == 1
 
 
@@ -773,7 +829,7 @@ def test_jobs_logs_follow_sleeps_after_bounded_drain_polls(monkeypatch, capsys) 
     assert rc == 0
     assert "line-1" in out.out
     assert f"line-{jobs._FOLLOW_LOG_MAX_DRAIN_POLLS}" in out.out
-    assert sleep_calls["count"] == 1
+    assert sleep_calls["count"] == jobs._FOLLOW_LOG_MAX_DRAIN_POLLS
     assert client.job_calls == 2
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -12,9 +12,20 @@ def test_parser_has_auth_commands() -> None:
 def test_parser_has_run_command() -> None:
     parser = build_parser()
     args = parser.parse_args(
-        ["run", "--logs", "one", "script.py", "--", "--rows", "10"]
+        [
+            "run",
+            "--attach",
+            "attach",
+            "--logs",
+            "one",
+            "script.py",
+            "--",
+            "--rows",
+            "10",
+        ]
     )
     assert args.command == "run"
+    assert args.attach == "attach"
     assert args.logs == "one"
     assert args.script == "script.py"
     assert args.script_args == ["--rows", "10"]
@@ -52,6 +63,14 @@ def test_parser_has_jobs_cancel_command() -> None:
     args = parser.parse_args(["jobs", "cancel", "job-1"])
     assert args.command == "jobs"
     assert args.jobs_command == "cancel"
+    assert args.job_id == "job-1"
+
+
+def test_parser_has_jobs_attach_command() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["jobs", "attach", "job-1"])
+    assert args.command == "jobs"
+    assert args.jobs_command == "attach"
     assert args.job_id == "job-1"
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -15,7 +15,6 @@ def test_parser_has_run_command() -> None:
         [
             "run",
             "--attach",
-            "attach",
             "--logs",
             "one",
             "script.py",
@@ -25,10 +24,20 @@ def test_parser_has_run_command() -> None:
         ]
     )
     assert args.command == "run"
-    assert args.attach == "attach"
+    assert args.attach is True
+    assert args.detach is False
     assert args.logs == "one"
     assert args.script == "script.py"
     assert args.script_args == ["--rows", "10"]
+
+
+def test_parser_has_run_detach_flag() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["run", "--detach", "script.py"])
+    assert args.command == "run"
+    assert args.attach is False
+    assert args.detach is True
+    assert args.script == "script.py"
 
 
 def test_parser_has_jobs_commands() -> None:

--- a/tests/cli/test_run_command.py
+++ b/tests/cli/test_run_command.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 import pytest
 
 from refiner.cli import run
+from refiner.cli.cloud_run import CloudAttachDetached
 from refiner.cli.local_run import (
     LocalLaunchInterrupted,
     LocalLaunchResumeError,
@@ -12,7 +13,7 @@ from refiner.cli.local_run import (
 )
 
 
-def test_cmd_run_sets_log_env_and_forwards_args(monkeypatch, tmp_path) -> None:
+def test_cmd_run_sets_env_overrides_and_forwards_args(monkeypatch, tmp_path) -> None:
     script = tmp_path / "demo.py"
     script.write_text("print('ok')\n", encoding="utf-8")
     captured: dict[str, object] = {}
@@ -22,6 +23,7 @@ def test_cmd_run_sets_log_env_and_forwards_args(monkeypatch, tmp_path) -> None:
         captured["run_name"] = run_name
         captured["argv"] = list(run.sys.argv)
         captured["logs"] = run.os.environ.get("REFINER_LOCAL_LOGS")
+        captured["attach"] = run.os.environ.get("REFINER_ATTACH")
 
     monkeypatch.setattr(run.runpy, "run_path", _fake_run_path)
 
@@ -30,18 +32,42 @@ def test_cmd_run_sets_log_env_and_forwards_args(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=["--", "--rows", "10"],
             logs="one",
+            attach="attach",
         )
     )
 
     assert rc == 0
     assert captured["path"] == str(script)
     assert captured["run_name"] == "__main__"
-    assert captured["argv"] == [
-        str(script),
-        "--rows",
-        "10",
-    ]
+    assert captured["argv"] == [str(script), "--rows", "10"]
     assert captured["logs"] == "one"
+    assert captured["attach"] == "attach"
+    assert run.os.environ.get("REFINER_ATTACH") is None
+
+
+def test_cmd_run_restores_attach_env(monkeypatch, tmp_path) -> None:
+    script = tmp_path / "demo.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("REFINER_ATTACH", "detach")
+
+    def _fake_run_path(path: str, *, run_name: str):
+        captured["attach"] = run.os.environ.get("REFINER_ATTACH")
+
+    monkeypatch.setattr(run.runpy, "run_path", _fake_run_path)
+
+    rc = run.cmd_run(
+        Namespace(
+            script=str(script),
+            script_args=[],
+            logs=None,
+            attach="attach",
+        )
+    )
+
+    assert rc == 0
+    assert captured["attach"] == "attach"
+    assert run.os.environ.get("REFINER_ATTACH") == "detach"
 
 
 def test_cmd_run_missing_script_returns_error(capsys, tmp_path) -> None:
@@ -50,6 +76,7 @@ def test_cmd_run_missing_script_returns_error(capsys, tmp_path) -> None:
             script=str(tmp_path / "missing.py"),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
     out = capsys.readouterr()
@@ -79,6 +106,7 @@ def test_cmd_run_prints_runtime_error_without_traceback(
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 
@@ -105,6 +133,7 @@ def test_cmd_run_suppresses_resume_error_print_on_tty(
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 
@@ -129,6 +158,7 @@ def test_cmd_run_does_not_swallow_plain_runtime_error(monkeypatch, tmp_path) -> 
                 script=str(script),
                 script_args=[],
                 logs=None,
+                attach=None,
             )
         )
 
@@ -152,12 +182,39 @@ def test_cmd_run_returns_130_for_launcher_interrupt(
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 
     out = capsys.readouterr()
     assert rc == 130
     assert "Local job interrupted" in out.err
+
+
+def test_cmd_run_suppresses_generic_interrupt_message_for_cloud_detach(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    script = tmp_path / "demo.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+
+    def _raise(path: str, *, run_name: str):
+        del path, run_name
+        raise CloudAttachDetached()
+
+    monkeypatch.setattr(run.runpy, "run_path", _raise)
+
+    rc = run.cmd_run(
+        Namespace(
+            script=str(script),
+            script_args=[],
+            logs=None,
+            attach=None,
+        )
+    )
+
+    out = capsys.readouterr()
+    assert rc == 130
+    assert out.err == ""
 
 
 def test_cmd_run_returns_141_for_broken_pipe(monkeypatch, tmp_path) -> None:
@@ -175,6 +232,7 @@ def test_cmd_run_returns_141_for_broken_pipe(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 
@@ -198,6 +256,7 @@ def test_cmd_run_prepends_script_directory_to_sys_path(monkeypatch, tmp_path) ->
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 
@@ -225,6 +284,7 @@ def test_cmd_run_drops_cwd_entry_from_sys_path(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=[],
             logs=None,
+            attach=None,
         )
     )
 

--- a/tests/cli/test_run_command.py
+++ b/tests/cli/test_run_command.py
@@ -46,6 +46,32 @@ def test_cmd_run_sets_env_overrides_and_forwards_args(monkeypatch, tmp_path) -> 
     assert run.os.environ.get("REFINER_ATTACH") is None
 
 
+def test_cmd_run_sets_auto_attach_mode_by_default(monkeypatch, tmp_path) -> None:
+    script = tmp_path / "demo.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def _fake_run_path(path: str, *, run_name: str):
+        del path, run_name
+        captured["attach"] = run.os.environ.get("REFINER_ATTACH")
+
+    monkeypatch.setattr(run.runpy, "run_path", _fake_run_path)
+
+    rc = run.cmd_run(
+        Namespace(
+            script=str(script),
+            script_args=[],
+            logs=None,
+            attach=False,
+            detach=False,
+        )
+    )
+
+    assert rc == 0
+    assert captured["attach"] == "auto"
+    assert run.os.environ.get("REFINER_ATTACH") is None
+
+
 def test_cmd_run_restores_attach_env(monkeypatch, tmp_path) -> None:
     script = tmp_path / "demo.py"
     script.write_text("print('ok')\n", encoding="utf-8")

--- a/tests/cli/test_run_command.py
+++ b/tests/cli/test_run_command.py
@@ -32,7 +32,8 @@ def test_cmd_run_sets_env_overrides_and_forwards_args(monkeypatch, tmp_path) -> 
             script=str(script),
             script_args=["--", "--rows", "10"],
             logs="one",
-            attach="attach",
+            attach=True,
+            detach=False,
         )
     )
 
@@ -61,7 +62,8 @@ def test_cmd_run_restores_attach_env(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=[],
             logs=None,
-            attach="attach",
+            attach=True,
+            detach=False,
         )
     )
 
@@ -76,7 +78,8 @@ def test_cmd_run_missing_script_returns_error(capsys, tmp_path) -> None:
             script=str(tmp_path / "missing.py"),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
     out = capsys.readouterr()
@@ -106,7 +109,8 @@ def test_cmd_run_prints_runtime_error_without_traceback(
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -133,7 +137,8 @@ def test_cmd_run_suppresses_resume_error_print_on_tty(
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -158,7 +163,8 @@ def test_cmd_run_does_not_swallow_plain_runtime_error(monkeypatch, tmp_path) -> 
                 script=str(script),
                 script_args=[],
                 logs=None,
-                attach=None,
+                attach=False,
+                detach=False,
             )
         )
 
@@ -182,7 +188,8 @@ def test_cmd_run_returns_130_for_launcher_interrupt(
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -208,7 +215,8 @@ def test_cmd_run_suppresses_generic_interrupt_message_for_cloud_detach(
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -232,7 +240,8 @@ def test_cmd_run_returns_141_for_broken_pipe(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -256,7 +265,8 @@ def test_cmd_run_prepends_script_directory_to_sys_path(monkeypatch, tmp_path) ->
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 
@@ -284,7 +294,8 @@ def test_cmd_run_drops_cwd_entry_from_sys_path(monkeypatch, tmp_path) -> None:
             script=str(script),
             script_args=[],
             logs=None,
-            attach=None,
+            attach=False,
+            detach=False,
         )
     )
 

--- a/tests/launchers/test_base_launcher.py
+++ b/tests/launchers/test_base_launcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from refiner.job_urls import build_job_tracking_url
 from refiner.platform.client import MacrodataClient
 from refiner.pipeline import RefinerPipeline
 from refiner.launchers.base import BaseLauncher
@@ -28,12 +29,9 @@ class _ResourceHintLauncher(_DummyLauncher):
 
 
 def test_job_tracking_url_sanitizes_terminal_control_characters() -> None:
-    launcher = _DummyLauncher(
-        pipeline=cast(RefinerPipeline, object()), name="unit-test"
-    )
     client = MacrodataClient(api_key="md_test", base_url="https://app.\x9bexample.com")
 
-    url = launcher._job_tracking_url(
+    url = build_job_tracking_url(
         client=client,
         workspace_slug="macro\x07data",
         job_id="job-\x1b[31m",

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -523,7 +523,9 @@ def test_pipeline_launch_cloud_detached_mode_prints_followup_commands(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
         lambda ref: True,
     )
-    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "detach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.resolve_launcher_attach_mode", lambda: "detach"
+    )
     monkeypatch.setattr(
         "refiner.launchers.cloud.emit_cloud_followup_commands",
         lambda *, context, file=None: print(f"attach {context.job_id}", file=file),
@@ -542,7 +544,9 @@ def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch) -> None:
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
         lambda ref: True,
     )
-    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.resolve_launcher_attach_mode", lambda: "attach"
+    )
     captured: dict[str, object] = {}
 
     def _fake_attach_to_cloud_job(**kwargs: object) -> int:
@@ -569,7 +573,9 @@ def test_pipeline_launch_cloud_attach_failure_prints_fallback(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
         lambda ref: True,
     )
-    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.resolve_launcher_attach_mode", lambda: "attach"
+    )
     monkeypatch.setattr(
         "refiner.launchers.cloud.attach_to_cloud_job",
         lambda **_: (_ for _ in ()).throw(
@@ -597,7 +603,9 @@ def test_pipeline_launch_cloud_unexpected_attach_failure_propagates(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
         lambda ref: True,
     )
-    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.resolve_launcher_attach_mode", lambda: "attach"
+    )
     monkeypatch.setattr(
         "refiner.launchers.cloud.attach_to_cloud_job",
         lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
@@ -605,3 +613,28 @@ def test_pipeline_launch_cloud_unexpected_attach_failure_propagates(
 
     with pytest.raises(RuntimeError, match="boom"):
         read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+
+def test_pipeline_launch_cloud_defaults_to_detached_outside_cli(
+    monkeypatch, capsys
+) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    monkeypatch.delenv("REFINER_ATTACH", raising=False)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.emit_cloud_followup_commands",
+        lambda *, context, file=None: print(f"attach {context.job_id}", file=file),
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.attach_to_cloud_job",
+        lambda **_: (_ for _ in ()).throw(AssertionError("should not attach")),
+    )
+
+    result = read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+    out = capsys.readouterr()
+
+    assert result.job_id == "job-123"
+    assert "attach job-123" in out.out

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -512,3 +512,74 @@ def test_pipeline_launch_cloud_noninteractive_ref_fallback_requires_override(
 
     with pytest.raises(SystemExit, match="MACRODATA_FALLBACK_TO_LATEST_PYPI=1"):
         read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+
+def test_pipeline_launch_cloud_detached_mode_prints_followup_commands(
+    monkeypatch, capsys
+) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "detach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.emit_cloud_followup_commands",
+        lambda *, context, file=None: print(f"attach {context.job_id}", file=file),
+    )
+
+    result = read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+    out = capsys.readouterr()
+
+    assert result.job_id == "job-123"
+    assert "attach job-123" in out.out
+
+
+def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    captured: dict[str, object] = {}
+
+    def _fake_attach_to_cloud_job(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.attach_to_cloud_job", _fake_attach_to_cloud_job
+    )
+
+    result = read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    assert result.job_id == "job-123"
+    assert captured["job_id"] == "job-123"
+    assert captured["stage_index_hint"] == 0
+
+
+def test_pipeline_launch_cloud_attach_failure_prints_fallback(
+    monkeypatch, capsys
+) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.attach_to_cloud_job",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.emit_cloud_followup_commands",
+        lambda *, context, file=None: print(f"fallback {context.job_id}", file=file),
+    )
+
+    result = read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    out = capsys.readouterr()
+    assert result.job_id == "job-123"
+    assert "attach failed" in out.err
+    assert "fallback job-123" in out.err

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -10,6 +10,7 @@ from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
     CloudPipelinePayload,
     CloudRunCreateRequest,
+    MacrodataApiError,
 )
 from refiner.platform.manifest import _redact_captured_text
 
@@ -557,6 +558,7 @@ def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch) -> None:
     assert result.job_id == "job-123"
     assert captured["job_id"] == "job-123"
     assert captured["stage_index_hint"] == 0
+    assert captured["force_attach"] is True
 
 
 def test_pipeline_launch_cloud_attach_failure_prints_fallback(
@@ -570,7 +572,9 @@ def test_pipeline_launch_cloud_attach_failure_prints_fallback(
     monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
     monkeypatch.setattr(
         "refiner.launchers.cloud.attach_to_cloud_job",
-        lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda **_: (_ for _ in ()).throw(
+            MacrodataApiError(status=503, message="boom")
+        ),
     )
     monkeypatch.setattr(
         "refiner.launchers.cloud.emit_cloud_followup_commands",
@@ -583,3 +587,21 @@ def test_pipeline_launch_cloud_attach_failure_prints_fallback(
     assert result.job_id == "job-123"
     assert "attach failed" in out.err
     assert "fallback job-123" in out.err
+
+
+def test_pipeline_launch_cloud_unexpected_attach_failure_propagates(
+    monkeypatch,
+) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    monkeypatch.setattr("refiner.launchers.cloud.resolve_attach_mode", lambda: "attach")
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.attach_to_cloud_job",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        read_jsonl("input.jsonl").launch_cloud(name="demo cloud")

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -79,6 +79,13 @@ def test_launch_local_single_worker(tmp_path) -> None:
     assert stats.output_rows == 2
 
 
+def test_launch_local_rejects_attach_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REFINER_ATTACH", "attach")
+
+    with pytest.raises(SystemExit, match="only supported for cloud launches"):
+        read_jsonl("input.jsonl").launch_local(name="unit-test-local")
+
+
 def test_launch_local_single_worker_csv(tmp_path) -> None:
     path = tmp_path / "a.csv"
     path.write_text("x\n1\n2\n")

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -341,6 +341,44 @@ def test_local_stage_console_omits_rundir_row_when_absent(
     assert any("Runtime:" in line for line in header_lines)
 
 
+def test_local_stage_console_apply_snapshot_updates_stage_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("refiner.cli.local_run.stdout_is_interactive", lambda: False)
+    console = LocalStageConsole(
+        job_id="job-1",
+        job_name="demo",
+        rundir=None,
+        stage_index=0,
+        total_stages=2,
+        stage_workers=1,
+        tracking_url=None,
+    )
+    try:
+        console.apply_snapshot(
+            LocalStageSnapshot(
+                job_id="job-1",
+                job_name="demo",
+                rundir=None,
+                stage_index=1,
+                total_stages=3,
+                stage_workers=4,
+                tracking_url=None,
+                status="running",
+                worker_total=4,
+                worker_running=2,
+                worker_completed=1,
+                worker_failed=0,
+                elapsed_seconds=5.0,
+            )
+        )
+    finally:
+        console.close()
+
+    assert console._stage_index == 1
+    assert console._total_stages == 3
+
+
 def test_local_stage_console_formats_system_lines_without_worker_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -79,10 +79,10 @@ def test_launch_local_single_worker(tmp_path) -> None:
     assert stats.output_rows == 2
 
 
-def test_launch_local_rejects_attach_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("REFINER_ATTACH", "attach")
+def test_launch_local_rejects_detach_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REFINER_ATTACH", "detach")
 
-    with pytest.raises(SystemExit, match="only supported for cloud launches"):
+    with pytest.raises(SystemExit, match="--detach is only supported"):
         read_jsonl("input.jsonl").launch_local(name="unit-test-local")
 
 

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -319,6 +319,28 @@ def test_local_stage_console_colors_timestamp_level_and_message(
     assert "__main__:emit_logs:14 - loguru row=0 starting\x1b[0m" in line
 
 
+def test_local_stage_console_omits_rundir_row_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("refiner.cli.local_run.stdout_is_interactive", lambda: True)
+    console = LocalStageConsole(
+        job_id="job-1",
+        job_name="cloud-attach-demo",
+        rundir=None,
+        stage_index=0,
+        total_stages=2,
+        stage_workers=1,
+        tracking_url="https://example.com/jobs/job-1",
+    )
+    try:
+        header_lines = console._build_header_lines(width=80)
+    finally:
+        console.close()
+
+    assert not any("Rundir:" in line for line in header_lines)
+    assert any("Runtime:" in line for line in header_lines)
+
+
 def test_local_stage_console_formats_system_lines_without_worker_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -737,6 +759,20 @@ def test_should_emit_worker_line_filters_by_mode() -> None:
         worker_id="worker-a",
         selected_worker_id=None,
         line=info_line,
+    )
+    assert should_emit_worker_line(
+        log_mode="errors",
+        worker_id="worker-a",
+        selected_worker_id=None,
+        line=info_line,
+        severity="error",
+    )
+    assert not should_emit_worker_line(
+        log_mode="errors",
+        worker_id="worker-a",
+        selected_worker_id=None,
+        line=error_line,
+        severity="info",
     )
 
 

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -61,8 +61,8 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
     assert resp.workspace_slug == "macrodata"
     assert captured["method"] == "POST"
     assert captured["path"] == "/api/cloud/runs"
-    assert captured["api_key"] == "md_test"
     assert captured["base_url"] == "https://example.com"
+    assert "http_client" in captured
     json_payload = cast(dict[str, object], captured["json_payload"])
     assert json_payload["executor"] == {
         "type": "macrodata-cloud",


### PR DESCRIPTION
## What changed
- added cloud attach support to `macrodata run` with `--attach` and `--detach`
- added `macrodata jobs attach <job_id>` to reopen the attached cloud console for an existing cloud job
- reused the local stage console for cloud attach, including pinned header state, live logs, terminal-state exit, and detach guidance on `Ctrl+C`
- extracted shared CLI job/log helpers into `src/refiner/cli/job_utils.py` so `jobs.py` and `cloud_run.py` do not maintain separate copies
- reset cloud attach log pagination state on stage transitions and avoid busy-looping when logs are unavailable
- documented the new run and attach behavior in `docs/cli.md`

## Why
Cloud launches previously submitted remotely and then exited immediately. This change unifies the richer local launch experience with cloud jobs while preserving a clear interactive vs non-interactive split:
- interactive terminals attach by default for cloud jobs
- non-interactive output returns immediately with concrete follow-up commands
- `--attach` forces attached mode
- `--detach` forces detached mode where supported and errors for local launches

## Validation
- `uv run pytest tests/cli/test_cloud_run.py tests/cli/test_main.py tests/cli/test_run_command.py tests/cli/test_job_commands.py tests/launchers/test_base_launcher.py tests/launchers/test_cloud_launcher.py tests/launchers/test_local_launcher.py`
- `uv run ruff check --force-exclude src/refiner/cli/job_utils.py src/refiner/cli/cloud_run.py src/refiner/cli/jobs.py src/refiner/cli/main.py src/refiner/cli/run.py tests/cli/test_cloud_run.py tests/cli/test_main.py tests/cli/test_run_command.py tests/cli/test_job_commands.py docs/cli.md`
- `uv run ty check`

## Notes
- attached cloud logs stay live and may skip older backlog under sustained load, with recovery guidance pointing users back to `macrodata jobs logs`
- attached cloud log output caps itself to a small subset of workers learned from the live stream to stay readable without extra worker-list polling
- `mdr` remains an alias for `macrodata`
