### PR TITLE
Add Dots PDF OCR example

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -81,11 +81,12 @@ pipeline = mdr.read_jsonl("input.jsonl").map_async(
 
 #### Cold-Starts
 Because Refiner Cloud may start VLLM on fresh hardware, startup can take 2 to 20 minutes depending on model size, weight downloads, and torch initialization. To reduce this, Refiner Cloud prewarms a small set of commonly used models:
-- `google/gemma-4-26B-A4B-it`
-- `Qwen/Qwen3-VL-30B-A3B-Instruct`
-- `Qwen/Qwen3-VL-8B-Instruct`
+- `Qwen/Qwen3.5-9B`
+- `google/gemma-4-E4B-it`
+- `rednote-hilab/dots.mocr`
+- `Qwen/Qwen3.5-4B`
 
-The two Qwen vision-language models should currently be launched with a single worker because multi-worker cold starts can hit compilation race conditions.
+The OCR example should currently be launched with a single worker because it starts both Dots OCR and Qwen VLM services for the same job.
 
 Other models can still be used, but the first startup is usually slower.
 
@@ -96,3 +97,4 @@ At the moment, VLLM deployments run on `1x H100`, which limits the model sizes t
 
 - Direct endpoint example: [examples/inference_endpoint.py](/Users/hynky/.codex/worktrees/ab9a/refiner/examples/inference_endpoint.py)
 - VLLM-backed example: [examples/inference_vllm.py](/Users/hynky/.codex/worktrees/ab9a/refiner/examples/inference_vllm.py)
+- PDF OCR example: [examples/ocr_dots_pdf.py](/Users/hynky/.codex/worktrees/ab9a/refiner/examples/ocr_dots_pdf.py)

--- a/examples/ocr_dots_pdf.py
+++ b/examples/ocr_dots_pdf.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import refiner as mdr
+from refiner.pipeline.data.row import Row
+
+DEFAULT_OUTPUT_PATH = "output/dots-pdf-ocr.jsonl"
+DOTS_MODEL = "rednote-hilab/dots.mocr"
+QWEN_BLANK_MODEL = "Qwen/Qwen3.5-4B"
+DOTS_IMAGE_MARKER = "<|img|><|imgpad|><|endofimg|>"
+DOTS_PROVIDER = mdr.inference.VLLMProvider(model=DOTS_MODEL)
+QWEN_PROVIDER = mdr.inference.VLLMProvider(model=QWEN_BLANK_MODEL)
+
+
+def render_pdf_pages(row: Row) -> Iterable[dict[str, Any]]:
+    try:
+        fitz = importlib.import_module("fitz")
+    except ImportError as exc:
+        raise RuntimeError(
+            "PDF rendering requires PyMuPDF. Install it in the worker image before "
+            "running this example."
+        ) from exc
+
+    pdf_path = Path(str(row["pdf_path"]))
+    zoom = float(row.get("zoom", 2.0))
+    matrix = fitz.Matrix(zoom, zoom)
+    with fitz.open(pdf_path) as document:
+        for page_index, page in enumerate(document):
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            png_bytes = pixmap.tobytes("png")
+            yield {
+                "pdf_path": str(pdf_path),
+                "page_index": page_index,
+                "image_data_url": _image_data_url(png_bytes),
+            }
+
+
+async def transcribe_page(row, generate):
+    response = await generate(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": row["image_data_url"]},
+                        },
+                        {
+                            "type": "text",
+                            "text": (
+                                f"{DOTS_IMAGE_MARKER}Extract the text content from this page. "
+                                "Return only the page text."
+                            ),
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    text = response.text.strip()
+    return {
+        **row,
+        "text": text,
+        "ocr_finish_reason": response.finish_reason,
+    }
+
+
+def add_repetition_flags(row: Row) -> dict[str, Any]:
+    text = str(row.get("text", ""))
+    return {
+        **row,
+        "starts_with_the": text.lstrip().startswith("The "),
+        "has_repetition": has_repetition(text),
+        "text_chars": len(text),
+    }
+
+
+def keep_after_repetition_check(row: Row) -> bool:
+    return bool(row.get("text")) and not bool(row.get("has_repetition"))
+
+
+async def check_blank_page_candidate(row, generate):
+    if not bool(row.get("starts_with_the")):
+        return {**row, "blank_page_check": "skipped", "is_blank_page": False}
+
+    response = await generate(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": row["image_data_url"]},
+                        },
+                        {
+                            "type": "text",
+                            "text": (
+                                "Decide whether this PDF page is blank or only contains "
+                                "non-content marks. Reply as JSON with exactly "
+                                '{"is_blank_page": true|false}.'
+                            ),
+                        },
+                    ],
+                }
+            ],
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        }
+    )
+    is_blank = parse_blank_page_response(response.text)
+    return {
+        **row,
+        "blank_page_check": response.text.strip(),
+        "is_blank_page": is_blank,
+    }
+
+
+def keep_after_blank_check(row: Row) -> bool:
+    return not bool(row.get("is_blank_page"))
+
+
+def to_output_row(row: Row) -> dict[str, Any]:
+    return {
+        "pdf_path": row["pdf_path"],
+        "page_index": row["page_index"],
+        "text": row["text"],
+        "text_chars": row["text_chars"],
+        "starts_with_the": row["starts_with_the"],
+        "has_repetition": row["has_repetition"],
+        "blank_page_check": row["blank_page_check"],
+    }
+
+
+def has_repetition(text: str) -> bool:
+    lines = [line.strip() for line in text.splitlines() if len(line.strip()) >= 12]
+    line_counts: dict[str, int] = {}
+    for line in lines:
+        line_counts[line] = line_counts.get(line, 0) + 1
+        if line_counts[line] >= 3:
+            return True
+
+    normalized = " ".join(text.split())
+    if len(normalized) < 120:
+        return False
+
+    words = normalized.split()
+    for window_size in (4, 6, 8):
+        if _has_repeated_word_window(words, window_size=window_size, min_repeats=4):
+            return True
+    return False
+
+
+def parse_blank_page_response(raw: str) -> bool:
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        cleaned = cleaned.removeprefix("json").strip()
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        lowered = cleaned.lower()
+        return '"is_blank_page": true' in lowered or "is_blank_page: true" in lowered
+    if not isinstance(parsed, dict):
+        return False
+    return bool(parsed.get("is_blank_page"))
+
+
+def build_pipeline(
+    pdf_paths: list[str],
+    *,
+    output_path: str = DEFAULT_OUTPUT_PATH,
+    zoom: float = 2.0,
+):
+    rows = [{"pdf_path": pdf_path, "zoom": zoom} for pdf_path in pdf_paths]
+    return (
+        mdr.from_items(rows)
+        .flat_map(render_pdf_pages)
+        .map_async(
+            mdr.inference.generate(
+                fn=transcribe_page,
+                provider=DOTS_PROVIDER,
+                default_generation_params={"temperature": 0.0, "max_tokens": 4096},
+                max_concurrent_requests=64,
+            ),
+            max_in_flight=64,
+            preserve_order=False,
+        )
+        .map(add_repetition_flags)
+        .filter(keep_after_repetition_check)
+        .map_async(
+            mdr.inference.generate(
+                fn=check_blank_page_candidate,
+                provider=QWEN_PROVIDER,
+                default_generation_params={"temperature": 0.0, "max_tokens": 128},
+                max_concurrent_requests=32,
+            ),
+            max_in_flight=32,
+            preserve_order=False,
+        )
+        .filter(keep_after_blank_check)
+        .map(to_output_row)
+        .write_jsonl(output_path)
+    )
+
+
+def _has_repeated_word_window(
+    words: list[str], *, window_size: int, min_repeats: int
+) -> bool:
+    if len(words) < window_size * min_repeats:
+        return False
+    counts: dict[tuple[str, ...], int] = {}
+    for index in range(0, len(words) - window_size + 1):
+        window = tuple(words[index : index + window_size])
+        counts[window] = counts.get(window, 0) + 1
+        if counts[window] >= min_repeats:
+            return True
+    return False
+
+
+def _image_data_url(png_bytes: bytes) -> str:
+    encoded = base64.b64encode(png_bytes).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OCR PDFs with Dots OCR on Refiner.")
+    parser.add_argument("pdf", nargs="+", help="PDF file paths to transcribe.")
+    parser.add_argument(
+        "--output", default=DEFAULT_OUTPUT_PATH, help="Output JSONL path."
+    )
+    parser.add_argument(
+        "--zoom", type=float, default=2.0, help="PDF render zoom factor."
+    )
+    parser.add_argument("--workers", type=int, default=1, help="Cloud worker count.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    build_pipeline(args.pdf, output_path=args.output, zoom=args.zoom).launch_cloud(
+        name="dots-pdf-ocr",
+        num_workers=args.workers,
+    )

