### PR TITLE
[codex] stop sending executor type

### DIFF
--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -205,7 +205,6 @@ class LocalLauncher(BaseLauncher):
             )
             registered_job = tracking_client.create_job(
                 name=self.name,
-                executor={"type": "refiner-local"},
                 plan=self._compiled_plan(stages),
                 manifest=manifest,
             )

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -226,13 +226,11 @@ class MacrodataClient:
         self,
         *,
         name: str,
-        executor: dict[str, Any],
         plan: dict[str, Any],
         manifest: dict[str, Any],
     ) -> CreateJobResponse:
         request_body = {
             "name": name,
-            "executor": executor,
             "plan": plan,
             "manifest": manifest,
         }

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -182,7 +182,6 @@ class CloudRunCreateRequest:
         payload: dict[str, Any] = {
             "name": self.name,
             "executor": {
-                "type": "macrodata-cloud",
                 "sync_local_dependencies": self.sync_local_dependencies,
             },
             "plan": self.plan,

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -1242,7 +1242,7 @@ def test_local_launcher_registers_job_and_reports_stage_lifecycle(
     launcher.launch()
 
     assert create_calls
-    assert create_calls[0]["executor"] == {"type": "refiner-local"}
+    assert "executor" not in create_calls[0]
     manifest = cast(dict[str, object], create_calls[0]["manifest"])
     environment = cast(dict[str, object], manifest["environment"])
     assert environment["rundir"] == str(tmp_path / "runs" / "<jobid>")

--- a/tests/platform/test_client.py
+++ b/tests/platform/test_client.py
@@ -23,7 +23,6 @@ def test_create_job_treats_whitespace_workspace_slug_as_none(
     client = MacrodataClient(api_key="md_test", base_url="https://example.com")
     context = client.create_job(
         name="Job",
-        executor={"type": "refiner-local"},
         plan={"stages": [{"name": "stage_0", "steps": []}]},
         manifest={"version": 1},
     )

--- a/tests/platform/test_client_create_job.py
+++ b/tests/platform/test_client_create_job.py
@@ -26,7 +26,6 @@ def test_create_job_includes_manifest_refiner_metadata(monkeypatch) -> None:
     client = MacrodataClient(api_key="ing_test", base_url="https://example.com")
     ctx = client.create_job(
         name="local job",
-        executor={"type": "refiner-local"},
         plan={"stages": [{"name": "stage_0", "steps": []}]},
         manifest={
             "version": 1,
@@ -40,7 +39,7 @@ def test_create_job_includes_manifest_refiner_metadata(monkeypatch) -> None:
     assert ctx.stage_index == 0
 
     json_payload = cast(dict[str, object], captured["json_payload"])
-    assert json_payload["executor"] == {"type": "refiner-local"}
+    assert "executor" not in json_payload
     assert json_payload["manifest"] == {
         "version": 1,
         "environment": {

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -65,7 +65,6 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
     assert "http_client" in captured
     json_payload = cast(dict[str, object], captured["json_payload"])
     assert json_payload["executor"] == {
-        "type": "macrodata-cloud",
         "sync_local_dependencies": True,
     }
     stage_payloads = cast(list[dict[str, object]], json_payload["stage_payloads"])


### PR DESCRIPTION
## What changed
Refiner no longer sends `executor.type` when registering local jobs or submitting cloud runs.

Local job creation now omits the `executor` field entirely, and cloud submits keep only `sync_local_dependencies` under `executor` because that still affects runtime behavior.

## Why
Perpetuity now treats executor type as server-owned state. This keeps the client aligned with that contract and removes a stale field that no longer needs to cross the wire.

## Validation
- `uv run pytest tests/platform/test_client.py tests/platform/test_client_create_job.py tests/platform/test_cloud_client.py tests/launchers/test_local_launcher.py -k 'create_job or cloud_submit_job or registers_job_and_reports_stage_lifecycle'`
- `uv run ty check src/refiner/launchers/local.py src/refiner/platform/client/api.py src/refiner/platform/client/models.py tests/platform/test_client.py tests/platform/test_client_create_job.py tests/platform/test_cloud_client.py tests/launchers/test_local_launcher.py`