### PR TITLE
[codex] Add writer asset uploads

### DIFF
--- a/docs/reading-and-writing.md
+++ b/docs/reading-and-writing.md
@@ -183,11 +183,40 @@ Example:
 pipeline = pipeline.write_parquet("s3://my-bucket/clean-output/")
 ```
 
+`write_jsonl(...)` and `write_parquet(...)` can also copy file-typed asset
+columns into the same output folder:
+
+```python
+pipeline = pipeline.write_parquet(
+    "s3://my-bucket/clean-output/",
+    upload_assets=True,
+)
+```
+
+When `upload_assets=True`, Refiner infers asset columns from file dtype metadata,
+copies those files without decoding them, and rewrites the column values to the
+copied asset paths. Assets are written under
+`{output}/assets/{shard_id}__w{worker_id}/...` by default; use `assets_subdir` to
+change the subfolder name and `max_asset_uploads_in_flight` to bound per-worker
+copy concurrency. Missing or unreadable asset paths fail the shard.
+
+Mark path columns as assets with `dtypes=...` on row transforms or with
+`cast(...)`:
+
+```python
+pipeline = pipeline.map(
+    lambda row: {"image": f"{row['image_dir']}/{row['image_name']}"},
+    dtypes={"image": mdr.datatype.image_file()},
+)
+
+pipeline = pipeline.cast(video=mdr.datatype.video_file())
+```
+
 When you run a writer through `launch_local(...)` or `launch_cloud(...)`, some
 sinks add a reducer stage after the main writer stage. For `write_jsonl(...)`
 and `write_parquet(...)`, that reducer removes stale shard/worker files and
-keeps only finalized outputs. The output prefix should therefore be dedicated to
-Refiner-managed files.
+uploaded asset attempt folders, keeping only finalized outputs. The output
+prefix should therefore be dedicated to Refiner-managed files.
 
 ## What Python Functions Actually See
 

--- a/src/refiner/execution/asyncio/runtime.py
+++ b/src/refiner/execution/asyncio/runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-import os
 import threading
 from collections.abc import Coroutine
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -12,8 +11,7 @@ T = TypeVar("T")
 
 
 def _default_io_workers() -> int:
-    cpu_count = max(1, os.cpu_count() or 1)
-    return min(4, cpu_count)
+    return 8
 
 
 class AsyncRuntime:

--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -74,9 +74,8 @@ def execute_segments(
     max_vectorized_block_bytes: int | None = None,
     on_shard_delta: ShardDeltaFn | None = None,
     input_schema: pa.Schema | None = None,
-    final_output_tabular: bool = False,
 ) -> Iterator[Block]:
-    """Execute segments, optionally converting final row blocks to `Tabular` blocks."""
+    """Execute segments and yield row or tabular blocks."""
     current: Iterable[Block] = _normalize_blocks(
         stream,
         block_rows=vectorized_chunk_rows,
@@ -93,9 +92,9 @@ def execute_segments(
                 on_shard_delta=on_shard_delta,
                 input_schema=current_schema,
             )
-            current_schema = _vector_segment_schema(current_schema, segment.ops)
+            current_schema = _segment_schema(current_schema, segment)
         else:
-            output_schema = _row_segment_schema(current_schema, segment.steps)
+            output_schema = _segment_schema(current_schema, segment)
             current = _execute_row_segment(
                 current,
                 segment.steps,
@@ -106,10 +105,26 @@ def execute_segments(
                 output_schema=output_schema,
             )
             current_schema = output_schema
-    if final_output_tabular:
-        yield from _tabularize_blocks(current, schema=current_schema)
-        return
     yield from current
+
+
+def schema_after_segments(
+    input_schema: pa.Schema | None,
+    segments: Sequence[Segment],
+) -> pa.Schema | None:
+    schema = input_schema
+    for segment in segments:
+        schema = _segment_schema(schema, segment)
+    return schema
+
+
+def _segment_schema(
+    input_schema: pa.Schema | None,
+    segment: Segment,
+) -> pa.Schema | None:
+    if isinstance(segment, VectorSegment):
+        return _vector_segment_schema(input_schema, segment.ops)
+    return _row_segment_schema(input_schema, segment.steps)
 
 
 def iter_rows(stream: Iterable[StreamItem]) -> Iterator[Row]:
@@ -423,24 +438,6 @@ def _chunk_output_rows(rows: Iterable[Row], block_rows: int) -> Iterator[list[Ro
             yield out
     if pending:
         yield pending
-
-
-def _tabularize_blocks(
-    blocks: Iterable[Block],
-    *,
-    schema: pa.Schema | None,
-) -> Iterator[Tabular]:
-    for block in blocks:
-        if isinstance(block, Tabular):
-            yield block
-            continue
-        table = (
-            Tabular.from_rows(block, schema=schema)
-            if not block
-            else block[0].tabular_type.from_rows(block, schema=schema)
-        )
-        if table.num_rows > 0:
-            yield table
 
 
 __all__ = [

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+import os
 from os import PathLike
+import posixpath
+import shutil
 from typing import Any, TypeAlias, Union, cast
 
 from fsspec import AbstractFileSystem, url_to_fs
@@ -73,6 +76,45 @@ class DataFile:
 
     def open(self, mode: str = "rt", **kwargs):
         return self.fs.open(self.path, mode=mode, **kwargs)
+
+    def copy(self, dest: DataFileLike, *, buffer_size: int = 2 * 1024 * 1024) -> None:
+        target = DataFile.resolve(dest)
+        if self.abs_path() == target.abs_path():
+            return
+        if (
+            self.is_local
+            and target.is_local
+            and os.path.realpath(self.abs_path()) == os.path.realpath(target.abs_path())
+        ):
+            return
+        if self.fs is target.fs and (
+            posixpath.normpath(self.path) == posixpath.normpath(target.path)
+        ):
+            return
+
+        # Same-filesystem copies are usually server-side for object stores; fall back to
+        # streaming only when the backend cannot copy directly.
+        if self.fs is target.fs and callable(getattr(target.fs, "copy", None)):
+            target.fs.makedirs(target.fs._parent(target.path), exist_ok=True)
+            try:
+                target.fs.copy(self.path, target.path)
+                return
+            except Exception:
+                try:
+                    target.fs.rm(target.path)
+                except FileNotFoundError:
+                    pass
+
+        try:
+            target.fs.makedirs(target.fs._parent(target.path), exist_ok=True)
+            with self.open(mode="rb") as src, target.open(mode="wb") as dst:
+                shutil.copyfileobj(src, dst, length=buffer_size)
+        except Exception:
+            try:
+                target.fs.rm(target.path)
+            except FileNotFoundError:
+                pass
+            raise
 
     def exists(self) -> bool:
         return self.fs.exists(self.path)

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -47,6 +47,7 @@ from refiner.execution.engine import (
     compile_segments,
     execute_segments,
     iter_rows,
+    schema_after_segments,
 )
 from refiner.execution.operators.row import ShardDeltaFn
 from refiner.pipeline.sources.base import SourceUnit
@@ -133,6 +134,9 @@ class RefinerPipeline:
         if self._compiled_segments is None:
             self._compiled_segments = compile_segments(self.pipeline_steps)
         return self._compiled_segments
+
+    def output_schema(self) -> pa.Schema | None:
+        return schema_after_segments(self.source.schema, self._get_compiled_segments())
 
     def map(
         self, fn: MapFn, *, dtypes: DTypeMapping | None = None
@@ -294,9 +298,6 @@ class RefinerPipeline:
             max_vectorized_block_bytes=self.max_vectorized_block_bytes,
             on_shard_delta=on_shard_delta,
             input_schema=self.source.schema,
-            final_output_tabular=(
-                self.sink.requires_tabular_input if self.sink is not None else False
-            ),
         )
 
     def iter_rows(self) -> Iterable[Row]:
@@ -326,11 +327,17 @@ class RefinerPipeline:
         output: DataFolderLike,
         *,
         filename_template: str = "{shard_id}__w{worker_id}.jsonl",
+        upload_assets: bool = False,
+        assets_subdir: str = "assets",
+        max_asset_uploads_in_flight: int = 16,
     ) -> "RefinerPipeline":
         return self.with_sink(
             JsonlSink(
                 output=output,
                 filename_template=filename_template,
+                upload_assets=upload_assets,
+                assets_subdir=assets_subdir,
+                max_asset_uploads_in_flight=max_asset_uploads_in_flight,
             )
         )
 
@@ -340,12 +347,18 @@ class RefinerPipeline:
         *,
         filename_template: str = "{shard_id}__w{worker_id}.parquet",
         compression: str | None = None,
+        upload_assets: bool = False,
+        assets_subdir: str = "assets",
+        max_asset_uploads_in_flight: int = 16,
     ) -> "RefinerPipeline":
         return self.with_sink(
             ParquetSink(
                 output=output,
                 filename_template=filename_template,
                 compression=compression,
+                upload_assets=upload_assets,
+                assets_subdir=assets_subdir,
+                max_asset_uploads_in_flight=max_asset_uploads_in_flight,
             )
         )
 

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable, Sequence
+from functools import partial
+import posixpath
+import re
+from urllib.parse import unquote, urlsplit
+
+import pyarrow as pa
+
+from refiner.execution.asyncio.runtime import io_executor
+from refiner.execution.asyncio.window import AsyncWindow
+from refiner.io import DataFile
+from refiner.io.datafolder import DataFolder
+from refiner.pipeline.data import datatype
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.data.tabular import set_or_append_column
+from refiner.worker.context import get_active_worker_token
+from refiner.worker.metrics.api import log_throughput
+
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class AssetUploadManager:
+    def __init__(
+        self,
+        output: DataFolder,
+        *,
+        assets_subdir: str,
+        filename_template: str,
+        max_uploads_in_flight: int,
+    ) -> None:
+        self.output = output
+        # Assets live in a writer-managed subtree, so both the assets directory and
+        # the sink's output template must stay relative and disjoint.
+        if (
+            not assets_subdir
+            or assets_subdir.strip("/") != assets_subdir
+            or "\\" in assets_subdir
+            or "://" in assets_subdir
+            or any(part in {"", ".", ".."} for part in assets_subdir.split("/"))
+        ):
+            raise ValueError("assets_subdir must be a non-empty relative path")
+        self.assets_subdir = assets_subdir
+        normalized_template = posixpath.normpath(filename_template)
+        if (
+            normalized_template == ".."
+            or normalized_template.startswith("../")
+            or normalized_template.startswith("/")
+        ):
+            raise ValueError("filename_template must be a relative path")
+        if normalized_template == self.assets_subdir or normalized_template.startswith(
+            f"{self.assets_subdir}/"
+        ):
+            raise ValueError("filename_template must not write into assets_subdir")
+        self._window = AsyncWindow[None](
+            max_in_flight=max_uploads_in_flight,
+            preserve_order=False,
+        )
+        self._next_row_index: dict[str, int] = {}
+        self._asset_columns: dict[str, str] = {}
+        self._asset_column_segments: dict[str, str] = {}
+        self._input_schema_set = False
+
+    def set_input_schema(self, schema: pa.Schema | None) -> None:
+        self._set_asset_columns(asset_columns_from_schema(schema))
+        self._input_schema_set = True
+
+    def _set_asset_columns(self, columns: dict[str, str]) -> None:
+        self._asset_columns = columns
+        self._asset_column_segments = {}
+        used_segments: set[str] = set()
+        for column_name in self._asset_columns:
+            base_segment = _SAFE_NAME_RE.sub("_", column_name).strip("._-") or "column"
+            segment = base_segment
+            suffix = 2
+            while segment in used_segments:
+                segment = f"{base_segment}_{suffix}"
+                suffix += 1
+            self._asset_column_segments[column_name] = segment
+            used_segments.add(segment)
+
+    def require_input_schema(self) -> None:
+        if not self._input_schema_set:
+            raise ValueError(
+                "Row asset upload requires an input schema. Mark asset columns with "
+                "dtypes=... or cast(...), or call set_input_schema(...)."
+            )
+
+    def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
+        start = self._next_row_index.get(shard_id, 0)
+        out = table
+        # Tables may already carry asset metadata, while row-derived tables rely on
+        # the schema passed through set_input_schema().
+        columns = dict(self._asset_columns)
+        columns.update(asset_columns_from_schema(table.schema))
+        if columns != self._asset_columns:
+            self._set_asset_columns(columns)
+            columns = self._asset_columns
+        for column_name, kind in columns.items():
+            idx = out.schema.get_field_index(column_name)
+            if idx < 0:
+                continue
+            field = out.schema.field(idx)
+            rewritten = [
+                self._rewrite_asset_path(
+                    value,
+                    shard_id=shard_id,
+                    column_name=column_name,
+                    row_index=start + row_offset,
+                    list_items=kind == "list",
+                )
+                for row_offset, value in enumerate(out.column(idx).to_pylist())
+            ]
+            out = set_or_append_column(
+                out,
+                column_name,
+                pa.array(rewritten, type=field.type),
+            )
+        # Do not expose output rows that point at assets until those copies have
+        # completed; otherwise a later copy failure leaves dangling references.
+        self._window.flush()
+        self._next_row_index[shard_id] = start + table.num_rows
+        return out
+
+    def rewrite_rows(
+        self,
+        shard_id: str,
+        rows: Iterable[Row],
+    ) -> Iterable[Row]:
+        self.require_input_schema()
+        if not self._asset_columns:
+            return rows
+
+        start = self._next_row_index.get(shard_id, 0)
+        out: list[Row] = []
+        row_count = 0
+        for row_index, row in enumerate(rows, start=start):
+            row_count += 1
+            patch: dict[str, object] = {}
+            for column_name, kind in self._asset_columns.items():
+                if column_name not in row:
+                    continue
+                patch[column_name] = self._rewrite_asset_path(
+                    row[column_name],
+                    shard_id=shard_id,
+                    column_name=column_name,
+                    row_index=row_index,
+                    list_items=kind == "list",
+                )
+            out.append(row.update(patch) if patch else row)
+        # Keep row-mode JSONL writes atomic at the block level for asset references.
+        self._window.flush()
+        self._next_row_index[shard_id] = start + row_count
+        return out
+
+    def flush(self) -> None:
+        self._window.flush()
+
+    def _rewrite_asset_path(
+        self,
+        value: object,
+        *,
+        shard_id: str,
+        column_name: str,
+        row_index: int,
+        list_items: bool,
+    ) -> object:
+        if value is None:
+            return None
+        if list_items:
+            if not isinstance(value, Sequence) or isinstance(
+                value,
+                (str, bytes, bytearray),
+            ):
+                raise TypeError(f"Asset column {column_name!r} expected list values")
+            return [
+                None
+                if item is None
+                else self._rewrite_path(
+                    item,
+                    shard_id=shard_id,
+                    column_name=column_name,
+                    row_index=row_index,
+                    item_index=item_index,
+                )
+                for item_index, item in enumerate(value)
+            ]
+        return self._rewrite_path(
+            value,
+            shard_id=shard_id,
+            column_name=column_name,
+            row_index=row_index,
+            item_index=None,
+        )
+
+    def _rewrite_path(
+        self,
+        value: object,
+        *,
+        shard_id: str,
+        column_name: str,
+        row_index: int,
+        item_index: int | None,
+    ) -> str:
+        if not isinstance(value, str) or not value:
+            raise TypeError(f"Asset value for column {column_name!r} must be a path")
+
+        basename = unquote(posixpath.basename(urlsplit(value).path.rstrip("/")))
+        basename = _SAFE_NAME_RE.sub("_", basename.replace("\\", "_")).strip("._-")
+        if not basename:
+            basename = "asset"
+        prefix = f"{row_index}" if item_index is None else f"{row_index}-{item_index}"
+        column_segment = self._asset_column_segments[column_name]
+        # Attempt directories are keyed by shard and worker so reducers can delete
+        # whole failed attempts without inspecting individual asset files.
+        attempt_dir = f"{shard_id}__w{get_active_worker_token()}"
+        relpath = (
+            f"{self.assets_subdir}/{attempt_dir}/{column_segment}/{prefix}-{basename}"
+        )
+
+        async def copy_asset() -> None:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                io_executor(),
+                partial(
+                    DataFile.resolve(value).copy,
+                    self.output.file(relpath),
+                ),
+            )
+            log_throughput("assets_uploaded", 1, shard_id=shard_id, unit="assets")
+
+        self._window.submit_blocking(copy_asset())
+        return self.output.abs_path(relpath)
+
+
+ASSET_ATTEMPT_DIR_RE = re.compile(
+    r"^(?P<shard_id>[0-9a-f]{12})__w(?P<worker_id>[0-9a-f]{12})$"
+)
+
+
+def asset_columns_from_schema(schema: pa.Schema | None) -> dict[str, str]:
+    if schema is None:
+        return {}
+    columns: dict[str, str] = {}
+    for field in schema:
+        if datatype.is_file_field(field):
+            columns[field.name] = "scalar"
+            continue
+        field_type = field.type
+        if (
+            pa.types.is_list(field_type)
+            or pa.types.is_large_list(field_type)
+            or pa.types.is_fixed_size_list(field_type)
+        ) and datatype.is_file_field(field_type.value_field):
+            columns[field.name] = "list"
+    return columns
+
+
+__all__ = ["AssetUploadManager"]

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any
 
+import pyarrow as pa
+
 from refiner.execution.tracking.shards import count_block_by_shard
 from refiner.pipeline.data.block import Block, split_block_by_shard
 from refiner.worker.metrics.api import log_throughput
@@ -58,15 +60,14 @@ class BaseSink(ABC):
         """
         return None
 
+    def set_input_schema(self, schema: pa.Schema | None) -> None:
+        """Receive the schema expected at this sink boundary before writing starts."""
+        del schema
+
     @property
     def counts_output_rows(self) -> bool:
         """Whether blocks written into this sink should count toward output_rows."""
         return True
-
-    @property
-    def requires_tabular_input(self) -> bool:
-        """Whether this sink expects blocks to be converted to `Tabular` before writing."""
-        return False
 
     def on_shard_complete(self, shard_id: str) -> None:
         """Flush or finalize state for one shard after upstream completion.

--- a/src/refiner/pipeline/sinks/jsonl.py
+++ b/src/refiner/pipeline/sinks/jsonl.py
@@ -8,7 +8,9 @@ import pyarrow as pa
 
 from refiner.io.datafolder import DataFolder, DataFolderLike
 from refiner.pipeline.data.block import Block
+from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.sinks.assets import AssetUploadManager
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
@@ -21,11 +23,32 @@ class JsonlSink(BaseSink):
         output: DataFolderLike,
         *,
         filename_template: str = "{shard_id}__w{worker_id}.jsonl",
+        upload_assets: bool = False,
+        assets_subdir: str = "assets",
+        max_asset_uploads_in_flight: int = 16,
     ):
         self.output = DataFolder.resolve(output)
         self.filename_template = filename_template
+        self.upload_assets = upload_assets
+        self.assets_subdir = assets_subdir
         self._files: dict[str, IO[str]] = {}
         self._encoder = json.JSONEncoder(ensure_ascii=True, separators=(",", ":"))
+        self._assets = (
+            AssetUploadManager(
+                self.output,
+                assets_subdir=assets_subdir,
+                filename_template=filename_template,
+                max_uploads_in_flight=max_asset_uploads_in_flight,
+            )
+            if upload_assets
+            else None
+        )
+        if self._assets is not None:
+            self.assets_subdir = self._assets.assets_subdir
+
+    def set_input_schema(self, schema: pa.Schema | None) -> None:
+        if self._assets is not None:
+            self._assets.set_input_schema(schema)
 
     def _relpath(self, shard_id: str) -> str:
         return self.filename_template.format(
@@ -44,10 +67,17 @@ class JsonlSink(BaseSink):
     def _write_rows(self, shard_id: str, rows: Iterable[Mapping[str, object]]) -> None:
         file = self._file(shard_id)
         for row in rows:
-            file.write(self._encoder.encode(row))
+            file.write(
+                self._encoder.encode(row.to_dict() if isinstance(row, Row) else row)
+            )
             file.write("\n")
 
     def _write_table_rows(self, shard_id: str, table: pa.Table) -> None:
+        if self._assets is not None:
+            self._write_rows(
+                shard_id, self._assets.rewrite_table(shard_id, table).to_pylist()
+            )
+            return
         for batch in table.to_batches(max_chunksize=4096):
             self._write_rows(shard_id, batch.to_pylist())
 
@@ -55,7 +85,10 @@ class JsonlSink(BaseSink):
         if isinstance(block, Tabular):
             self._write_table_rows(shard_id, block.table)
         else:
-            self._write_rows(shard_id, (row.to_dict() for row in block))
+            rows = block
+            if self._assets is not None:
+                rows = self._assets.rewrite_rows(shard_id, rows)
+            self._write_rows(shard_id, rows)
 
     def on_shard_complete(self, shard_id: str) -> None:
         file = self._files.pop(shard_id, None)
@@ -64,25 +97,30 @@ class JsonlSink(BaseSink):
             log_throughput("files_written", 1, shard_id=shard_id, unit="files")
 
     def close(self) -> None:
-        for file in self._files.values():
-            file.close()
-        self._files.clear()
+        try:
+            if self._assets is not None:
+                self._assets.flush()
+        finally:
+            for file in self._files.values():
+                file.close()
+            self._files.clear()
 
     def describe(self) -> tuple[str, str, dict[str, object]]:
-        return (
-            "write_jsonl",
-            "writer",
-            {
-                "path": self.output.abs_path(),
-                "filename_template": self.filename_template,
-            },
-        )
+        args: dict[str, object] = {
+            "path": self.output.abs_path(),
+            "filename_template": self.filename_template,
+        }
+        if self.upload_assets:
+            args["upload_assets"] = True
+            args["assets_subdir"] = self.assets_subdir
+        return ("write_jsonl", "writer", args)
 
     def build_reducer(self) -> BaseSink | None:
         return FileCleanupReducerSink(
             output=self.output,
             filename_template=self.filename_template,
             reducer_name="write_jsonl_reduce",
+            assets_subdir=self.assets_subdir if self.upload_assets else None,
         )
 
 

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -7,6 +7,7 @@ from refiner.io.datafolder import DataFolder, DataFolderLike
 from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.shard import SHARD_ID_COLUMN
 from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.sinks.assets import AssetUploadManager
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
@@ -20,11 +21,34 @@ class ParquetSink(BaseSink):
         *,
         filename_template: str = "{shard_id}__w{worker_id}.parquet",
         compression: str | None = None,
+        upload_assets: bool = False,
+        assets_subdir: str = "assets",
+        max_asset_uploads_in_flight: int = 16,
     ):
         self.output = DataFolder.resolve(output)
         self.filename_template = filename_template
         self.compression = compression
+        self.upload_assets = upload_assets
+        self.assets_subdir = assets_subdir
         self._writers: dict[str, pq.ParquetWriter] = {}
+        self._schema: pa.Schema | None = None
+        self._assets = (
+            AssetUploadManager(
+                self.output,
+                assets_subdir=assets_subdir,
+                filename_template=filename_template,
+                max_uploads_in_flight=max_asset_uploads_in_flight,
+            )
+            if upload_assets
+            else None
+        )
+        if self._assets is not None:
+            self.assets_subdir = self._assets.assets_subdir
+
+    def set_input_schema(self, schema: pa.Schema | None) -> None:
+        self._schema = schema
+        if self._assets is not None:
+            self._assets.set_input_schema(schema)
 
     def _relpath(self, shard_id: str) -> str:
         return self.filename_template.format(
@@ -42,22 +66,25 @@ class ParquetSink(BaseSink):
         return writer
 
     def write_shard_block(self, shard_id: str, block: Block) -> None:
-        table = (
-            block.table
-            if isinstance(block, Tabular)
-            else (
-                Tabular.from_rows(block).table
+        if isinstance(block, Tabular):
+            table = block.table
+        else:
+            if self._assets is not None:
+                self._assets.require_input_schema()
+            table = (
+                Tabular.from_rows(block, schema=self._schema).table
                 if not block
-                else block[0].tabular_type.from_rows(block).table
+                else block[0].tabular_type.from_rows(block, schema=self._schema).table
             )
-        )
         if SHARD_ID_COLUMN in table.schema.names:
             table = table.drop_columns([SHARD_ID_COLUMN])
-        self._writer(shard_id, table.schema).write_table(table)
-
-    @property
-    def requires_tabular_input(self) -> bool:
-        return True
+        if self._assets is None:
+            self._writer(shard_id, table.schema).write_table(table)
+            return
+        self._writer(
+            shard_id,
+            (table := self._assets.rewrite_table(shard_id, table)).schema,
+        ).write_table(table)
 
     def on_shard_complete(self, shard_id: str) -> None:
         writer = self._writers.pop(shard_id, None)
@@ -66,9 +93,13 @@ class ParquetSink(BaseSink):
             log_throughput("files_written", 1, shard_id=shard_id, unit="files")
 
     def close(self) -> None:
-        for writer in self._writers.values():
-            writer.close()
-        self._writers.clear()
+        try:
+            if self._assets is not None:
+                self._assets.flush()
+        finally:
+            for writer in self._writers.values():
+                writer.close()
+            self._writers.clear()
 
     def describe(self) -> tuple[str, str, dict[str, object]]:
         args: dict[str, object] = {
@@ -77,6 +108,9 @@ class ParquetSink(BaseSink):
         }
         if self.compression is not None:
             args["compression"] = self.compression
+        if self.upload_assets:
+            args["upload_assets"] = True
+            args["assets_subdir"] = self.assets_subdir
         return ("write_parquet", "writer", args)
 
     def build_reducer(self) -> BaseSink | None:
@@ -84,6 +118,7 @@ class ParquetSink(BaseSink):
             output=self.output,
             filename_template=self.filename_template,
             reducer_name="write_parquet_reduce",
+            assets_subdir=self.assets_subdir if self.upload_assets else None,
         )
 
 

--- a/src/refiner/pipeline/sinks/reducer/file.py
+++ b/src/refiner/pipeline/sinks/reducer/file.py
@@ -4,6 +4,7 @@ import re
 from string import Formatter
 
 from refiner.io.datafolder import DataFolder, DataFolderLike
+from refiner.pipeline.sinks.assets import ASSET_ATTEMPT_DIR_RE
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.worker.context import get_active_stage_index, get_finalized_workers
 
@@ -65,10 +66,12 @@ class FileCleanupReducerSink(BaseSink):
         *,
         filename_template: str,
         reducer_name: str,
+        assets_subdir: str | None = None,
     ) -> None:
         self.output = DataFolder.resolve(output)
         self.filename_template = filename_template
         self.reducer_name = reducer_name
+        self.assets_subdir = assets_subdir
         self._managed_path_pattern = _compile_managed_path_pattern(filename_template)
         self._cleanup_ran = False
 
@@ -81,13 +84,16 @@ class FileCleanupReducerSink(BaseSink):
         return False
 
     def describe(self) -> tuple[str, str, dict[str, object]]:
+        args = {
+            "path": self.output.abs_path(),
+            "filename_template": self.filename_template,
+        }
+        if self.assets_subdir is not None:
+            args["assets_subdir"] = self.assets_subdir
         return (
             self.reducer_name,
             "writer",
-            {
-                "path": self.output.abs_path(),
-                "filename_template": self.filename_template,
-            },
+            args,
         )
 
     def _run_cleanup(self) -> None:
@@ -112,14 +118,39 @@ class FileCleanupReducerSink(BaseSink):
         try:
             listed_paths = self.output.find("")
         except FileNotFoundError:
-            return
+            listed_paths = []
 
+        assets_prefix = (
+            f"{self.assets_subdir.rstrip('/')}/"
+            if self.assets_subdir is not None
+            else None
+        )
+
+        removed_asset_attempts: set[str] = set()
         # Extra template fields are treated as structure only. Authority is decided
         # solely from the finalized (shard_id, worker_id) pair extracted from each
         # managed path.
         for rel_path in listed_paths:
             if not isinstance(rel_path, str) or not rel_path or rel_path == ".":
                 continue
+            if assets_prefix is not None and (
+                rel_path == self.assets_subdir or rel_path.startswith(assets_prefix)
+            ):
+                attempt_dir = rel_path[len(assets_prefix) :].split("/", maxsplit=1)[0]
+                match = ASSET_ATTEMPT_DIR_RE.fullmatch(attempt_dir)
+                if match is None:
+                    continue
+                if (match.group("shard_id"), match.group("worker_id")) in keep_pairs:
+                    continue
+                if attempt_dir in removed_asset_attempts:
+                    continue
+                removed_asset_attempts.add(attempt_dir)
+                try:
+                    self.output.rm(f"{assets_prefix}{attempt_dir}", recursive=True)
+                except FileNotFoundError:
+                    continue
+                continue
+
             match = self._managed_path_pattern.fullmatch(rel_path)
             if match is None:
                 continue

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -88,6 +88,8 @@ class Worker:
         )
         runtime_services = collect_pipeline_services(self.pipeline)
         sink = self.pipeline.sink or NullSink()
+        sink_schema = self.pipeline.output_schema()
+        sink.set_input_schema(sink_schema)
         sink_step_index = (
             self.pipeline._next_step_index() if self.pipeline.sink is not None else None
         )

--- a/tests/io/test_datafile_datafolder.py
+++ b/tests/io/test_datafile_datafolder.py
@@ -37,6 +37,28 @@ def test_datafile_resolve_with_path_fs_tuple(tmp_path):
     assert df.is_local
 
 
+def test_datafile_copy_skips_same_source_and_destination(tmp_path):
+    asset = tmp_path / "image.png"
+    asset.write_bytes(b"existing")
+    source = DataFile.resolve(str(asset))
+
+    source.copy(str(asset))
+    assert asset.read_bytes() == b"existing"
+
+    source.copy(str(tmp_path / "nested" / ".." / "image.png"))
+    assert asset.read_bytes() == b"existing"
+
+
+def test_datafile_copy_writes_destination(tmp_path):
+    source_path = tmp_path / "source.txt"
+    dest_path = tmp_path / "nested" / "dest.txt"
+    source_path.write_bytes(b"payload")
+
+    DataFile.resolve(str(source_path)).copy(str(dest_path))
+
+    assert dest_path.read_bytes() == b"payload"
+
+
 def test_datafolder_file_and_open_creates_parent_dirs(tmp_path):
     folder = DataFolder.resolve(str(tmp_path))
 

--- a/tests/pipeline/test_datatype.py
+++ b/tests/pipeline/test_datatype.py
@@ -456,7 +456,7 @@ def test_vectorized_cast_after_map_table_reestablishes_schema_override() -> None
     assert blocks[0].table.schema.field("x").type == pa.float32()
 
 
-def test_sink_execution_forces_final_row_schema_to_tabular(tmp_path) -> None:
+def test_pipeline_exposes_final_row_schema_for_sink(tmp_path) -> None:
     pipeline = (
         from_items([{"id": 1}])
         .map(
@@ -468,8 +468,10 @@ def test_sink_execution_forces_final_row_schema_to_tabular(tmp_path) -> None:
 
     blocks = list(pipeline.execute(pipeline.source.read()))
 
-    assert isinstance(blocks[0], Tabular)
-    assert blocks[0].table.schema.field("frames").metadata == {b"asset_type": b"video"}
+    assert isinstance(blocks[0], list)
+    schema = pipeline.output_schema()
+    assert schema is not None
+    assert schema.field("frames").metadata == {b"asset_type": b"video"}
 
 
 def test_tabular_schema_flows_through_row_segment() -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 from typing import cast
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
 from refiner import col
-from refiner.pipeline.data.row import DictRow
+from refiner.pipeline.data import datatype
+from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline import from_items
 from refiner.pipeline.sinks import JsonlSink
 from refiner.pipeline.sinks.parquet import ParquetSink
@@ -115,6 +118,337 @@ def test_jsonl_sink_uses_local_worker_suffix_outside_runtime(tmp_path) -> None:
     assert json.loads(written[0].read_text(encoding="utf-8")) == {"x": 1}
 
 
+def test_parquet_sink_uploads_asset_columns(tmp_path) -> None:
+    source = tmp_path / "source clip.mp4"
+    source.write_bytes(b"video-bytes")
+    output_dir = tmp_path / "parquet-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    table = datatype.apply_dtypes_to_table(
+        pa.table({"video": [str(source), None], "label": ["keep", "none"]}),
+        {"video": datatype.video_file()},
+    )
+    sink = ParquetSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "video" / "0-source_clip.mp4"
+    )
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    assert asset.read_bytes() == b"video-bytes"
+    out = pq.read_table(written)
+    assert out.column("video").to_pylist() == [str(asset), None]
+    assert out.schema.field("video").metadata == {b"asset_type": b"video"}
+
+
+def test_asset_upload_rejects_unsafe_assets_subdir(tmp_path) -> None:
+    with pytest.raises(ValueError, match="assets_subdir"):
+        JsonlSink(tmp_path / "jsonl-assets", upload_assets=True, assets_subdir="../x")
+
+    with pytest.raises(ValueError, match="assets_subdir"):
+        ParquetSink(
+            tmp_path / "parquet-assets",
+            upload_assets=True,
+            assets_subdir="a/../x",
+        )
+
+
+def test_asset_upload_sanitizes_column_path_segment(tmp_path) -> None:
+    source = tmp_path / "source.png"
+    source.write_bytes(b"image")
+    output_dir = tmp_path / "column-segment-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    field = datatype.image_file().with_name("../image")
+    table = pa.Table.from_arrays(
+        [pa.array([str(source)], type=field.type)],
+        schema=pa.schema([field]),
+    )
+    sink = ParquetSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    uploaded = list((output_dir / "assets").glob("**/0-source.png"))
+    assert len(uploaded) == 1
+    assert uploaded[0].read_bytes() == b"image"
+    assert tmp_path.joinpath("image", "0-source.png").exists() is False
+
+
+def test_asset_upload_disambiguates_sanitized_column_segments(tmp_path) -> None:
+    first = tmp_path / "first" / "asset.png"
+    second = tmp_path / "second" / "asset.png"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    output_dir = tmp_path / "column-collision-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    schema = pa.schema(
+        [
+            datatype.image_file().with_name("a/b"),
+            datatype.image_file().with_name("a?b"),
+        ]
+    )
+    table = pa.Table.from_pydict(
+        {"a/b": [str(first)], "a?b": [str(second)]},
+        schema=schema,
+    )
+    sink = ParquetSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    first_asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "a_b" / "0-asset.png"
+    )
+    second_asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "a_b_2" / "0-asset.png"
+    )
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    assert first_asset.read_bytes() == b"first"
+    assert second_asset.read_bytes() == b"second"
+    out = pq.read_table(written)
+    assert out.column("a/b").to_pylist() == [str(first_asset)]
+    assert out.column("a?b").to_pylist() == [str(second_asset)]
+
+
+def test_jsonl_sink_uploads_assets_with_shard_local_row_indexes(tmp_path) -> None:
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    output_dir = tmp_path / "jsonl-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    sink = JsonlSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        for path in [first, second]:
+            table = datatype.apply_dtypes_to_table(
+                pa.table({"image": [str(path)]}),
+                {"image": datatype.image_file()},
+            )
+            sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset_dir = output_dir / "assets" / f"{shard_id}__w{worker}" / "image"
+    assert (asset_dir / "0-first.png").read_bytes() == b"first"
+    assert (asset_dir / "1-second.png").read_bytes() == b"second"
+    jsonl = output_dir / f"{shard_id}__w{worker}.jsonl"
+    rows = [json.loads(line) for line in jsonl.read_text(encoding="utf-8").splitlines()]
+    assert rows == [
+        {"image": str(asset_dir / "0-first.png")},
+        {"image": str(asset_dir / "1-second.png")},
+    ]
+
+
+def test_jsonl_sink_uploads_assets_from_row_blocks_without_tabularizing(
+    tmp_path,
+) -> None:
+    source = tmp_path / "frame.png"
+    source.write_bytes(b"frame")
+    output_dir = tmp_path / "jsonl-row-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    sink = JsonlSink(output_dir, upload_assets=True)
+    sink.set_input_schema(pa.schema([datatype.image_file().with_name("image")]))
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, [DictRow({"image": str(source)})])
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset = output_dir / "assets" / f"{shard_id}__w{worker}" / "image" / "0-frame.png"
+    jsonl = output_dir / f"{shard_id}__w{worker}.jsonl"
+    assert asset.read_bytes() == b"frame"
+    assert json.loads(jsonl.read_text(encoding="utf-8")) == {"image": str(asset)}
+
+
+def test_row_asset_upload_requires_input_schema(tmp_path) -> None:
+    row: list[Row] = [DictRow({"image": str(tmp_path / "frame.png")})]
+
+    jsonl = JsonlSink(tmp_path / "jsonl-row-assets", upload_assets=True)
+    with pytest.raises(ValueError, match="input schema"):
+        jsonl.write_shard_block("0123456789ab", row)
+
+    parquet = ParquetSink(tmp_path / "parquet-row-assets", upload_assets=True)
+    with pytest.raises(ValueError, match="input schema"):
+        parquet.write_shard_block("0123456789ab", row)
+
+
+def test_jsonl_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None:
+    source = tmp_path / "frame.png"
+    source.write_bytes(b"frame")
+    output_dir = tmp_path / "jsonl-pipeline-assets"
+    pipeline = (
+        from_items([{"image": str(source)}])
+        .map(
+            lambda row: {"image": row["image"]},
+            dtypes={"image": datatype.image_file()},
+        )
+        .write_jsonl(output_dir, upload_assets=True)
+    )
+
+    stats = pipeline.launch_local(
+        name="jsonl-row-asset-upload",
+        num_workers=1,
+        rundir=str(tmp_path / "run"),
+    )
+
+    asset = next((output_dir / "assets").glob("*/image/0-frame.png"))
+    written = next(output_dir.glob("*.jsonl"))
+    assert stats.output_rows == 1
+    assert asset.read_bytes() == b"frame"
+    assert json.loads(written.read_text(encoding="utf-8")) == {"image": str(asset)}
+
+
+def test_parquet_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None:
+    source = tmp_path / "frame.png"
+    source.write_bytes(b"frame")
+    output_dir = tmp_path / "parquet-pipeline-assets"
+    pipeline = (
+        from_items([{"image": str(source)}])
+        .map(
+            lambda row: {"image": row["image"]},
+            dtypes={"image": datatype.image_file()},
+        )
+        .write_parquet(output_dir, upload_assets=True)
+    )
+
+    stats = pipeline.launch_local(
+        name="parquet-row-asset-upload",
+        num_workers=1,
+        rundir=str(tmp_path / "run"),
+    )
+
+    asset = next((output_dir / "assets").glob("*/image/0-frame.png"))
+    written = next(output_dir.glob("*.parquet"))
+    table = pq.read_table(written)
+    assert stats.output_rows == 1
+    assert asset.read_bytes() == b"frame"
+    assert table.column("image").to_pylist() == [str(asset)]
+    assert table.schema.field("image").metadata == {b"asset_type": b"image"}
+
+
+def test_parquet_sink_uploads_list_asset_columns(tmp_path) -> None:
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    output_dir = tmp_path / "parquet-list-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    field = pa.field("images", pa.list_(datatype.image_file()))
+    table = pa.Table.from_arrays(
+        [pa.array([[str(first), str(second)], None], type=field.type)],
+        schema=pa.schema([field]),
+    )
+    sink = ParquetSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset_dir = output_dir / "assets" / f"{shard_id}__w{worker}" / "images"
+    assert (asset_dir / "0-0-first.png").read_bytes() == b"first"
+    assert (asset_dir / "0-1-second.png").read_bytes() == b"second"
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    out = pq.read_table(written)
+    assert out.column("images").to_pylist() == [
+        [
+            str(asset_dir / "0-0-first.png"),
+            str(asset_dir / "0-1-second.png"),
+        ],
+        None,
+    ]
+
+
+def test_jsonl_sink_uploads_tuple_asset_columns(tmp_path) -> None:
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    output_dir = tmp_path / "jsonl-tuple-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    sink = JsonlSink(output_dir, upload_assets=True)
+    sink.set_input_schema(
+        pa.schema([pa.field("images", pa.list_(datatype.image_file()))])
+    )
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(
+            shard_id,
+            [DictRow({"images": (str(first), str(second))})],
+        )
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset_dir = output_dir / "assets" / f"{shard_id}__w{worker}" / "images"
+    assert (asset_dir / "0-0-first.png").read_bytes() == b"first"
+    assert (asset_dir / "0-1-second.png").read_bytes() == b"second"
+    jsonl = output_dir / f"{shard_id}__w{worker}.jsonl"
+    assert json.loads(jsonl.read_text(encoding="utf-8")) == {
+        "images": [
+            str(asset_dir / "0-0-first.png"),
+            str(asset_dir / "0-1-second.png"),
+        ]
+    }
+
+
 def test_jsonl_reducer_keeps_only_finalized_worker_outputs(tmp_path) -> None:
     output_dir = tmp_path / "jsonl-cleanup"
     shard_id = "0123456789ab"
@@ -203,6 +537,48 @@ def test_parquet_reducer_keeps_only_finalized_worker_outputs(tmp_path) -> None:
     assert kept.exists()
     assert not deleted.exists()
     assert pq.read_table(kept).column("x").to_pylist() == [9]
+
+
+def test_file_cleanup_reducer_removes_non_finalized_asset_attempt_dirs(
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "asset-cleanup"
+    shard_id = "0123456789ab"
+    winner = worker_token_for("winner")
+    loser = worker_token_for("loser")
+    keep_asset = output_dir / "assets" / f"{shard_id}__w{winner}" / "video" / "0-a.mp4"
+    drop_asset = output_dir / "assets" / f"{shard_id}__w{loser}" / "video" / "0-a.mp4"
+    keep_asset.parent.mkdir(parents=True)
+    drop_asset.parent.mkdir(parents=True)
+    keep_asset.write_bytes(b"keep")
+    drop_asset.write_bytes(b"drop")
+    unmanaged = output_dir / "assets" / "manual" / "keep.txt"
+    unmanaged.parent.mkdir(parents=True)
+    unmanaged.write_text("keep", encoding="utf-8")
+
+    reducer = FileCleanupReducerSink(
+        output_dir,
+        filename_template="{shard_id}__w{worker_id}.jsonl",
+        reducer_name="cleanup_jsonl",
+        assets_subdir="assets",
+    )
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="reducer",
+        worker_name=None,
+        runtime_lifecycle=cast(
+            RuntimeLifecycle,
+            _FinalizedWorkersRuntime(
+                [FinalizedShardWorker(shard_id=shard_id, worker_id="winner")]
+            ),
+        ),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    assert keep_asset.exists()
+    assert unmanaged.exists()
+    assert not drop_asset.exists()
 
 
 def test_file_cleanup_reducer_ignores_extra_template_fields(tmp_path) -> None:
@@ -300,6 +676,22 @@ def test_jsonl_sink_rejects_unsupported_cleanup_filename_template(tmp_path) -> N
 
     with pytest.raises(ValueError, match="requires fields"):
         sink.build_reducer()
+
+
+def test_jsonl_sink_rejects_asset_subdir_filename_template(tmp_path) -> None:
+    with pytest.raises(ValueError, match="assets_subdir"):
+        JsonlSink(
+            tmp_path / "jsonl-custom",
+            filename_template="assets/{shard_id}__w{worker_id}.jsonl",
+            upload_assets=True,
+        )
+
+    with pytest.raises(ValueError, match="assets_subdir"):
+        JsonlSink(
+            tmp_path / "jsonl-custom",
+            filename_template="tmp/../assets/{shard_id}__w{worker_id}.jsonl",
+            upload_assets=True,
+        )
 
 
 def test_parquet_sink_rejects_unsupported_cleanup_filename_template(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- add `upload_assets`, `assets_subdir`, and `max_asset_uploads_in_flight` to JSONL and Parquet writers
- infer file-typed asset columns from dtype/schema metadata, copy raw asset bytes, and rewrite output rows/tables to copied asset paths
- pass final schema metadata to sinks without forcing JSONL row pipelines into tabular blocks
- clean up stale asset attempt directories in the existing reducer, with path traversal guards and safe column path segments

## Validation

- `uv run ruff check src/refiner/execution/engine.py src/refiner/pipeline/pipeline.py src/refiner/pipeline/sinks/assets.py src/refiner/pipeline/sinks/base.py src/refiner/pipeline/sinks/jsonl.py src/refiner/pipeline/sinks/parquet.py src/refiner/pipeline/sinks/reducer/file.py tests/pipeline/test_sinks.py`
- `uv run ty check src/refiner/execution/engine.py src/refiner/pipeline/pipeline.py src/refiner/pipeline/sinks/assets.py src/refiner/pipeline/sinks/base.py src/refiner/pipeline/sinks/jsonl.py src/refiner/pipeline/sinks/parquet.py src/refiner/pipeline/sinks/reducer/file.py tests/pipeline/test_sinks.py`
- `uv run pytest tests/pipeline/test_sinks.py`
- `uv run pytest tests/pipeline tests/readers/test_multi_source_readers.py`