--- a/tests/test_ocr_dots_pdf_example.py
+++ b/tests/test_ocr_dots_pdf_example.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_example_module():
+    path = Path(__file__).resolve().parents[1] / "examples" / "ocr_dots_pdf.py"
+    spec = importlib.util.spec_from_file_location("ocr_dots_pdf", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repetition_check_flags_repeated_lines() -> None:
+    example = _load_example_module()
+    text = "\n".join(["Repeated OCR header"] * 3)
+
+    assert example.has_repetition(text)
+
+
+def test_repetition_check_allows_short_normal_text() -> None:
+    example = _load_example_module()
+
+    assert not example.has_repetition("A concise page of normal text.")
+
+
+def test_blank_page_response_parser_accepts_json() -> None:
+    example = _load_example_module()
+
+    assert example.parse_blank_page_response('{"is_blank_page": true}')
+    assert not example.parse_blank_page_response('{"is_blank_page": false}')
+
+
+def test_pipeline_uses_dots_and_qwen_runtime_services() -> None:
+    example = _load_example_module()
+    from refiner.services.discovery import collect_pipeline_services
+
+    pipeline = example.build_pipeline(["sample.pdf"], output_path="output/test.jsonl")
+    services = collect_pipeline_services(pipeline)
+
+    models = {service.config["model_name_or_path"] for service in services}
+    assert models == {"rednote-hilab/dots.mocr", "Qwen/Qwen3.5-4B"}


### PR DESCRIPTION
## Summary
- add a simplified Refiner PDF OCR example using rednote-hilab/dots.mocr
- filter repeated OCR output and run Qwen/Qwen3.5-4B blank-page checks for pages starting with "The "
- document the OCR example in inference docs

## Verification
- uv run ruff format examples/ocr_dots_pdf.py tests/test_ocr_dots_pdf_example.py
- uv run ruff check examples/ocr_dots_pdf.py tests/test_ocr_dots_pdf_example.py
- uv run ty check examples/ocr_dots_pdf.py tests/test_ocr_dots_pdf_example.py
- uv run pytest tests/test_ocr_dots_pdf_example.py
- pre-commit hook passed