### PR TITLE
[codex] add Arrow-backed datatype metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "cloudpickle==3.1.2",
-    "fsspec",
+    "fsspec[http]",
     "httpx",
     "loguru",
     "numpy",

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -4,6 +4,7 @@ import refiner.pipeline as pipeline
 import refiner.robotics as robotics
 import refiner.text as text
 import refiner.video as video
+from refiner.pipeline.data import datatype
 from refiner.pipeline import (
     from_items,
     from_source,
@@ -54,4 +55,5 @@ __all__ = [
     "robot",
     "robotics",
     "text",
+    "datatype",
 ]

--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -214,7 +214,7 @@ def _row_segment_schema(
         )
         if not dtypes:
             continue
-        schema = schema_with_dtypes(schema, dtypes)
+        schema = schema_with_dtypes(schema, dtypes, preserve_metadata=False)
     return schema
 
 

--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -8,8 +8,23 @@ from typing import cast
 import pyarrow as pa
 
 from refiner.pipeline.data.block import Block, StreamItem
+from refiner.pipeline.data.datatype import schema_with_dtypes
 from refiner.pipeline.data.tabular import Tabular
-from refiner.pipeline.steps import RefinerStep, VectorizedOp, VectorizedSegmentStep
+from refiner.pipeline.steps import (
+    CastStep,
+    DropStep,
+    FnAsyncRowStep,
+    FnBatchStep,
+    FnFlatMapStep,
+    FnRowStep,
+    FnTableStep,
+    RenameStep,
+    RefinerStep,
+    SelectStep,
+    VectorizedOp,
+    VectorizedSegmentStep,
+    WithColumnsStep,
+)
 from refiner.execution.buffer import RowBuffer
 from refiner.execution.operators.row import ShardDeltaFn, execute_row_steps
 from refiner.execution.operators.vectorized import (
@@ -58,11 +73,15 @@ def execute_segments(
     vectorized_chunk_rows: int = _DEFAULT_VECTORIZED_CHUNK_ROWS,
     max_vectorized_block_bytes: int | None = None,
     on_shard_delta: ShardDeltaFn | None = None,
+    input_schema: pa.Schema | None = None,
+    final_output_tabular: bool = False,
 ) -> Iterator[Block]:
+    """Execute segments, optionally converting final row blocks to `Tabular` blocks."""
     current: Iterable[Block] = _normalize_blocks(
         stream,
         block_rows=vectorized_chunk_rows,
     )
+    current_schema = input_schema
     for idx, segment in enumerate(segments):
         next_segment = segments[idx + 1] if idx + 1 < len(segments) else None
         if isinstance(segment, VectorSegment):
@@ -72,16 +91,24 @@ def execute_segments(
                 vectorized_chunk_rows=vectorized_chunk_rows,
                 max_vectorized_block_bytes=max_vectorized_block_bytes,
                 on_shard_delta=on_shard_delta,
+                input_schema=current_schema,
             )
+            current_schema = _vector_segment_schema(current_schema, segment.ops)
         else:
+            output_schema = _row_segment_schema(current_schema, segment.steps)
             current = _execute_row_segment(
                 current,
                 segment.steps,
                 output_block_rows=vectorized_chunk_rows,
-                output_tabular=isinstance(next_segment, VectorSegment),
-                max_vectorized_block_bytes=max_vectorized_block_bytes,
+                output_tabular=isinstance(next_segment, VectorSegment)
+                and max_vectorized_block_bytes is None,
                 on_shard_delta=on_shard_delta,
+                output_schema=output_schema,
             )
+            current_schema = output_schema
+    if final_output_tabular:
+        yield from _tabularize_blocks(current, schema=current_schema)
+        return
     yield from current
 
 
@@ -154,24 +181,96 @@ def _execute_row_segment(
     *,
     output_block_rows: int,
     output_tabular: bool,
-    max_vectorized_block_bytes: int | None,
     on_shard_delta: ShardDeltaFn | None,
+    output_schema: pa.Schema | None,
 ) -> Iterator[Block]:
     # Row/UDF execution consumes row views and emits row blocks for downstream
     # vectorized segments (or final row iteration).
     rows = iter_rows(stream)
     step_out = execute_row_steps(rows, steps, on_shard_delta=on_shard_delta)
-    if not output_tabular or max_vectorized_block_bytes is not None:
+    if not output_tabular:
         yield from _chunk_output_rows(step_out, output_block_rows)
         return
     for batch in _chunk_output_rows(step_out, output_block_rows):
         block = (
-            Tabular.from_rows(batch)
+            Tabular.from_rows(batch, schema=output_schema)
             if not batch
-            else batch[0].tabular_type.from_rows(batch)
+            else batch[0].tabular_type.from_rows(batch, schema=output_schema)
         )
         if block.table.num_rows > 0:
             yield block
+
+
+def _row_segment_schema(
+    input_schema: pa.Schema | None,
+    steps: Sequence[RefinerStep],
+) -> pa.Schema | None:
+    schema = input_schema
+    for step in steps:
+        dtypes = (
+            step.dtypes
+            if isinstance(step, (FnRowStep, FnAsyncRowStep, FnBatchStep, FnFlatMapStep))
+            else None
+        )
+        if not dtypes:
+            continue
+        schema = schema_with_dtypes(schema, dtypes)
+    return schema
+
+
+def _vector_segment_schema(
+    input_schema: pa.Schema | None,
+    ops: Sequence[VectorizedOp],
+) -> pa.Schema | None:
+    schema = input_schema
+    for op in ops:
+        if isinstance(op, FnTableStep):
+            schema = None
+            continue
+        if isinstance(op, CastStep):
+            schema = schema_with_dtypes(
+                schema,
+                op.dtypes,
+                preserve_metadata=False,
+            )
+            continue
+        if schema is None:
+            continue
+        if isinstance(op, SelectStep):
+            fields = [
+                schema.field(idx)
+                for name in op.columns
+                if (idx := schema.get_field_index(name)) >= 0
+            ]
+            schema = pa.schema(
+                fields,
+                metadata=schema.metadata,
+            )
+            continue
+        if isinstance(op, DropStep):
+            drop = set(op.columns)
+            schema = pa.schema(
+                [field for field in schema if field.name not in drop],
+                metadata=schema.metadata,
+            )
+            continue
+        if isinstance(op, RenameStep):
+            schema = pa.schema(
+                [
+                    field.with_name(op.mapping.get(field.name, field.name))
+                    for field in schema
+                ],
+                metadata=schema.metadata,
+            )
+            continue
+        if isinstance(op, WithColumnsStep):
+            assigned = set(op.assignments)
+            schema = pa.schema(
+                [field for field in schema if field.name not in assigned],
+                metadata=schema.metadata,
+            )
+            continue
+    return schema
 
 
 def _execute_vector_segment(
@@ -181,6 +280,7 @@ def _execute_vector_segment(
     vectorized_chunk_rows: int,
     max_vectorized_block_bytes: int | None,
     on_shard_delta: ShardDeltaFn | None,
+    input_schema: pa.Schema | None,
 ) -> Iterator[Tabular]:
     pending_rows = RowBuffer()
     current_chunk_rows = max(1, int(vectorized_chunk_rows))
@@ -208,9 +308,9 @@ def _execute_vector_segment(
             batch = pending_rows.peek(rows_for_try)
             try:
                 block = (
-                    Tabular.from_rows(batch)
+                    Tabular.from_rows(batch, schema=input_schema)
                     if not batch
-                    else batch[0].tabular_type.from_rows(batch)
+                    else batch[0].tabular_type.from_rows(batch, schema=input_schema)
                 )
             except pa.ArrowMemoryError:
                 if rows_for_try <= 1:
@@ -323,6 +423,24 @@ def _chunk_output_rows(rows: Iterable[Row], block_rows: int) -> Iterator[list[Ro
             yield out
     if pending:
         yield pending
+
+
+def _tabularize_blocks(
+    blocks: Iterable[Block],
+    *,
+    schema: pa.Schema | None,
+) -> Iterator[Tabular]:
+    for block in blocks:
+        if isinstance(block, Tabular):
+            yield block
+            continue
+        table = (
+            Tabular.from_rows(block, schema=schema)
+            if not block
+            else block[0].tabular_type.from_rows(block, schema=schema)
+        )
+        if table.num_rows > 0:
+            yield table
 
 
 __all__ = [

--- a/src/refiner/execution/operators/vectorized.py
+++ b/src/refiner/execution/operators/vectorized.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from refiner.execution.tracking.shards import (
     ShardDeltaFn,
     count_table_by_shard,
     counts_delta,
 )
-from refiner.pipeline.data.tabular import filter_table, repeat_scalar
+from refiner.pipeline.data.datatype import apply_dtypes_to_table
+from refiner.pipeline.data.tabular import (
+    filter_table,
+    repeat_scalar,
+)
 from refiner.pipeline.expressions import eval_expr_arrow
 from refiner.pipeline.steps import (
     CastStep,
@@ -46,14 +49,11 @@ def apply_vectorized_op(
         return table.rename_columns(names), None
 
     if isinstance(op, CastStep):
-        out = table
-        for col_name, dtype in op.dtypes.items():
-            idx = out.schema.get_field_index(col_name)
-            if idx < 0:
-                raise KeyError(f"Unknown column for cast: {col_name}")
-            casted = pc.cast(out.column(col_name), target_type=pa.type_for_alias(dtype))
-            out = out.set_column(idx, col_name, casted)
-        return out, None
+        return apply_dtypes_to_table(
+            table,
+            op.dtypes,
+            preserve_metadata=False,
+        ), None
 
     if isinstance(op, WithColumnsStep):
         out = table
@@ -65,7 +65,7 @@ def apply_vectorized_op(
             if idx < 0:
                 out = out.append_column(col_name, values)
             else:
-                out = out.set_column(idx, col_name, values)
+                out = out.set_column(idx, pa.field(col_name, values.type), values)
         return out, None
 
     if isinstance(op, FilterExprStep):

--- a/src/refiner/pipeline/data/datatype.py
+++ b/src/refiner/pipeline/data/datatype.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import builtins
+from collections.abc import Mapping, Sequence
+from typing import TypeAlias, cast
+
+import pyarrow as pa
+
+_ASSET_TYPE_METADATA_KEY = b"asset_type"
+_FILE_ASSET_TYPES = frozenset({b"unknown", b"image", b"audio", b"video", b"pdf"})
+_FILE_FIELD_NAME = "__refiner_file__"
+
+DTypeLike: TypeAlias = str | pa.DataType | pa.Field
+DTypeMapping: TypeAlias = Mapping[str, DTypeLike]
+
+
+null = pa.null
+bool = pa.bool_
+int8 = pa.int8
+int16 = pa.int16
+int32 = pa.int32
+int64 = pa.int64
+uint8 = pa.uint8
+uint16 = pa.uint16
+uint32 = pa.uint32
+uint64 = pa.uint64
+float32 = pa.float32
+float64 = pa.float64
+string = pa.string
+large_string = pa.large_string
+binary = pa.binary
+large_binary = pa.large_binary
+duration = pa.duration
+
+
+def date() -> pa.DataType:
+    return pa.date32()
+
+
+def time(unit: str = "us") -> pa.DataType:
+    return pa.time32(unit) if unit in {"s", "ms"} else pa.time64(unit)
+
+
+def timestamp(unit: str = "us", timezone: str | None = None) -> pa.DataType:
+    return pa.timestamp(unit, tz=timezone)
+
+
+def list(dtype: DTypeLike, size: int | None = None) -> pa.DataType:
+    child = _child_type_or_field(dtype)
+    return pa.list_(child) if size is None else pa.list_(child, list_size=size)
+
+
+def large_list(dtype: DTypeLike) -> pa.DataType:
+    return pa.large_list(_child_type_or_field(dtype))
+
+
+def struct(
+    fields: Mapping[str, DTypeLike] | Sequence[pa.Field | tuple[str, DTypeLike]],
+) -> pa.DataType:
+    if isinstance(fields, Mapping):
+        mapping = cast(Mapping[str, DTypeLike], fields)
+        arrow_fields = [_to_field(name, dtype) for name, dtype in mapping.items()]
+    else:
+        arrow_fields = [
+            item if isinstance(item, pa.Field) else _to_field(item[0], item[1])
+            for item in fields
+        ]
+    return pa.struct(arrow_fields)
+
+
+def map(key_type: DTypeLike, value_type: DTypeLike) -> pa.DataType:
+    return pa.map_(_arrow_type(key_type), _arrow_type(value_type))
+
+
+def file() -> pa.Field:
+    return _file_field(b"unknown")
+
+
+def image_file() -> pa.Field:
+    return _file_field(b"image")
+
+
+def audio_file() -> pa.Field:
+    return _file_field(b"audio")
+
+
+def video_file() -> pa.Field:
+    return _file_field(b"video")
+
+
+def pdf_file() -> pa.Field:
+    return _file_field(b"pdf")
+
+
+def schema_with_dtypes(
+    schema: pa.Schema | None,
+    dtypes: DTypeMapping | None,
+    *,
+    preserve_metadata: builtins.bool = True,
+) -> pa.Schema | None:
+    if not dtypes:
+        return schema
+
+    fields = builtins.list(schema) if schema is not None else []
+    index_by_name = {field.name: idx for idx, field in enumerate(fields)}
+    for name, dtype in dtypes.items():
+        idx = index_by_name.get(name)
+        if idx is None:
+            index_by_name[name] = len(fields)
+            fields.append(_to_field(name, dtype))
+            continue
+        fields[idx] = _replace_field_dtype(
+            fields[idx],
+            dtype,
+            preserve_metadata=preserve_metadata,
+        )
+    return pa.schema(fields, metadata=schema.metadata if schema is not None else None)
+
+
+def apply_dtypes_to_table(
+    table: pa.Table,
+    dtypes: DTypeMapping | None,
+    *,
+    strict: builtins.bool = True,
+    preserve_metadata: builtins.bool = True,
+) -> pa.Table:
+    if not dtypes:
+        return table
+    out = table
+    for name, dtype in dtypes.items():
+        idx = out.schema.get_field_index(name)
+        if idx < 0:
+            if strict:
+                raise KeyError(f"Unknown column for dtype: {name}")
+            continue
+        field = _replace_field_dtype(
+            out.schema.field(idx),
+            dtype,
+            preserve_metadata=preserve_metadata,
+        )
+        column = out.column(idx)
+        if column.type != field.type:
+            column = column.cast(field.type)
+        if out.schema.field(idx).equals(field, check_metadata=True):
+            continue
+        out = out.set_column(idx, field, column)
+    return out
+
+
+def is_file_field(field: pa.Field) -> builtins.bool:
+    metadata = field.metadata or {}
+    return metadata.get(_ASSET_TYPE_METADATA_KEY) in _FILE_ASSET_TYPES
+
+
+def dtype_to_plan(dtype: DTypeLike) -> str | dict[str, object]:
+    if isinstance(dtype, str):
+        return dtype
+    if isinstance(dtype, pa.DataType):
+        return str(dtype)
+    if isinstance(dtype, pa.Field):
+        out: dict[str, object] = {"type": str(dtype.type)}
+        if dtype.metadata:
+            out["metadata"] = {
+                key.decode("utf-8", errors="replace"): value.decode(
+                    "utf-8",
+                    errors="replace",
+                )
+                for key, value in dtype.metadata.items()
+            }
+        return out
+    raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
+
+
+def _file_field(asset_type: bytes) -> pa.Field:
+    return pa.field(
+        _FILE_FIELD_NAME,
+        pa.string(),
+        metadata={_ASSET_TYPE_METADATA_KEY: asset_type},
+    )
+
+
+def _replace_field_dtype(
+    field: pa.Field,
+    dtype: DTypeLike,
+    *,
+    preserve_metadata: builtins.bool = True,
+) -> pa.Field:
+    if isinstance(dtype, pa.Field):
+        metadata = dict(field.metadata or {}) if preserve_metadata else {}
+        if dtype.metadata:
+            metadata.update(dtype.metadata)
+        return pa.field(
+            field.name,
+            dtype.type,
+            nullable=field.nullable,
+            metadata=metadata or None,
+        )
+    if isinstance(dtype, pa.DataType):
+        return pa.field(
+            field.name,
+            dtype,
+            nullable=field.nullable,
+            metadata=field.metadata if preserve_metadata else None,
+        )
+    if isinstance(dtype, str):
+        return pa.field(
+            field.name,
+            pa.type_for_alias(dtype),
+            nullable=field.nullable,
+            metadata=field.metadata if preserve_metadata else None,
+        )
+    raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
+
+
+def _to_field(name: str, dtype: DTypeLike) -> pa.Field:
+    if isinstance(dtype, pa.Field):
+        return dtype.with_name(name)
+    if isinstance(dtype, pa.DataType):
+        return pa.field(name, dtype)
+    if isinstance(dtype, str):
+        return pa.field(name, pa.type_for_alias(dtype))
+    raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
+
+
+def _child_type_or_field(dtype: DTypeLike) -> pa.DataType | pa.Field:
+    if isinstance(dtype, pa.Field):
+        return dtype.with_name("item")
+    if isinstance(dtype, pa.DataType):
+        return dtype
+    if isinstance(dtype, str):
+        return pa.type_for_alias(dtype)
+    raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
+
+
+def _arrow_type(dtype: DTypeLike) -> pa.DataType:
+    if isinstance(dtype, pa.Field):
+        return dtype.type
+    if isinstance(dtype, pa.DataType):
+        return dtype
+    if isinstance(dtype, str):
+        return pa.type_for_alias(dtype)
+    raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
+
+
+__all__ = [
+    "DTypeLike",
+    "DTypeMapping",
+    "apply_dtypes_to_table",
+    "audio_file",
+    "binary",
+    "bool",
+    "date",
+    "dtype_to_plan",
+    "duration",
+    "file",
+    "float32",
+    "float64",
+    "image_file",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "is_file_field",
+    "large_binary",
+    "large_list",
+    "large_string",
+    "list",
+    "map",
+    "null",
+    "pdf_file",
+    "schema_with_dtypes",
+    "string",
+    "struct",
+    "time",
+    "timestamp",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "video_file",
+]

--- a/src/refiner/pipeline/data/tabular.py
+++ b/src/refiner/pipeline/data/tabular.py
@@ -24,19 +24,27 @@ class Tabular:
         self.shard_idx = self.index_by_name.get(SHARD_ID_COLUMN)
 
     @classmethod
-    def from_rows(cls, rows: Sequence[Row]) -> "Tabular":
+    def from_rows(
+        cls,
+        rows: Sequence[Row],
+        *,
+        schema: pa.Schema | None = None,
+    ) -> "Tabular":
         if not rows:
             return cls(pa.table({}))
         if all(_is_arrow_backed(row) for row in rows):
             # Fast path for Arrow-backed rows: sort by backing tabular source and row index so
             # we can rebuild with slice/take instead of materializing every cell in Python.
-            tables = _arrow_tables_from_rows(_sorted_arrow_rows(rows))
+            tables = _arrow_tables_from_rows(
+                _sorted_arrow_rows(rows),
+                schema=schema,
+            )
             if len(tables) == 1:
                 return cls(tables[0])
-            return cls(pa.concat_tables(tables))
+            return cls(_concat_tables(tables))
         # Generic row fallback. A union-of-names pass plus row.get(...) was as fast as the
         # earlier DictRow-specific special case and simpler to keep correct for mixed rows.
-        return cls(_table_from_rows(rows))
+        return cls(_table_from_rows(rows, schema=schema))
 
     @classmethod
     def from_batch(cls, batch: pa.RecordBatch) -> "Tabular":
@@ -86,7 +94,16 @@ def set_or_append_column(
     column: pa.Array | pa.ChunkedArray,
 ) -> pa.Table:
     if name in table.column_names:
-        return table.set_column(table.column_names.index(name), name, column)
+        idx = table.column_names.index(name)
+        current = table.schema.field(idx)
+        metadata = current.metadata if current.type == column.type else None
+        field = pa.field(
+            name,
+            column.type,
+            nullable=current.nullable or column.null_count > 0,
+            metadata=metadata,
+        )
+        return table.set_column(idx, field, column)
     return table.append_column(name, column)
 
 
@@ -106,7 +123,11 @@ def filter_table(table: pa.Table, predicate: Expr) -> pa.Table:
 
 
 # everything below is for fast from_rows
-def _table_from_rows(rows: Sequence[Row]) -> pa.Table:
+def _table_from_rows(
+    rows: Sequence[Row],
+    *,
+    schema: pa.Schema | None = None,
+) -> pa.Table:
     names: list[str] = []
     seen: set[str] = set()
     for row in rows:
@@ -115,10 +136,43 @@ def _table_from_rows(rows: Sequence[Row]) -> pa.Table:
                 continue
             seen.add(name)
             names.append(name)
-    columns = {name: [row.get(name) for row in rows] for name in names}
+    if schema is None:
+        columns = {name: [row.get(name) for row in rows] for name in names}
+        if any(row.shard_id is not None for row in rows):
+            columns[SHARD_ID_COLUMN] = [row.shard_id for row in rows]
+        return pa.table(columns)
+
+    arrays: dict[str, pa.Array] = {}
+    metadata_by_name: dict[str, dict[bytes, bytes]] = {}
+    for name in names:
+        schema_field = _schema_field(schema, name)
+        column, field_metadata = _array_from_values(
+            [row.get(name) for row in rows],
+            schema_field.type if schema_field is not None else None,
+            schema_field.metadata if schema_field is not None else None,
+        )
+        arrays[name] = column
+        if field_metadata:
+            metadata_by_name[name] = field_metadata
     if any(row.shard_id is not None for row in rows):
-        columns[SHARD_ID_COLUMN] = [row.shard_id for row in rows]
-    return pa.table(columns)
+        arrays[SHARD_ID_COLUMN] = pa.array(
+            [row.shard_id for row in rows],
+            type=pa.string(),
+        )
+    if not metadata_by_name:
+        return pa.table(arrays)
+    fields = [
+        pa.field(name, column.type, metadata=metadata_by_name.get(name))
+        for name, column in arrays.items()
+    ]
+    return pa.table(arrays, schema=pa.schema(fields))
+
+
+def _concat_tables(tables: Sequence[pa.Table]) -> pa.Table:
+    try:
+        return pa.concat_tables(tables)
+    except pa.ArrowInvalid:
+        return pa.concat_tables(tables, promote_options="default")
 
 
 def _sorted_arrow_rows(rows: Sequence[Row]) -> Sequence[Row]:
@@ -132,15 +186,12 @@ def _sorted_arrow_rows(rows: Sequence[Row]) -> Sequence[Row]:
     )
 
 
-def _arrow_tables_from_rows(rows: Sequence[Row]) -> list[pa.Table]:
+def _arrow_tables_from_rows(
+    rows: Sequence[Row],
+    *,
+    schema: pa.Schema | None = None,
+) -> list[pa.Table]:
     tables: list[pa.Table] = []
-    # Pristine Arrow batches do not need any overlay bookkeeping; skipping it improved the
-    # plain Arrow cases without affecting patched batches.
-    changed_specs = (
-        _overlay_changed_specs(rows)
-        if any(isinstance(row, _OverlayRow) for row in rows)
-        else []
-    )
     group_start = 0
     while group_start < len(rows):
         first = rows[group_start]
@@ -157,14 +208,19 @@ def _arrow_tables_from_rows(rows: Sequence[Row]) -> list[pa.Table]:
                 break
             group_end += 1
         tables.append(
-            _arrow_table_from_group(rows[group_start:group_end], changed_specs)
+            _arrow_table_from_group(
+                rows[group_start:group_end],
+                schema=schema,
+            )
         )
         group_start = group_end
     return tables
 
 
 def _arrow_table_from_group(
-    rows: Sequence[Row], changed_specs: list[tuple[str, pa.DataType]]
+    rows: Sequence[Row],
+    *,
+    schema: pa.Schema | None = None,
 ) -> pa.Table:
     sample = _base_arrow_row(rows[0])
     base = sample.tabular.table
@@ -185,21 +241,64 @@ def _arrow_table_from_group(
     else:
         table = base.take(pa.array(row_indices, type=pa.int64()))
 
-    changed_columns = _overlay_changes_by_column(rows)
-    for name, value_type in changed_specs:
-        changes = changed_columns.get(name, [])
+    changed_columns = (
+        _overlay_changes_by_column(rows)
+        if any(isinstance(row, _OverlayRow) for row in rows)
+        else {}
+    )
+    if schema is None and not changed_columns:
+        return _with_shard_id(table, rows[0].shard_id, len(rows))
+
+    for name, changes in changed_columns.items():
+        if all(name not in row for row in rows):
+            if name in table.column_names:
+                table = table.drop([name])
+            continue
+
+        schema_field = _schema_field(schema, name)
+        value_type = schema_field.type if schema_field is not None else None
         if name in table.column_names:
             values = table[name].to_pylist()
         else:
             values = [None] * len(rows)
         for idx, value in changes:
             values[idx] = value
-        column = pa.array(values, type=value_type)
-        table = set_or_append_column(table, name, column)
+        column, field_metadata = _array_from_values(
+            values,
+            value_type,
+            schema_field.metadata if schema_field is not None else None,
+        )
+        if schema_field is not None:
+            field = pa.field(name, column.type, metadata=field_metadata)
+            if name in table.column_names:
+                table = table.set_column(table.column_names.index(name), field, column)
+            else:
+                table = table.append_column(field, column)
+        elif name in table.column_names:
+            table = table.set_column(
+                table.column_names.index(name),
+                pa.field(name, column.type),
+                column,
+            )
+        else:
+            table = set_or_append_column(table, name, column)
 
-    shard_id = rows[0].shard_id
+    table = _apply_schema_to_unchanged_columns(
+        table,
+        schema=schema,
+        changed_names=set(changed_columns),
+    )
+
+    return _with_shard_id(table, rows[0].shard_id, len(rows))
+
+
+def _with_shard_id(
+    table: pa.Table,
+    shard_id: str | None,
+    num_rows: int,
+) -> pa.Table:
     if shard_id is not None:
-        shard_col = pa.array([shard_id] * len(rows), type=pa.string())
+        shard_col = pa.array([shard_id] * num_rows, type=pa.string())
         table = set_or_append_column(table, SHARD_ID_COLUMN, shard_col)
     return table
 
@@ -219,23 +318,59 @@ def _overlay_changes_by_column(
     return changes
 
 
-def _overlay_changed_specs(rows: Sequence[Row]) -> list[tuple[str, pa.DataType]]:
-    specs: list[tuple[str, pa.DataType]] = []
-    seen: set[str] = set()
-    for row in rows:
-        if not isinstance(row, _OverlayRow):
+def _schema_field(schema: pa.Schema | None, name: str) -> pa.Field | None:
+    if schema is None:
+        return None
+    idx = schema.get_field_index(name)
+    return schema.field(idx) if idx >= 0 else None
+
+
+def _apply_schema_to_unchanged_columns(
+    table: pa.Table,
+    *,
+    schema: pa.Schema | None,
+    changed_names: set[str],
+) -> pa.Table:
+    if schema is None:
+        return table
+
+    out = table
+    for field in schema:
+        name = field.name
+        if name in changed_names:
             continue
-        for name in row.patch:
-            if name in seen:
-                continue
-            seen.add(name)
-            specs.append((name, pa.scalar(row.patch[name]).type))
-        for name in row.deleted:
-            if name in seen:
-                continue
-            seen.add(name)
-            specs.append((name, _base_arrow_row(row).tabular.table[name].type))
-    return specs
+        idx = out.schema.get_field_index(name)
+        if idx < 0:
+            continue
+        column = out.column(name)
+        try:
+            if column.type != field.type:
+                column = column.cast(field.type)
+            replacement = pa.field(
+                name,
+                column.type,
+                nullable=field.nullable,
+                metadata=field.metadata,
+            )
+        except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):
+            replacement = pa.field(name, column.type)
+        if out.schema.field(idx).equals(replacement, check_metadata=True):
+            continue
+        out = out.set_column(idx, replacement, column)
+    return out
+
+
+def _array_from_values(
+    values: Sequence[object],
+    value_type: pa.DataType | None,
+    metadata: dict[bytes, bytes] | None,
+) -> tuple[pa.Array, dict[bytes, bytes] | None]:
+    if value_type is None:
+        return pa.array(values), None
+    try:
+        return pa.array(values, type=value_type), dict(metadata) if metadata else None
+    except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):
+        return pa.array(values), None
 
 
 def _is_arrow_backed(row: Row) -> bool:

--- a/src/refiner/pipeline/data/tabular.py
+++ b/src/refiner/pipeline/data/tabular.py
@@ -256,7 +256,9 @@ def _arrow_table_from_group(
             continue
 
         schema_field = _schema_field(schema, name)
-        value_type = schema_field.type if schema_field is not None else None
+        base_field = _schema_field(base.schema, name)
+        field = schema_field if schema_field is not None else base_field
+        value_type = field.type if field is not None else None
         if name in table.column_names:
             values = table[name].to_pylist()
         else:
@@ -266,7 +268,7 @@ def _arrow_table_from_group(
         column, field_metadata = _array_from_values(
             values,
             value_type,
-            schema_field.metadata if schema_field is not None else None,
+            field.metadata if field is not None else None,
         )
         if schema_field is not None:
             field = pa.field(name, column.type, metadata=field_metadata)
@@ -277,7 +279,7 @@ def _arrow_table_from_group(
         elif name in table.column_names:
             table = table.set_column(
                 table.column_names.index(name),
-                pa.field(name, column.type),
+                pa.field(name, column.type, metadata=field_metadata),
                 column,
             )
         else:
@@ -370,7 +372,13 @@ def _array_from_values(
     try:
         return pa.array(values, type=value_type), dict(metadata) if metadata else None
     except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):
-        return pa.array(values), None
+        inferred = pa.array(values)
+        if metadata and b"asset_type" in metadata:
+            return inferred, None
+        try:
+            return inferred.cast(value_type), dict(metadata) if metadata else None
+        except (pa.ArrowInvalid, pa.ArrowTypeError, TypeError):
+            return inferred, None
 
 
 def _is_arrow_backed(row: Row) -> bool:

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -28,10 +28,16 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.pipeline.sinks import BaseSink, JsonlSink, ParquetSink
-from refiner.pipeline.sources import BaseSource, CsvReader, JsonlReader, ParquetReader
+from refiner.pipeline.sources import (
+    BaseSource,
+    CsvReader,
+    JsonlReader,
+    ParquetReader,
+)
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.pipeline.sources.items import ItemsSource
 from refiner.pipeline.sources.task import TaskSource
+from refiner.pipeline.data.datatype import DTypeLike, DTypeMapping
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.shard import SHARD_ID_COLUMN
 from refiner.execution.engine import (
@@ -127,9 +133,16 @@ class RefinerPipeline:
             self._compiled_segments = compile_segments(self.pipeline_steps)
         return self._compiled_segments
 
-    def map(self, fn: MapFn) -> "RefinerPipeline":
+    def map(
+        self, fn: MapFn, *, dtypes: DTypeMapping | None = None
+    ) -> "RefinerPipeline":
         return self.add_step(
-            FnRowStep(fn=fn, op_name="map", index=self._next_step_index())
+            FnRowStep(
+                fn=fn,
+                op_name="map",
+                index=self._next_step_index(),
+                dtypes=dtypes,
+            )
         )
 
     def map_async(
@@ -138,6 +151,7 @@ class RefinerPipeline:
         *,
         max_in_flight: int = 16,
         preserve_order: bool = True,
+        dtypes: DTypeMapping | None = None,
     ) -> "RefinerPipeline":
         return self.add_step(
             FnAsyncRowStep(
@@ -146,10 +160,17 @@ class RefinerPipeline:
                 preserve_order=preserve_order,
                 op_name="map_async",
                 index=self._next_step_index(),
+                dtypes=dtypes,
             )
         )
 
-    def batch_map(self, fn: BatchFn, *, batch_size: int) -> "RefinerPipeline":
+    def batch_map(
+        self,
+        fn: BatchFn,
+        *,
+        batch_size: int,
+        dtypes: DTypeMapping | None = None,
+    ) -> "RefinerPipeline":
         if batch_size <= 1:
             raise ValueError("batch_size for batch_map must be > 1")
         return self.add_step(
@@ -158,12 +179,23 @@ class RefinerPipeline:
                 batch_size=batch_size,
                 op_name="batch_map",
                 index=self._next_step_index(),
+                dtypes=dtypes,
             )
         )
 
-    def flat_map(self, fn: FlatMapFn) -> "RefinerPipeline":
+    def flat_map(
+        self,
+        fn: FlatMapFn,
+        *,
+        dtypes: DTypeMapping | None = None,
+    ) -> "RefinerPipeline":
         return self.add_step(
-            FnFlatMapStep(fn=fn, op_name="flat_map", index=self._next_step_index())
+            FnFlatMapStep(
+                fn=fn,
+                op_name="flat_map",
+                index=self._next_step_index(),
+                dtypes=dtypes,
+            )
         )
 
     def map_table(self, fn: Callable[[pa.Table], pa.Table]) -> "RefinerPipeline":
@@ -235,7 +267,7 @@ class RefinerPipeline:
             RenameStep(mapping=mapping, index=self._next_step_index())
         )
 
-    def cast(self, **dtypes: str) -> "RefinerPipeline":
+    def cast(self, **dtypes: DTypeLike) -> "RefinerPipeline":
         if not dtypes:
             raise ValueError("cast requires at least one dtype mapping")
         if SHARD_ID_COLUMN in dtypes:
@@ -260,6 +292,10 @@ class RefinerPipeline:
             self._get_compiled_segments(),
             max_vectorized_block_bytes=self.max_vectorized_block_bytes,
             on_shard_delta=on_shard_delta,
+            input_schema=self.source.schema,
+            final_output_tabular=(
+                self.sink.requires_tabular_input if self.sink is not None else False
+            ),
         )
 
     def iter_rows(self) -> Iterable[Row]:
@@ -441,6 +477,7 @@ def read_csv(
     multiline_rows: bool = False,
     encoding: str = "utf-8",
     parse_use_threads: bool = False,
+    dtypes: DTypeMapping | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline with a CSV reader source.
 
@@ -459,6 +496,7 @@ def read_csv(
             multiline_rows=multiline_rows,
             encoding=encoding,
             parse_use_threads=parse_use_threads,
+            dtypes=dtypes,
         )
     )
 
@@ -473,6 +511,7 @@ def read_jsonl(
     num_shards: int | None = None,
     file_path_column: str | None = "file_path",
     parse_use_threads: bool = False,
+    dtypes: DTypeMapping | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline with a JSONL reader source.
 
@@ -489,6 +528,7 @@ def read_jsonl(
             num_shards=num_shards,
             file_path_column=file_path_column,
             parse_use_threads=parse_use_threads,
+            dtypes=dtypes,
         )
     )
 
@@ -506,6 +546,7 @@ def read_parquet(
     filter: Expr | None = None,
     split_row_groups: bool = False,
     file_path_column: str | None = "file_path",
+    dtypes: DTypeMapping | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline with a Parquet reader source.
 
@@ -527,6 +568,7 @@ def read_parquet(
             filter=filter,
             split_row_groups=split_row_groups,
             file_path_column=file_path_column,
+            dtypes=dtypes,
         )
     )
 

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -22,6 +22,7 @@ from refiner.pipeline.steps import (
     VectorizedSegmentStep,
     WithColumnsStep,
 )
+from refiner.pipeline.data.datatype import dtype_to_plan
 from refiner.platform.manifest import _redact_captured_text
 from refiner.services import RuntimeServiceSpec
 
@@ -185,7 +186,15 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
     if isinstance(step, RenameStep):
         return (explicit_name or "rename"), "rename", {"mapping": dict(step.mapping)}
     if isinstance(step, CastStep):
-        return (explicit_name or "cast"), "cast", {"dtypes": dict(step.dtypes)}
+        return (
+            (explicit_name or "cast"),
+            "cast",
+            {
+                "dtypes": {
+                    name: dtype_to_plan(dtype) for name, dtype in step.dtypes.items()
+                }
+            },
+        )
     if isinstance(step, FilterExprStep):
         return (
             explicit_name or "filter",

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -63,6 +63,11 @@ class BaseSink(ABC):
         """Whether blocks written into this sink should count toward output_rows."""
         return True
 
+    @property
+    def requires_tabular_input(self) -> bool:
+        """Whether this sink expects blocks to be converted to `Tabular` before writing."""
+        return False
+
     def on_shard_complete(self, shard_id: str) -> None:
         """Flush or finalize state for one shard after upstream completion.
 

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -55,6 +55,10 @@ class ParquetSink(BaseSink):
             table = table.drop_columns([SHARD_ID_COLUMN])
         self._writer(shard_id, table.schema).write_table(table)
 
+    @property
+    def requires_tabular_input(self) -> bool:
+        return True
+
     def on_shard_complete(self, shard_id: str) -> None:
         writer = self._writers.pop(shard_id, None)
         if writer is not None:

--- a/src/refiner/pipeline/sources/base.py
+++ b/src/refiner/pipeline/sources/base.py
@@ -39,6 +39,10 @@ class BaseSource(ABC):
         for shard in self.list_shards():
             yield from self.iter_shard_units(shard)
 
+    @property
+    def schema(self) -> pa.Schema | None:
+        return None
+
     def describe(self) -> dict[str, Any]:
         """Optional source metadata for planning/observability."""
         return {}

--- a/src/refiner/pipeline/sources/readers/csv.py
+++ b/src/refiner/pipeline/sources/readers/csv.py
@@ -10,6 +10,11 @@ import pyarrow.csv as pa_csv
 from fsspec import AbstractFileSystem
 
 from refiner.io.fileset import DataFileSetLike
+from refiner.pipeline.data.datatype import (
+    DTypeMapping,
+    apply_dtypes_to_table,
+    schema_with_dtypes,
+)
 from refiner.pipeline.data.shard import FilePart, FilePartsDescriptor
 from refiner.pipeline.data.row import DictRow
 from refiner.pipeline.data.tabular import Tabular
@@ -41,6 +46,7 @@ class CsvReader(BaseReader):
         multiline_rows: bool = False,
         encoding: str = "utf-8",
         parse_use_threads: bool = False,
+        dtypes: DTypeMapping | None = None,
     ):
         """Create a CSV reader.
 
@@ -64,6 +70,7 @@ class CsvReader(BaseReader):
         self.multiline_rows = multiline_rows
         self.encoding = encoding
         self.parse_use_threads = parse_use_threads
+        self.dtypes = dtypes
         self._open_header: Optional[list[str]] = None
 
     def _get_handle_and_header(self, source_file):
@@ -138,8 +145,12 @@ class CsvReader(BaseReader):
                 )
                 for batch in reader:
                     yield Tabular(
-                        self._table_with_file_path(
-                            pa.Table.from_batches([batch]), source
+                        apply_dtypes_to_table(
+                            self._table_with_file_path(
+                                pa.Table.from_batches([batch]), source
+                            ),
+                            self.dtypes,
+                            strict=False,
                         )
                     )
             return
@@ -170,7 +181,11 @@ class CsvReader(BaseReader):
         )
         for batch in reader:
             yield Tabular(
-                self._table_with_file_path(pa.Table.from_batches([batch]), source)
+                apply_dtypes_to_table(
+                    self._table_with_file_path(pa.Table.from_batches([batch]), source),
+                    self.dtypes,
+                    strict=False,
+                )
             )
 
     def _read_shard_python(self, part: FilePart) -> Iterator[SourceUnit]:
@@ -184,7 +199,9 @@ class CsvReader(BaseReader):
             ) as tf:
                 reader = csv.DictReader(tf)
                 for row in reader:
-                    yield DictRow(self._with_file_path(dict(row), source))
+                    yield DictRow(
+                        self._with_file_path(dict(row), source),
+                    )
             return
 
         bounded = self._bounded_part(part)
@@ -207,7 +224,13 @@ class CsvReader(BaseReader):
                 fields = list(fields) + [None] * (len(header) - len(fields))
             if len(fields) > len(header):
                 fields = fields[: len(header)]
-            yield DictRow(self._with_file_path(dict(zip(header, fields)), source))
+            yield DictRow(
+                self._with_file_path(dict(zip(header, fields)), source),
+            )
+
+    @property
+    def schema(self) -> pa.Schema | None:
+        return schema_with_dtypes(None, self.dtypes)
 
 
 __all__ = ["CsvReader"]

--- a/src/refiner/pipeline/sources/readers/jsonl.py
+++ b/src/refiner/pipeline/sources/readers/jsonl.py
@@ -8,6 +8,11 @@ import pyarrow as pa
 import pyarrow.json as pa_json
 
 from refiner.io.fileset import DataFileSetLike
+from refiner.pipeline.data.datatype import (
+    DTypeMapping,
+    apply_dtypes_to_table,
+    schema_with_dtypes,
+)
 from refiner.pipeline.data.shard import FilePartsDescriptor
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.base import BaseReader, Shard, SourceUnit
@@ -36,6 +41,7 @@ class JsonlReader(BaseReader):
         num_shards: int | None = None,
         file_path_column: str | None = "file_path",
         parse_use_threads: bool = False,
+        dtypes: DTypeMapping | None = None,
     ):
         """Create a JSONL reader.
 
@@ -54,6 +60,7 @@ class JsonlReader(BaseReader):
             file_path_column=file_path_column,
         )
         self.parse_use_threads = parse_use_threads
+        self.dtypes = dtypes
 
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one planned JSONL shard by snapping file parts to newline boundaries."""
@@ -74,8 +81,12 @@ class JsonlReader(BaseReader):
                     )
                     for batch in reader:
                         yield Tabular(
-                            self._table_with_file_path(
-                                pa.Table.from_batches([batch]), source
+                            apply_dtypes_to_table(
+                                self._table_with_file_path(
+                                    pa.Table.from_batches([batch]), source
+                                ),
+                                self.dtypes,
+                                strict=False,
                             )
                         )
                 continue
@@ -90,8 +101,18 @@ class JsonlReader(BaseReader):
             )
             for batch in reader:
                 yield Tabular(
-                    self._table_with_file_path(pa.Table.from_batches([batch]), source)
+                    apply_dtypes_to_table(
+                        self._table_with_file_path(
+                            pa.Table.from_batches([batch]), source
+                        ),
+                        self.dtypes,
+                        strict=False,
+                    )
                 )
+
+    @property
+    def schema(self) -> pa.Schema | None:
+        return schema_with_dtypes(None, self.dtypes)
 
 
 __all__ = ["JsonlReader"]

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -13,6 +13,11 @@ from fsspec import AbstractFileSystem
 
 from refiner.io import DataFile
 from refiner.io.fileset import DataFileSetLike
+from refiner.pipeline.data.datatype import (
+    DTypeMapping,
+    apply_dtypes_to_table,
+    schema_with_dtypes,
+)
 from refiner.pipeline.data.shard import FilePart
 from refiner.pipeline.data.shard import FilePartsDescriptor
 from refiner.pipeline.data.tabular import Tabular, filter_table
@@ -57,6 +62,7 @@ class ParquetReader(BaseReader):
         filter: Expr | None = None,
         split_row_groups: bool = False,
         file_path_column: str | None = "file_path",
+        dtypes: DTypeMapping | None = None,
     ):
         """Create a Parquet reader.
 
@@ -90,6 +96,7 @@ class ParquetReader(BaseReader):
         )
         self.arrow_batch_size = int(arrow_batch_size)
         self.split_row_groups = split_row_groups
+        self.dtypes = dtypes
 
         ## filter
         # full filter expression
@@ -157,9 +164,14 @@ class ParquetReader(BaseReader):
                 else None,
                 "split_row_groups": self.split_row_groups,
                 "filter": self.filter.to_code() if self.filter is not None else None,
+                "dtypes": list(self.dtypes) if self.dtypes else None,
             }
         )
         return description
+
+    @property
+    def schema(self) -> pa.Schema | None:
+        return schema_with_dtypes(None, self.dtypes)
 
     def _metadata(self, pf: pq.ParquetFile) -> _ParquetMetadata | None:
         """Cache row-group byte starts and row starts for the currently open parquet file."""
@@ -279,6 +291,7 @@ class ParquetReader(BaseReader):
                 batch = batch.slice(begin, length)
                 offset += batch_rows
             table = pa.Table.from_batches([batch])
+            table = apply_dtypes_to_table(table, self.dtypes, strict=False)
             if self.filter is not None:
                 before = int(table.num_rows)
                 table = filter_table(table, self.filter)
@@ -310,13 +323,16 @@ class ParquetReader(BaseReader):
         fragment = self._get_parquet_fragment(source_file)
         if row_groups is not None:
             fragment = fragment.subset(row_group_ids=row_groups)
-        return [
-            row_group.id
-            for row_group_fragment in fragment.split_by_row_group(
-                filter=self._pushdown_filter
-            )
-            for row_group in row_group_fragment.row_groups
-        ]
+        try:
+            return [
+                row_group.id
+                for row_group_fragment in fragment.split_by_row_group(
+                    filter=self._pushdown_filter
+                )
+                for row_group in row_group_fragment.row_groups
+            ]
+        except (pa.ArrowInvalid, pa.ArrowNotImplementedError, pa.ArrowTypeError):
+            return row_groups
 
     def _log_pushdown_pruning(
         self,

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -101,14 +101,18 @@ class ParquetReader(BaseReader):
         ## filter
         # full filter expression
         self.filter = filter
-        # what we can pass down to scanner. essentially an arrow dataset expression
-        self._pushdown_filter = (
-            filter.extract_pushdown_filter() if filter is not None else None
-        )
         # the columns we will need to have in order to be able to apply self.filter
         self._filter_columns = (
             filter.referenced_columns() if filter is not None else set()
         )
+        # what we can pass down to scanner. essentially an arrow dataset expression.
+        # If a filter touches dtype-overridden columns, pruning against the original
+        # parquet stats can use different semantics from the in-memory casted filter.
+        dtype_columns = set(dtypes or ())
+        self._pushdown_filter = (
+            filter.extract_pushdown_filter() if filter is not None else None
+        )
+        self._pushdown_dtype_columns = self._filter_columns & dtype_columns
 
         ## columns
         # the columns the parquet reader will return at the end
@@ -291,7 +295,12 @@ class ParquetReader(BaseReader):
                 batch = batch.slice(begin, length)
                 offset += batch_rows
             table = pa.Table.from_batches([batch])
-            table = apply_dtypes_to_table(table, self.dtypes, strict=False)
+            table = apply_dtypes_to_table(
+                table,
+                self.dtypes,
+                strict=False,
+                preserve_metadata=False,
+            )
             if self.filter is not None:
                 before = int(table.num_rows)
                 table = filter_table(table, self.filter)
@@ -321,6 +330,10 @@ class ParquetReader(BaseReader):
             return row_groups
 
         fragment = self._get_parquet_fragment(source_file)
+        if self._pushdown_dtype_columns and not self._pushdown_dtypes_keep_types(
+            fragment
+        ):
+            return row_groups
         if row_groups is not None:
             fragment = fragment.subset(row_group_ids=row_groups)
         try:
@@ -333,6 +346,25 @@ class ParquetReader(BaseReader):
             ]
         except (pa.ArrowInvalid, pa.ArrowNotImplementedError, pa.ArrowTypeError):
             return row_groups
+
+    def _pushdown_dtypes_keep_types(self, fragment: ds.ParquetFileFragment) -> bool:
+        schema = fragment.physical_schema
+        for name in self._pushdown_dtype_columns:
+            idx = schema.get_field_index(name)
+            if idx < 0 or self.dtypes is None:
+                return False
+            field_schema = pa.schema([schema.field(idx)])
+            overridden = schema_with_dtypes(
+                field_schema,
+                {name: self.dtypes[name]},
+                preserve_metadata=False,
+            )
+            if (
+                overridden is None
+                or overridden.field(name).type != schema.field(idx).type
+            ):
+                return False
+        return True
 
     def _log_pushdown_pruning(
         self,

--- a/src/refiner/pipeline/steps.py
+++ b/src/refiner/pipeline/steps.py
@@ -8,6 +8,7 @@ from typing import Any, TypeAlias
 import pyarrow as pa
 
 from refiner.pipeline.expressions import Expr
+from refiner.pipeline.data.datatype import DTypeMapping
 from refiner.pipeline.data.row import Row
 
 
@@ -39,6 +40,7 @@ class FnRowStep(RowStep):
     fn: MapFn
     index: int
     op_name: str | None = None
+    dtypes: DTypeMapping | None = None
 
     def apply_row(self, row: Row) -> MapResult:
         return self.fn(row)
@@ -60,6 +62,7 @@ class FnAsyncRowStep(AsyncRowStep):
     max_in_flight: int = 16
     preserve_order: bool = True
     op_name: str | None = None
+    dtypes: DTypeMapping | None = None
 
     def __post_init__(self) -> None:
         if self.max_in_flight <= 0:
@@ -83,6 +86,7 @@ class FnBatchStep(BatchStep):
     index: int
     batch_size: int
     op_name: str | None = None
+    dtypes: DTypeMapping | None = None
 
     def __post_init__(self) -> None:
         if self.batch_size <= 1:
@@ -104,6 +108,7 @@ class FnFlatMapStep(FlatMapStep):
     fn: FlatMapFn
     index: int
     op_name: str | None = None
+    dtypes: DTypeMapping | None = None
 
     def apply_row_many(self, row: Row) -> Iterable[MapResult]:
         return self.fn(row)
@@ -149,7 +154,7 @@ class RenameStep(RefinerStep):
 
 @dataclass(frozen=True, slots=True)
 class CastStep(RefinerStep):
-    dtypes: Mapping[str, str]
+    dtypes: DTypeMapping
     index: int
     op_name: str | None = "cast"
 

--- a/src/refiner/robotics/lerobot_format/tabular.py
+++ b/src/refiner/robotics/lerobot_format/tabular.py
@@ -45,7 +45,12 @@ class LeRobotTabular(Tabular):
         object.__setattr__(self, "roots_by_row", roots_by_row)
 
     @classmethod
-    def from_rows(cls, rows: Sequence[Row]) -> "LeRobotTabular":
+    def from_rows(
+        cls,
+        rows: Sequence[Row],
+        *,
+        schema: pa.Schema | None = None,
+    ) -> "LeRobotTabular":
         from refiner.robotics.lerobot_format.row import LeRobotRow
 
         if not all(isinstance(row, LeRobotRow) for row in rows):
@@ -55,7 +60,8 @@ class LeRobotTabular(Tabular):
             [
                 row._row.update({_ROW_INDEX_COLUMN: idx})
                 for idx, row in enumerate(lerobot_rows)
-            ]
+            ],
+            schema=schema,
         )
         row_order = [
             int(value) for value in base.table.column(_ROW_INDEX_COLUMN).to_pylist()

--- a/tests/pipeline/test_datatype.py
+++ b/tests/pipeline/test_datatype.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import refiner as rf
+from refiner.execution.engine import RowSegment, VectorSegment, execute_segments
+from refiner.pipeline import from_items
+from refiner.pipeline.data import datatype
+from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.data.tabular import Tabular, set_or_append_column
+from refiner.pipeline.sinks.parquet import ParquetSink
+from refiner.pipeline.sources.readers import ParquetReader
+from refiner.pipeline.steps import FilterExprStep, FnRowStep
+
+
+def test_datatype_constructors_produce_arrow_types_and_metadata() -> None:
+    assert datatype.int64() == pa.int64()
+    assert datatype.list("uint8") == pa.list_(pa.uint8())
+    assert datatype.video_file().type == pa.string()
+    assert datatype.video_file().metadata == {b"asset_type": b"video"}
+    assert datatype.file().metadata == {b"asset_type": b"unknown"}
+    assert datatype.list(datatype.uint8()) == pa.list_(pa.uint8())
+    assert datatype.list(datatype.uint8(), size=3) == pa.list_(pa.uint8(), list_size=3)
+    assert datatype.struct({"x": datatype.float32()}) == pa.struct(
+        [pa.field("x", pa.float32())]
+    )
+    assert datatype.map(datatype.string(), datatype.int32()) == pa.map_(
+        pa.string(), pa.int32()
+    )
+
+
+def test_schema_and_table_dtypes_preserve_unrelated_metadata() -> None:
+    table = pa.table(
+        {
+            "frames": pa.array(["clip.mp4"]),
+            "label": pa.array(["pick"]),
+        },
+        schema=pa.schema(
+            [
+                pa.field("frames", pa.string(), metadata={b"old": b"kept"}),
+                pa.field("label", pa.string(), metadata={b"label": b"kept"}),
+            ]
+        ),
+    )
+
+    schema = datatype.schema_with_dtypes(
+        table.schema,
+        {"frames": datatype.video_file(), "label": pa.large_string()},
+    )
+    out = datatype.apply_dtypes_to_table(
+        table,
+        {"frames": datatype.video_file(), "label": pa.large_string()},
+    )
+
+    assert schema is not None
+    assert schema.field("frames").metadata == {
+        b"old": b"kept",
+        b"asset_type": b"video",
+    }
+    assert schema.field("label").metadata == {b"label": b"kept"}
+    assert out.schema.field("frames").metadata == {
+        b"old": b"kept",
+        b"asset_type": b"video",
+    }
+    assert out.schema.field("frames").type == pa.string()
+    assert out.schema.field("label").metadata == {b"label": b"kept"}
+    assert out.schema.field("label").type == pa.large_string()
+
+
+def test_dict_rows_with_schema_preserve_field_metadata() -> None:
+    schema = pa.schema(
+        [pa.field("frames", pa.string(), metadata={b"asset_type": b"video"})]
+    )
+
+    table = Tabular.from_rows(
+        [
+            DictRow({"frames": "a.mp4"}),
+            DictRow({"frames": "b.mp4"}),
+        ],
+        schema=schema,
+    ).table
+
+    assert table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_arrow_row_fast_path_preserves_field_metadata() -> None:
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"frames": ["a.mp4", "b.mp4"]}),
+        {"frames": datatype.video_file()},
+    )
+    rows = Tabular(table).to_rows()
+
+    out = Tabular.from_rows(rows).table
+
+    assert out.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_arrow_row_fast_path_applies_carried_schema_to_unchanged_columns() -> None:
+    table = pa.table({"frames": ["a.mp4", "b.mp4"]})
+    rows = Tabular(table).to_rows()
+    schema = datatype.schema_with_dtypes(
+        table.schema,
+        {"frames": datatype.video_file()},
+    )
+
+    out = Tabular.from_rows(rows, schema=schema).table
+
+    assert out.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_set_or_append_column_keeps_metadata_only_for_same_type() -> None:
+    table = pa.table(
+        {"frames": ["a.mp4"]},
+        schema=pa.schema(
+            [
+                pa.field(
+                    "frames",
+                    pa.string(),
+                    nullable=False,
+                    metadata={b"asset_type": b"video"},
+                )
+            ]
+        ),
+    )
+
+    same_type = set_or_append_column(table, "frames", pa.array(["b.mp4"]))
+    same_type_with_null = set_or_append_column(
+        table,
+        "frames",
+        pa.array([None], type=pa.string()),
+    )
+    different_type = set_or_append_column(table, "frames", pa.array([123]))
+
+    assert same_type.schema.field("frames").metadata == {b"asset_type": b"video"}
+    assert not same_type.schema.field("frames").nullable
+    assert same_type_with_null.schema.field("frames").metadata == {
+        b"asset_type": b"video"
+    }
+    assert same_type_with_null.schema.field("frames").nullable
+    assert different_type.schema.field("frames").type == pa.int64()
+    assert different_type.schema.field("frames").metadata is None
+
+
+def test_row_segment_dtypes_apply_to_unchanged_arrow_rows() -> None:
+    blocks = list(
+        execute_segments(
+            [Tabular(pa.table({"frames": ["clip.mp4"]}))],
+            [
+                RowSegment(
+                    steps=(
+                        FnRowStep(
+                            fn=lambda row: row,
+                            index=1,
+                            dtypes={"frames": rf.datatype.video_file()},
+                        ),
+                    )
+                ),
+                VectorSegment(
+                    ops=(
+                        FilterExprStep(
+                            predicate=rf.col("frames").is_not_null(),
+                            index=2,
+                        ),
+                    )
+                ),
+            ],
+        )
+    )
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_map_dtypes_do_not_attach_schema_to_row_outputs() -> None:
+    pipeline = from_items([{"id": 1}]).map(
+        lambda row: {"frames": "clip.mp4"},
+        dtypes={"frames": rf.datatype.video_file()},
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], list)
+    row = blocks[0][0]
+    assert isinstance(row, Row)
+    assert not hasattr(row, "schema")
+
+
+def test_map_dtypes_do_not_attach_declared_schema_overrides_to_rows() -> None:
+    pipeline = from_items([{"id": 1}]).map(
+        lambda row: {"frames": "clip.mp4"},
+        dtypes={
+            "frames": rf.datatype.video_file(),
+            "missing": rf.datatype.video_file(),
+        },
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], list)
+    row = blocks[0][0]
+    assert isinstance(row, Row)
+    assert not hasattr(row, "schema")
+
+
+def test_map_dtypes_accumulate_across_row_steps() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .map(
+            lambda row: row.update({"audio": "clip.wav"}),
+            dtypes={"audio": rf.datatype.audio_file()},
+        )
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+    assert blocks[0].table.schema.field("audio").metadata == {b"asset_type": b"audio"}
+
+
+def test_row_drop_removes_schema_override() -> None:
+    schema = pa.schema(
+        [pa.field("frames", pa.string(), metadata={b"asset_type": b"video"})]
+    )
+    row = DictRow({"frames": "clip.mp4"})
+
+    out = row.drop("frames")
+    table = Tabular.from_rows([out], schema=schema).table
+
+    assert "frames" not in out
+    assert not hasattr(out, "schema")
+    assert "frames" not in table.schema.names
+
+
+def test_arrow_row_drop_removes_column_on_fast_path() -> None:
+    table = pa.table({"frames": ["a.mp4", "b.mp4"], "x": [1, 2]})
+    rows = [row.drop("frames") for row in Tabular(table)]
+    schema = pa.schema(
+        [pa.field("frames", pa.string(), metadata={b"asset_type": b"video"})]
+    )
+
+    without_schema = Tabular.from_rows(rows).table
+    with_schema = Tabular.from_rows(rows, schema=schema).table
+
+    assert without_schema.to_pydict() == {"x": [1, 2]}
+    assert with_schema.to_pydict() == {"x": [1, 2]}
+
+
+def test_untyped_row_overwrite_does_not_attach_schema_to_rows() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .map(lambda row: {"frames": "label-not-video"})
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], list)
+    row = blocks[0][0]
+    assert isinstance(row, Row)
+    assert row["frames"] == "label-not-video"
+    assert not hasattr(row, "schema")
+
+
+def test_incompatible_row_value_clears_schema_field_on_table_conversion() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .map(lambda row: {"frames": 123})
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table["frames"].to_pylist() == [123]
+    assert blocks[0].table.schema.field("frames").type == pa.int64()
+    assert blocks[0].table.schema.field("frames").metadata is None
+
+
+def test_incompatible_arrow_row_patch_clears_field_metadata() -> None:
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"frames": ["a.mp4", "b.mp4"]}),
+        {"frames": datatype.video_file()},
+    )
+    rows = [row.update({"frames": idx}) for idx, row in enumerate(Tabular(table))]
+
+    out = Tabular.from_rows(rows).table
+
+    assert out["frames"].to_pylist() == [0, 1]
+    assert out.schema.field("frames").type == pa.int64()
+    assert out.schema.field("frames").metadata is None
+
+
+def test_row_step_schemas_flow_through_untyped_steps() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .map(lambda row: row.update({"label": "keep"}))
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_vectorized_schema_flows_into_later_row_segment() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .filter(rf.col("frames").is_not_null())
+        .map(lambda row: row.update({"frames": row["frames"]}))
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_vectorized_assignment_clears_previous_schema_override() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .filter(rf.col("frames").is_not_null())
+        .with_column("frames", "label")
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table["frames"].to_pylist() == ["label"]
+    assert blocks[0].table.schema.field("frames").metadata is None
+
+
+def test_vectorized_cast_becomes_global_schema_override() -> None:
+    pipeline = (
+        from_items([{"x": 1}])
+        .cast(x=rf.datatype.float32())
+        .map(lambda row: row.update({"x": row["x"]}))
+        .filter(rf.col("x").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("x").type == pa.float32()
+
+
+def test_vectorized_cast_clears_previous_file_metadata() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "123"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .filter(rf.col("frames").is_not_null())
+        .cast(frames="int64")
+        .map(lambda row: row.update({"frames": row["frames"]}))
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").type == pa.int64()
+    assert blocks[0].table.schema.field("frames").metadata is None
+
+
+def test_vectorized_cast_accepts_file_dtype_metadata() -> None:
+    pipeline = (
+        from_items([{"frames": "clip.mp4"}])
+        .cast(frames=rf.datatype.video_file())
+        .map(lambda row: row.update({"frames": row["frames"]}))
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").type == pa.string()
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_vectorized_cast_after_map_table_reestablishes_schema_override() -> None:
+    pipeline = (
+        from_items([{"x": 1}])
+        .map_table(lambda table: table)
+        .cast(x="float32")
+        .map(lambda row: row.update({"x": row["x"]}))
+        .filter(rf.col("x").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("x").type == pa.float32()
+
+
+def test_sink_execution_forces_final_row_schema_to_tabular(tmp_path) -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "clip.mp4"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .write_parquet(tmp_path)
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_tabular_schema_flows_through_row_segment() -> None:
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"frames": ["clip.mp4"]}),
+        {"frames": datatype.video_file()},
+    )
+
+    blocks = list(
+        execute_segments(
+            [Tabular(table)],
+            [
+                RowSegment(
+                    steps=(FnRowStep(fn=lambda row: {"label": "keep"}, index=1),)
+                ),
+                VectorSegment(
+                    ops=(
+                        FilterExprStep(
+                            predicate=rf.col("frames").is_not_null(),
+                            index=2,
+                        ),
+                    )
+                ),
+            ],
+        )
+    )
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_map_dtypes_attach_declared_schema_even_when_column_is_absent() -> None:
+    pipeline = from_items([{"id": 1}]).map(
+        lambda row: {"frames": "clip.mp4"},
+        dtypes={"missing": rf.datatype.video_file()},
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], list)
+    row = blocks[0][0]
+    assert isinstance(row, Row)
+    assert not hasattr(row, "schema")
+
+
+def test_map_dtypes_apply_to_downstream_tabular_blocks() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: {"frames": "clip.mp4"},
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .filter(rf.col("frames").is_not_null())
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+
+def test_parquet_sink_and_reader_preserve_field_metadata(tmp_path) -> None:
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"frames": ["clip.mp4"]}),
+        {"frames": datatype.video_file()},
+    )
+    sink = ParquetSink(tmp_path)
+    sink.write_shard_block("train", Tabular(table))
+    sink.on_shard_complete("train")
+
+    path = next(tmp_path.glob("*.parquet"))
+    read_table = pq.read_table(path)
+    assert read_table.schema.field("frames").metadata == {b"asset_type": b"video"}
+
+    reader = ParquetReader(str(path), file_path_column=None)
+    units = [
+        unit
+        for shard in reader.list_shards()
+        for unit in reader.read_shard(shard)
+        if isinstance(unit, Tabular)
+    ]
+    assert units
+    assert units[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}

--- a/tests/pipeline/test_datatype.py
+++ b/tests/pipeline/test_datatype.py
@@ -96,6 +96,17 @@ def test_arrow_row_fast_path_preserves_field_metadata() -> None:
     assert out.schema.field("frames").metadata == {b"asset_type": b"video"}
 
 
+def test_arrow_row_patch_preserves_base_type_without_schema_override() -> None:
+    table = pa.table({"x": pa.array([1, 2], type=pa.uint8())})
+    rows = Tabular(table).to_rows()
+    rows[0] = rows[0].update({"x": None})
+
+    out = Tabular.from_rows(rows).table
+
+    assert out.schema.field("x").type == pa.uint8()
+    assert out["x"].to_pylist() == [None, 2]
+
+
 def test_arrow_row_fast_path_applies_carried_schema_to_unchanged_columns() -> None:
     table = pa.table({"frames": ["a.mp4", "b.mp4"]})
     rows = Tabular(table).to_rows()
@@ -389,6 +400,28 @@ def test_vectorized_cast_clears_previous_file_metadata() -> None:
     blocks = list(pipeline.execute(pipeline.source.read()))
 
     assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table.schema.field("frames").type == pa.int64()
+    assert blocks[0].table.schema.field("frames").metadata is None
+
+
+def test_row_dtype_redefinition_clears_previous_file_metadata() -> None:
+    pipeline = (
+        from_items([{"id": 1}])
+        .map(
+            lambda row: row.update({"frames": "123"}),
+            dtypes={"frames": rf.datatype.video_file()},
+        )
+        .map(
+            lambda row: row.update({"frames": row["frames"]}),
+            dtypes={"frames": "int64"},
+        )
+        .filter(rf.col("frames") > 100)
+    )
+
+    blocks = list(pipeline.execute(pipeline.source.read()))
+
+    assert isinstance(blocks[0], Tabular)
+    assert blocks[0].table["frames"].to_pylist() == [123]
     assert blocks[0].table.schema.field("frames").type == pa.int64()
     assert blocks[0].table.schema.field("frames").metadata is None
 

--- a/tests/pipeline/test_pipeline_vectorized_ops.py
+++ b/tests/pipeline/test_pipeline_vectorized_ops.py
@@ -94,6 +94,42 @@ def test_vectorized_and_row_udf_segments_interoperate() -> None:
     assert [int(r["w"]) for r in out] == [25, 35, 45]
 
 
+def test_arrow_row_patch_type_inference_skips_initial_null() -> None:
+    rows = [
+        row.update(
+            {"mapped": None if int(row["value"]) == 1 else int(row["value"]) * 2}
+        )
+        for row in Tabular(pa.table({"value": [1, 2]}))
+    ]
+
+    out = Tabular.from_rows(rows).table
+
+    assert out["mapped"].to_pylist() == [None, 4]
+    assert out["mapped"].type == pa.int64()
+
+
+def test_arrow_row_patch_type_inference_promotes_across_tables() -> None:
+    row_1 = next(iter(Tabular(pa.table({"value": [1]})))).update({"mapped": None})
+    row_2 = next(iter(Tabular(pa.table({"value": [2]})))).update({"mapped": 4})
+
+    out = Tabular.from_rows([row_1, row_2]).table
+
+    assert out["mapped"].to_pylist() == [None, 4]
+    assert out["mapped"].type == pa.int64()
+
+
+def test_arrow_row_patch_existing_column_can_change_type() -> None:
+    rows = [
+        row.update({"value": f"chunk-{int(row['value'])}"})
+        for row in Tabular(pa.table({"value": [1, 2]}))
+    ]
+
+    out = Tabular.from_rows(rows).table
+
+    assert out["value"].to_pylist() == ["chunk-1", "chunk-2"]
+    assert out["value"].type == pa.string()
+
+
 def test_map_table_runs_on_vectorized_path() -> None:
     out = (
         from_items([{"x": 1}, {"x": 2}, {"x": 3}])
@@ -268,11 +304,11 @@ def test_vectorized_chunk_shrink_is_run_local(monkeypatch) -> None:
     calls: list[int] = []
     original_from_rows = engine_module.Tabular.from_rows
 
-    def _from_rows_with_oom(rows):
+    def _from_rows_with_oom(rows, **kwargs):
         calls.append(len(rows))
         if len(rows) > 2:
             raise pa.ArrowMemoryError("oom")
-        return original_from_rows(rows)
+        return original_from_rows(rows, **kwargs)
 
     monkeypatch.setattr(engine_module.Tabular, "from_rows", _from_rows_with_oom)
 
@@ -291,6 +327,30 @@ def test_vectorized_chunk_shrink_is_run_local(monkeypatch) -> None:
     assert len(out2) == 8
     assert calls[first_run_start] == 8
     assert calls[second_run_start] == 8
+
+
+def test_row_segment_to_vectorized_chunk_shrink_is_budgeted(monkeypatch) -> None:
+    calls: list[int] = []
+    original_from_rows = engine_module.Tabular.from_rows
+
+    def _from_rows_with_oom(rows, **kwargs):
+        calls.append(len(rows))
+        if len(rows) > 2:
+            raise pa.ArrowMemoryError("oom")
+        return original_from_rows(rows, **kwargs)
+
+    monkeypatch.setattr(engine_module.Tabular, "from_rows", _from_rows_with_oom)
+
+    out = (
+        from_items([{"x": i} for i in range(8)])
+        .map(lambda row: row)
+        .with_column("y", col("x") + 1)
+        .with_max_vectorized_block_bytes(1_000_000)
+        .materialize()
+    )
+
+    assert len(out) == 8
+    assert calls[:3] == [8, 4, 2]
 
 
 def test_with_max_vectorized_block_bytes_validates_positive() -> None:

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+import refiner as rf
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner import col
 from refiner.pipeline import RefinerPipeline, from_items
@@ -106,6 +107,7 @@ def test_compile_pipeline_plan_flattens_vectorized_segment_ops() -> None:
         .filter(col("x") > 1)
         .with_columns(y=col("x") + 10)
         .select("y")
+        .cast(y=rf.datatype.video_file())
     )
     plan = compile_pipeline_plan(payload)
     steps = plan["stages"][0]["steps"]
@@ -114,13 +116,18 @@ def test_compile_pipeline_plan_flattens_vectorized_segment_ops() -> None:
         "filter",
         "with_columns",
         "select",
+        "cast",
     ]
     assert steps[1]["type"] == "filter_expr"
     assert steps[2]["type"] == "with_columns"
     assert steps[3]["type"] == "select"
+    assert steps[4]["type"] == "cast"
     assert "expression" in steps[1]["args"]
     assert "callable" not in steps[1]
     assert steps[2]["args"] == {"y": "(col('x') + 10)"}
+    assert steps[4]["args"]["dtypes"] == {
+        "y": {"type": "string", "metadata": {"asset_type": "video"}}
+    }
     assert "callable" not in steps[2]
 
 

--- a/tests/readers/test_csv_reader.py
+++ b/tests/readers/test_csv_reader.py
@@ -1,3 +1,4 @@
+from refiner.pipeline.data import datatype
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers import CsvReader
 
@@ -65,3 +66,23 @@ def test_csv_can_enable_arrow_parse_threads(tmp_path):
         rows.extend(list(_rows_from_shard_units(reader.read_shard(shard))))
 
     assert [str(row["id"]) for row in rows] == ["0", "1"]
+
+
+def test_csv_reader_applies_dtypes_to_arrow_and_python_paths(tmp_path):
+    p = tmp_path / "data.csv"
+    p.write_text("id,video\n0,clip.mp4\n")
+
+    arrow_reader = CsvReader(str(p), dtypes={"video": datatype.video_file()})
+    arrow_unit = next(iter(arrow_reader.read_shard(arrow_reader.list_shards()[0])))
+    assert isinstance(arrow_unit, Tabular)
+    assert arrow_unit.table.schema.field("video").metadata == {b"asset_type": b"video"}
+
+    python_reader = CsvReader(
+        str(p),
+        multiline_rows=True,
+        dtypes={"video": datatype.video_file()},
+    )
+    python_row = next(iter(python_reader.read_shard(python_reader.list_shards()[0])))
+    assert not hasattr(python_row, "schema")
+    assert python_reader.schema is not None
+    assert python_reader.schema.field("video").metadata == {b"asset_type": b"video"}

--- a/tests/readers/test_jsonl_reader.py
+++ b/tests/readers/test_jsonl_reader.py
@@ -1,4 +1,6 @@
 import orjson
+
+from refiner.pipeline.data import datatype
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers import JsonlReader
 
@@ -33,3 +35,24 @@ def test_jsonl_bytes_lazy_reads_all_objects(tmp_path):
 
     assert count == n
     assert ids == set(range(n))
+
+
+def test_jsonl_reader_applies_dtypes(tmp_path):
+    p = tmp_path / "data.jsonl"
+    p.write_bytes(orjson.dumps({"video": "clip.mp4"}) + b"\n")
+
+    reader = JsonlReader(str(p), dtypes={"video": datatype.video_file()})
+    unit = next(iter(reader.read_shard(reader.list_shards()[0])))
+
+    assert isinstance(unit, Tabular)
+    assert unit.table.schema.field("video").metadata == {b"asset_type": b"video"}
+
+
+def test_jsonl_reader_schema_exposes_dtype_overrides(tmp_path):
+    p = tmp_path / "data.jsonl"
+    p.write_bytes(orjson.dumps({"video": "clip.mp4"}) + b"\n")
+
+    reader = JsonlReader(str(p), dtypes={"video": datatype.video_file()})
+
+    assert reader.schema is not None
+    assert reader.schema.field("video").metadata == {b"asset_type": b"video"}

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.data import datatype
 from refiner.pipeline.expressions import col
 from refiner.pipeline.sources.readers import ParquetReader
 from refiner.worker.context import set_active_run_context
@@ -102,6 +103,21 @@ def test_parquet_reads_all_rows(tmp_path):
     assert ids == list(range(50))
 
 
+def test_parquet_reader_schema_exposes_only_dtype_overrides(tmp_path):
+    p = _write_parquet(tmp_path)
+    reader = ParquetReader(
+        str(p),
+        columns_to_read=("x",),
+        dtypes={"x": datatype.video_file()},
+    )
+
+    schema = reader.schema
+
+    assert schema is not None
+    assert schema.names == ["x"]
+    assert schema.field("x").metadata == {b"asset_type": b"video"}
+
+
 def test_parquet_filter_reads_only_matching_rows(tmp_path):
     p = _write_parquet(tmp_path)
     reader = ParquetReader(
@@ -131,6 +147,33 @@ def test_parquet_filter_supports_residual_string_predicates(tmp_path):
         out.extend(list(_rows_from_shard_units(reader.read_shard(shard))))
 
     assert [int(row["id"]) for row in out] == [7, 17, 27, 37, 47]
+
+
+def test_parquet_filter_runs_after_dtype_overrides(tmp_path):
+    p = tmp_path / "string-ints.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "x": pa.array(["1", "2", "10", "20"]),
+                "label": pa.array(["a", "b", "c", "d"]),
+            }
+        ),
+        p,
+        row_group_size=2,
+    )
+
+    reader = ParquetReader(
+        str(p),
+        filter=col("x") > 2,
+        dtypes={"x": datatype.int64()},
+    )
+
+    out = []
+    for shard in reader.list_shards():
+        out.extend(list(_rows_from_shard_units(reader.read_shard(shard))))
+
+    assert [row["x"] for row in out] == [10, 20]
+    assert [row["label"] for row in out] == ["c", "d"]
 
 
 def test_parquet_can_split_inside_large_row_group(tmp_path):
@@ -256,6 +299,7 @@ def test_parquet_logs_pushdown_and_total_filtered_metrics(tmp_path):
         str(p),
         target_shard_bytes=100_000,
         filter=col("keep"),
+        dtypes={"keep": pa.field("keep", pa.bool_(), metadata={b"kind": b"flag"})},
     )
 
     emitter = _RecordingEmitter()

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -176,6 +176,59 @@ def test_parquet_filter_runs_after_dtype_overrides(tmp_path):
     assert [row["label"] for row in out] == ["c", "d"]
 
 
+def test_parquet_dtype_override_clears_stale_file_metadata(tmp_path):
+    p = tmp_path / "metadata.parquet"
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"frames": ["123"]}),
+        {"frames": datatype.video_file()},
+    )
+    pq.write_table(table, p)
+
+    reader = ParquetReader(
+        str(p),
+        file_path_column=None,
+        dtypes={"frames": datatype.int64()},
+    )
+    out = [
+        unit
+        for shard in reader.list_shards()
+        for unit in reader.read_shard(shard)
+        if isinstance(unit, Tabular)
+    ]
+
+    assert len(out) == 1
+    assert out[0].table["frames"].to_pylist() == [123]
+    assert out[0].table.schema.field("frames").type == pa.int64()
+    assert out[0].table.schema.field("frames").metadata is None
+
+
+def test_parquet_filter_disables_pushdown_for_dtype_columns(tmp_path):
+    p = tmp_path / "string-ints.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "x": pa.array(["100", "60", "5"]),
+                "label": pa.array(["a", "b", "c"]),
+            }
+        ),
+        p,
+        row_group_size=1,
+    )
+
+    reader = ParquetReader(
+        str(p),
+        filter=col("x") > 50,
+        dtypes={"x": datatype.int64()},
+    )
+
+    out = []
+    for shard in reader.list_shards():
+        out.extend(list(_rows_from_shard_units(reader.read_shard(shard))))
+
+    assert [row["x"] for row in out] == [100, 60]
+    assert [row["label"] for row in out] == ["a", "b"]
+
+
 def test_parquet_can_split_inside_large_row_group(tmp_path):
     p = tmp_path / "large-row-group.parquet"
     table = pa.table(

--- a/uv.lock
+++ b/uv.lock
@@ -614,6 +614,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
 ]
 
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
 [[package]]
 name = "h11"
 version = "0.16.0"
@@ -770,7 +775,7 @@ version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
-    { name = "fsspec" },
+    { name = "fsspec", extra = ["http"] },
     { name = "httpx" },
     { name = "loguru" },
     { name = "msgspec" },
@@ -826,7 +831,7 @@ dev = [
 requires-dist = [
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
-    { name = "fsspec" },
+    { name = "fsspec", extras = ["http"] },
     { name = "hf", marker = "extra == 'robotics'", specifier = ">=1.7.1" },
     { name = "httpx" },
     { name = "huggingface-hub", marker = "extra == 'robotics'", specifier = ">=1.4.1" },


### PR DESCRIPTION
## Summary
- add lightweight Arrow-backed datatype helpers under `refiner.pipeline.data.datatype`, exposed as `rf.datatype`
- preserve field metadata through row/table materialization, row-step dtype output, vectorized column replacement, and Parquet read/write paths
- allow explicit dtypes on row/batch/map/cast paths without attaching schemas to rows

## Validation
- `uv run pytest tests/pipeline/test_datatype.py tests/readers/test_parquet_reader.py tests/pipeline/test_pipeline_vectorized_ops.py tests/pipeline/test_sinks.py tests/pipeline/test_planning.py`
- `uv run ruff check src/refiner/__init__.py src/refiner/pipeline/__init__.py src/refiner/pipeline/pipeline.py src/refiner/pipeline/sources/__init__.py src/refiner/pipeline/sources/readers/__init__.py`
- `uv run ty check src/refiner/__init__.py src/refiner/pipeline/__init__.py src/refiner/pipeline/pipeline.py src/refiner/pipeline/sources/__init__.py src/refiner/pipeline/sources/readers/__init__.py`
- pre-commit hooks on commit: ruff, ruff format, ty
