### PR TITLE
Add explicit asset storage dtypes

### DIFF
--- a/docs/reading-and-writing.md
+++ b/docs/reading-and-writing.md
@@ -53,14 +53,13 @@ pipeline = mdr.read_hf_dataset(
     "user/my-dataset",
     config="default",
     split="train",
-    dtypes={"video": mdr.datatype.video_file()},
+    dtypes={"video": mdr.datatype.video_path()},
 )
 ```
 
-Hugging Face `Image`, `Audio`, and `Video` features are marked as file columns
-automatically. Relative file paths in those columns are resolved to
-`hf://datasets/...` references by default; pass `resolve_relative_paths=False` to
-keep the raw values. Absolute paths and URI values are not rewritten.
+Hugging Face `Image`, `Audio`, and `Video` features are marked as embedded asset
+columns automatically. Refiner leaves path values unchanged; use `map(...)` if a
+dataset stores paths that need custom resolution.
 
 ## Common Crawl text readers
 
@@ -206,10 +205,10 @@ Mark path columns as assets with `dtypes=...` on row transforms or with
 ```python
 pipeline = pipeline.map(
     lambda row: {"image": f"{row['image_dir']}/{row['image_name']}"},
-    dtypes={"image": mdr.datatype.image_file()},
+    dtypes={"image": mdr.datatype.image_path()},
 )
 
-pipeline = pipeline.cast(video=mdr.datatype.video_file())
+pipeline = pipeline.cast(video=mdr.datatype.video_path())
 ```
 
 When you run a writer through `launch_local(...)` or `launch_cloud(...)`, some

--- a/src/refiner/pipeline/data/datatype.py
+++ b/src/refiner/pipeline/data/datatype.py
@@ -7,8 +7,13 @@ from typing import TypeAlias, cast
 import pyarrow as pa
 
 _ASSET_TYPE_METADATA_KEY = b"asset_type"
-_FILE_ASSET_TYPES = frozenset({b"unknown", b"image", b"audio", b"video", b"pdf"})
 _FILE_FIELD_NAME = "__refiner_file__"
+_BYTES_WITH_PATH_TYPE = pa.struct(
+    [
+        pa.field("bytes", pa.binary()),
+        pa.field("path", pa.string()),
+    ]
+)
 
 DTypeLike: TypeAlias = str | pa.DataType | pa.Field
 DTypeMapping: TypeAlias = Mapping[str, DTypeLike]
@@ -72,24 +77,76 @@ def map(key_type: DTypeLike, value_type: DTypeLike) -> pa.DataType:
     return pa.map_(_arrow_type(key_type), _arrow_type(value_type))
 
 
-def file() -> pa.Field:
-    return _file_field(b"unknown")
+def asset_path(asset_type: str) -> pa.Field:
+    return _asset_field(asset_type, pa.string())
 
 
-def image_file() -> pa.Field:
-    return _file_field(b"image")
+def asset_bytes(asset_type: str) -> pa.Field:
+    return _asset_field(asset_type, pa.binary())
 
 
-def audio_file() -> pa.Field:
-    return _file_field(b"audio")
+def asset_bytes_with_path(asset_type: str) -> pa.Field:
+    return _asset_field(asset_type, _BYTES_WITH_PATH_TYPE)
 
 
-def video_file() -> pa.Field:
-    return _file_field(b"video")
+def file_path() -> pa.Field:
+    return asset_path("file")
 
 
-def pdf_file() -> pa.Field:
-    return _file_field(b"pdf")
+def file_bytes() -> pa.Field:
+    return asset_bytes("file")
+
+
+def file_bytes_with_path() -> pa.Field:
+    return asset_bytes_with_path("file")
+
+
+def image_path() -> pa.Field:
+    return asset_path("image")
+
+
+def image_bytes() -> pa.Field:
+    return asset_bytes("image")
+
+
+def image_bytes_with_path() -> pa.Field:
+    return asset_bytes_with_path("image")
+
+
+def audio_path() -> pa.Field:
+    return asset_path("audio")
+
+
+def audio_bytes() -> pa.Field:
+    return asset_bytes("audio")
+
+
+def audio_bytes_with_path() -> pa.Field:
+    return asset_bytes_with_path("audio")
+
+
+def video_path() -> pa.Field:
+    return asset_path("video")
+
+
+def video_bytes() -> pa.Field:
+    return asset_bytes("video")
+
+
+def video_bytes_with_path() -> pa.Field:
+    return asset_bytes_with_path("video")
+
+
+def pdf_path() -> pa.Field:
+    return asset_path("pdf")
+
+
+def pdf_bytes() -> pa.Field:
+    return asset_bytes("pdf")
+
+
+def pdf_bytes_with_path() -> pa.Field:
+    return asset_bytes_with_path("pdf")
 
 
 def schema_with_dtypes(
@@ -147,9 +204,32 @@ def apply_dtypes_to_table(
     return out
 
 
-def is_file_field(field: pa.Field) -> builtins.bool:
+def is_asset_field(field: pa.Field) -> builtins.bool:
     metadata = field.metadata or {}
-    return metadata.get(_ASSET_TYPE_METADATA_KEY) in _FILE_ASSET_TYPES
+    return builtins.bool(metadata.get(_ASSET_TYPE_METADATA_KEY))
+
+
+def asset_type(field: pa.Field) -> str | None:
+    metadata = field.metadata or {}
+    value = metadata.get(_ASSET_TYPE_METADATA_KEY)
+    return value.decode("utf-8", errors="replace") if value else None
+
+
+def asset_storage(field: pa.Field) -> str | None:
+    if not is_asset_field(field):
+        return None
+    field_type = field.type
+    if pa.types.is_string(field_type) or pa.types.is_large_string(field_type):
+        return "path"
+    if pa.types.is_binary(field_type) or pa.types.is_large_binary(field_type):
+        return "bytes"
+    if _is_bytes_with_path_type(field_type):
+        return "bytes_with_path"
+    return None
+
+
+def is_asset_path_field(field: pa.Field) -> builtins.bool:
+    return asset_storage(field) == "path"
 
 
 def dtype_to_plan(dtype: DTypeLike) -> str | dict[str, object]:
@@ -171,12 +251,26 @@ def dtype_to_plan(dtype: DTypeLike) -> str | dict[str, object]:
     raise TypeError(f"Unsupported dtype: {type(dtype)!r}")
 
 
-def _file_field(asset_type: bytes) -> pa.Field:
+def _asset_field(asset_type: str, storage_type: pa.DataType) -> pa.Field:
     return pa.field(
         _FILE_FIELD_NAME,
-        pa.string(),
-        metadata={_ASSET_TYPE_METADATA_KEY: asset_type},
+        storage_type,
+        metadata={_ASSET_TYPE_METADATA_KEY: asset_type.encode("utf-8")},
     )
+
+
+def _is_bytes_with_path_type(field_type: pa.DataType) -> builtins.bool:
+    if not pa.types.is_struct(field_type):
+        return False
+    bytes_idx = field_type.get_field_index("bytes")
+    path_idx = field_type.get_field_index("path")
+    if bytes_idx < 0 or path_idx < 0:
+        return False
+    bytes_type = field_type.field(bytes_idx).type
+    path_type = field_type.field(path_idx).type
+    return (
+        pa.types.is_binary(bytes_type) or pa.types.is_large_binary(bytes_type)
+    ) and (pa.types.is_string(path_type) or pa.types.is_large_string(path_type))
 
 
 def _replace_field_dtype(
@@ -246,28 +340,42 @@ __all__ = [
     "DTypeLike",
     "DTypeMapping",
     "apply_dtypes_to_table",
-    "audio_file",
+    "asset_bytes",
+    "asset_bytes_with_path",
+    "asset_path",
+    "asset_storage",
+    "asset_type",
+    "audio_bytes",
+    "audio_bytes_with_path",
+    "audio_path",
     "binary",
     "bool",
     "date",
     "dtype_to_plan",
     "duration",
-    "file",
+    "file_bytes",
+    "file_bytes_with_path",
+    "file_path",
     "float32",
     "float64",
-    "image_file",
+    "image_bytes",
+    "image_bytes_with_path",
+    "image_path",
     "int8",
     "int16",
     "int32",
     "int64",
-    "is_file_field",
+    "is_asset_field",
+    "is_asset_path_field",
     "large_binary",
     "large_list",
     "large_string",
     "list",
     "map",
     "null",
-    "pdf_file",
+    "pdf_bytes",
+    "pdf_bytes_with_path",
+    "pdf_path",
     "schema_with_dtypes",
     "string",
     "struct",
@@ -277,5 +385,7 @@ __all__ = [
     "uint16",
     "uint32",
     "uint64",
-    "video_file",
+    "video_bytes",
+    "video_bytes_with_path",
+    "video_path",
 ]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -592,7 +592,6 @@ def read_hf_dataset(
     config: str | None = None,
     split: str = "train",
     *,
-    resolve_relative_paths: bool = True,
     dtypes: DTypeMapping | None = None,
     hf_token: str | None = None,
     timeout: float = 30.0,
@@ -610,16 +609,12 @@ def read_hf_dataset(
         repo: Hugging Face dataset repository ID.
         config: Dataset config name. If omitted, Hugging Face datasets resolves it.
         split: Dataset split to read.
-        resolve_relative_paths: Whether file-typed relative paths should be rewritten
-            as `hf://datasets/{repo}/...` references. Absolute paths and URI values
-            are left unchanged.
     """
     return RefinerPipeline(
         source=HFDatasetReader(
             repo,
             config=config,
             split=split,
-            resolve_relative_paths=resolve_relative_paths,
             dtypes=dtypes,
             hf_token=hf_token,
             timeout=timeout,

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -245,7 +245,7 @@ def asset_columns_from_schema(schema: pa.Schema | None) -> dict[str, str]:
         return {}
     columns: dict[str, str] = {}
     for field in schema:
-        if datatype.is_file_field(field):
+        if datatype.is_asset_path_field(field):
             columns[field.name] = "scalar"
             continue
         field_type = field.type
@@ -253,7 +253,7 @@ def asset_columns_from_schema(schema: pa.Schema | None) -> dict[str, str]:
             pa.types.is_list(field_type)
             or pa.types.is_large_list(field_type)
             or pa.types.is_fixed_size_list(field_type)
-        ) and datatype.is_file_field(field_type.value_field):
+        ) and datatype.is_asset_path_field(field_type.value_field):
             columns[field.name] = "list"
     return columns
 

--- a/src/refiner/pipeline/sources/readers/hf_dataset.py
+++ b/src/refiner/pipeline/sources/readers/hf_dataset.py
@@ -7,7 +7,6 @@ from urllib.parse import quote
 
 import httpx
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.datatype import DTypeMapping
@@ -26,22 +25,16 @@ from refiner.utils import check_required_dependencies
 
 _HF_HUB = "https://huggingface.co"
 _HF_DATASETS_SERVER = "https://datasets-server.huggingface.co"
-_HF_DATASET_URI_PREFIX = "hf://datasets"
-_HF_FILE_FEATURE_DTYPES = {
-    "Image": datatype.image_file,
-    "Audio": datatype.audio_file,
-    "Video": datatype.video_file,
-    "Pdf": datatype.pdf_file,
+_HF_ASSET_FEATURE_DTYPES = {
+    "Image": datatype.image_bytes_with_path,
+    "Audio": datatype.audio_bytes_with_path,
+    "Video": datatype.video_bytes_with_path,
+    "Pdf": datatype.pdf_bytes_with_path,
 }
 
 
 class HFDatasetReader(BaseSource):
-    """Read Hugging Face datasets through the Hub's generated Parquet shards.
-
-    `resolve_relative_paths` rewrites relative file-typed values as
-    `hf://datasets/{repo}/...` references. Absolute paths and URI values are left
-    unchanged.
-    """
+    """Read Hugging Face datasets through the Hub's generated Parquet shards."""
 
     name = "read_hf_dataset"
 
@@ -51,7 +44,6 @@ class HFDatasetReader(BaseSource):
         config: str | None = None,
         split: str = "train",
         *,
-        resolve_relative_paths: bool = True,
         dtypes: DTypeMapping | None = None,
         hf_token: str | None = None,
         timeout: float = 30.0,
@@ -65,7 +57,6 @@ class HFDatasetReader(BaseSource):
     ):
         self.repo = repo
         self.split = split
-        self.resolve_relative_paths = resolve_relative_paths
         self.hf_token = hf_token
         self.timeout = float(timeout)
         self.target_shard_bytes = target_shard_bytes
@@ -89,7 +80,7 @@ class HFDatasetReader(BaseSource):
 
         inferred_dtypes: dict[str, pa.Field] = {}
         for name, feature in (info.features or {}).items():
-            dtype_factory = _HF_FILE_FEATURE_DTYPES.get(type(feature).__name__)
+            dtype_factory = _HF_ASSET_FEATURE_DTYPES.get(type(feature).__name__)
             if dtype_factory is not None:
                 inferred_dtypes[name] = dtype_factory()
 
@@ -97,39 +88,17 @@ class HFDatasetReader(BaseSource):
         if dtypes:
             effective_dtypes.update(dtypes)
         self.dtypes = effective_dtypes or None
-        file_dtypes = {
-            name: dtype
-            for name, dtype in effective_dtypes.items()
-            if _is_file_dtype(dtype)
-        }
-        non_file_dtypes = {
-            name: dtype
-            for name, dtype in effective_dtypes.items()
-            if not _is_file_dtype(dtype)
-        }
-        self._file_dtypes = file_dtypes or None
-        self._non_file_dtypes = non_file_dtypes or None
-        self._explicit_file_dtype_names = {
-            name for name, dtype in (dtypes or {}).items() if _is_file_dtype(dtype)
-        }
 
-        # Filters on file columns must run after extracting the struct "path" field.
-        # Other filters can be delegated to the Parquet reader for pushdown.
         referenced_filter_columns = (
             filter.referenced_columns() if filter is not None else set()
         )
-        filter_uses_file_dtype = filter is not None and (
-            (
-                self._file_dtypes is not None
-                and bool(self._file_dtypes.keys() & referenced_filter_columns)
-            )
-            or (
-                self.file_path_column is not None
-                and self.file_path_column in referenced_filter_columns
-            )
+        filter_needs_postprocess = (
+            filter is not None
+            and self.file_path_column is not None
+            and self.file_path_column in referenced_filter_columns
         )
-        self._post_parquet_filter = filter if filter_uses_file_dtype else None
-        self._parquet_filter = None if filter_uses_file_dtype else filter
+        self._post_parquet_filter = filter if filter_needs_postprocess else None
+        self._parquet_filter = None if filter_needs_postprocess else filter
         self._post_fallback_filter = filter
         self.split_row_groups = split_row_groups
         self._delegate: ParquetReader | None = None
@@ -165,7 +134,6 @@ class HFDatasetReader(BaseSource):
             "repo": self.repo,
             "config": self.config,
             "split": self.split,
-            "resolve_relative_paths": self.resolve_relative_paths,
             "dtypes": list(self.dtypes) if self.dtypes else None,
         }
 
@@ -256,7 +224,7 @@ class HFDatasetReader(BaseSource):
             filter=self._parquet_filter,
             split_row_groups=self.split_row_groups,
             file_path_column=self.file_path_column,
-            dtypes=self._non_file_dtypes,
+            dtypes=self.dtypes,
             storage_options=(
                 {"headers": {"Authorization": f"Bearer {self.hf_token}"}}
                 if self.hf_token is not None
@@ -325,7 +293,7 @@ class HFDatasetReader(BaseSource):
                 )
             table = self._finish_table(
                 table,
-                non_file_dtypes=self._non_file_dtypes,
+                dtypes=self.dtypes,
                 post_filter=self._post_fallback_filter,
             )
             if table.num_rows > 0:
@@ -335,47 +303,15 @@ class HFDatasetReader(BaseSource):
         self,
         table: pa.Table,
         *,
-        non_file_dtypes: DTypeMapping | None = None,
+        dtypes: DTypeMapping | None = None,
         post_filter: Expr | None = None,
     ) -> pa.Table:
-        if non_file_dtypes:
+        if dtypes:
             table = datatype.apply_dtypes_to_table(
                 table,
-                non_file_dtypes,
+                dtypes,
                 strict=False,
             )
-        if self._file_dtypes:
-            extracted_file_dtypes: dict[str, object] = {}
-            for name, dtype in self._file_dtypes.items():
-                idx = table.schema.get_field_index(name)
-                if idx < 0:
-                    continue
-                field = table.schema.field(idx)
-                if (
-                    pa.types.is_struct(field.type)
-                    and field.type.get_field_index("path") >= 0
-                ):
-                    path = pc.call_function(
-                        "struct_field",
-                        [table.column(idx)],
-                        options=pc.StructFieldOptions(["path"]),
-                    )
-                    table = set_or_append_column(table, name, path)
-                    extracted_file_dtypes[name] = dtype
-                    continue
-                if pa.types.is_string(field.type) or pa.types.is_large_string(
-                    field.type
-                ):
-                    extracted_file_dtypes[name] = dtype
-                    continue
-                if name in self._explicit_file_dtype_names:
-                    extracted_file_dtypes[name] = dtype
-            if extracted_file_dtypes:
-                table = datatype.apply_dtypes_to_table(
-                    table,
-                    extracted_file_dtypes,
-                    strict=False,
-                )
         if post_filter is not None:
             table = filter_table(table, post_filter)
         if self.columns_to_read is not None:
@@ -387,71 +323,7 @@ class HFDatasetReader(BaseSource):
             ):
                 columns.append(self.file_path_column)
             table = table.select([col for col in columns if col in table.column_names])
-        if self.resolve_relative_paths:
-            table = resolve_hf_relative_paths(table, self.repo)
         return table
-
-
-def _is_file_dtype(dtype: object) -> bool:
-    return isinstance(dtype, pa.Field) and datatype.is_file_field(dtype)
-
-
-def resolve_hf_relative_paths(table: pa.Table, repo: str) -> pa.Table:
-    """Resolve relative file columns against the HF dataset repository root."""
-
-    out = table
-    for idx, field in enumerate(table.schema):
-        if not datatype.is_file_field(field):
-            continue
-        column = table.column(idx)
-
-        # Treat local absolute paths and any scheme:// URI as already resolved.
-        # find_substring is intentionally used instead of regex for the hot path.
-        local_absolute = pc.call_function(
-            "starts_with",
-            [column],
-            options=pc.MatchSubstringOptions("/"),
-        )
-        protocol_position = pc.call_function(
-            "find_substring",
-            [column],
-            options=pc.MatchSubstringOptions("://"),
-        )
-        remote_absolute = pc.call_function(
-            "greater_equal",
-            [protocol_position, pa.scalar(0, type=pa.int32())],
-        )
-        relative = pc.call_function(
-            "and",
-            [
-                pc.fill_null(pc.call_function("invert", [local_absolute]), False),
-                pc.fill_null(pc.call_function("invert", [remote_absolute]), False),
-            ],
-        )
-        if not bool(pc.call_function("any", [relative]).as_py()):
-            continue
-
-        # HF file feature paths sometimes start with ./; normalize those before
-        # constructing the hf://datasets/{repo}/... reference.
-        stripped = pc.call_function(
-            "replace_substring_regex",
-            [column],
-            options=pc.ReplaceSubstringOptions(pattern=r"^(?:\./)+", replacement=""),
-        )
-        resolved = pc.call_function(
-            "binary_join_element_wise",
-            [
-                pa.scalar(f"{_HF_DATASET_URI_PREFIX}/{repo}/"),
-                stripped,
-                pa.scalar(""),
-            ],
-        )
-        out = set_or_append_column(
-            out,
-            field.name,
-            pc.call_function("if_else", [relative, resolved, column]),
-        )
-    return out
 
 
 def _list_parquet_urls(

--- a/tests/pipeline/test_datatype.py
+++ b/tests/pipeline/test_datatype.py
@@ -17,9 +17,17 @@ from refiner.pipeline.steps import FilterExprStep, FnRowStep
 def test_datatype_constructors_produce_arrow_types_and_metadata() -> None:
     assert datatype.int64() == pa.int64()
     assert datatype.list("uint8") == pa.list_(pa.uint8())
-    assert datatype.video_file().type == pa.string()
-    assert datatype.video_file().metadata == {b"asset_type": b"video"}
-    assert datatype.file().metadata == {b"asset_type": b"unknown"}
+    assert datatype.video_path().type == pa.string()
+    assert datatype.video_path().metadata == {b"asset_type": b"video"}
+    assert datatype.file_path().metadata == {b"asset_type": b"file"}
+    assert datatype.video_path().type == pa.string()
+    assert datatype.video_bytes().type == pa.binary()
+    assert datatype.video_bytes_with_path().type == pa.struct(
+        [pa.field("bytes", pa.binary()), pa.field("path", pa.string())]
+    )
+    assert datatype.asset_storage(datatype.video_path()) == "path"
+    assert datatype.asset_storage(datatype.video_bytes()) == "bytes"
+    assert datatype.asset_storage(datatype.video_bytes_with_path()) == "bytes_with_path"
     assert datatype.list(datatype.uint8()) == pa.list_(pa.uint8())
     assert datatype.list(datatype.uint8(), size=3) == pa.list_(pa.uint8(), list_size=3)
     assert datatype.struct({"x": datatype.float32()}) == pa.struct(
@@ -46,11 +54,11 @@ def test_schema_and_table_dtypes_preserve_unrelated_metadata() -> None:
 
     schema = datatype.schema_with_dtypes(
         table.schema,
-        {"frames": datatype.video_file(), "label": pa.large_string()},
+        {"frames": datatype.video_path(), "label": pa.large_string()},
     )
     out = datatype.apply_dtypes_to_table(
         table,
-        {"frames": datatype.video_file(), "label": pa.large_string()},
+        {"frames": datatype.video_path(), "label": pa.large_string()},
     )
 
     assert schema is not None
@@ -87,7 +95,7 @@ def test_dict_rows_with_schema_preserve_field_metadata() -> None:
 def test_arrow_row_fast_path_preserves_field_metadata() -> None:
     table = datatype.apply_dtypes_to_table(
         pa.table({"frames": ["a.mp4", "b.mp4"]}),
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
     rows = Tabular(table).to_rows()
 
@@ -112,7 +120,7 @@ def test_arrow_row_fast_path_applies_carried_schema_to_unchanged_columns() -> No
     rows = Tabular(table).to_rows()
     schema = datatype.schema_with_dtypes(
         table.schema,
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
 
     out = Tabular.from_rows(rows, schema=schema).table
@@ -163,7 +171,7 @@ def test_row_segment_dtypes_apply_to_unchanged_arrow_rows() -> None:
                         FnRowStep(
                             fn=lambda row: row,
                             index=1,
-                            dtypes={"frames": rf.datatype.video_file()},
+                            dtypes={"frames": rf.datatype.video_path()},
                         ),
                     )
                 ),
@@ -186,7 +194,7 @@ def test_row_segment_dtypes_apply_to_unchanged_arrow_rows() -> None:
 def test_map_dtypes_do_not_attach_schema_to_row_outputs() -> None:
     pipeline = from_items([{"id": 1}]).map(
         lambda row: {"frames": "clip.mp4"},
-        dtypes={"frames": rf.datatype.video_file()},
+        dtypes={"frames": rf.datatype.video_path()},
     )
 
     blocks = list(pipeline.execute(pipeline.source.read()))
@@ -202,8 +210,8 @@ def test_map_dtypes_do_not_attach_declared_schema_overrides_to_rows() -> None:
     pipeline = from_items([{"id": 1}]).map(
         lambda row: {"frames": "clip.mp4"},
         dtypes={
-            "frames": rf.datatype.video_file(),
-            "missing": rf.datatype.video_file(),
+            "frames": rf.datatype.video_path(),
+            "missing": rf.datatype.video_path(),
         },
     )
 
@@ -220,11 +228,11 @@ def test_map_dtypes_accumulate_across_row_steps() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .map(
             lambda row: row.update({"audio": "clip.wav"}),
-            dtypes={"audio": rf.datatype.audio_file()},
+            dtypes={"audio": rf.datatype.audio_path()},
         )
         .filter(rf.col("frames").is_not_null())
     )
@@ -269,7 +277,7 @@ def test_untyped_row_overwrite_does_not_attach_schema_to_rows() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .map(lambda row: {"frames": "label-not-video"})
     )
@@ -288,7 +296,7 @@ def test_incompatible_row_value_clears_schema_field_on_table_conversion() -> Non
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .map(lambda row: {"frames": 123})
         .filter(rf.col("frames").is_not_null())
@@ -305,7 +313,7 @@ def test_incompatible_row_value_clears_schema_field_on_table_conversion() -> Non
 def test_incompatible_arrow_row_patch_clears_field_metadata() -> None:
     table = datatype.apply_dtypes_to_table(
         pa.table({"frames": ["a.mp4", "b.mp4"]}),
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
     rows = [row.update({"frames": idx}) for idx, row in enumerate(Tabular(table))]
 
@@ -321,7 +329,7 @@ def test_row_step_schemas_flow_through_untyped_steps() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .map(lambda row: row.update({"label": "keep"}))
         .filter(rf.col("frames").is_not_null())
@@ -338,7 +346,7 @@ def test_vectorized_schema_flows_into_later_row_segment() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .filter(rf.col("frames").is_not_null())
         .map(lambda row: row.update({"frames": row["frames"]}))
@@ -356,7 +364,7 @@ def test_vectorized_assignment_clears_previous_schema_override() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .filter(rf.col("frames").is_not_null())
         .with_column("frames", "label")
@@ -389,7 +397,7 @@ def test_vectorized_cast_clears_previous_file_metadata() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "123"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .filter(rf.col("frames").is_not_null())
         .cast(frames="int64")
@@ -409,7 +417,7 @@ def test_row_dtype_redefinition_clears_previous_file_metadata() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "123"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .map(
             lambda row: row.update({"frames": row["frames"]}),
@@ -429,7 +437,7 @@ def test_row_dtype_redefinition_clears_previous_file_metadata() -> None:
 def test_vectorized_cast_accepts_file_dtype_metadata() -> None:
     pipeline = (
         from_items([{"frames": "clip.mp4"}])
-        .cast(frames=rf.datatype.video_file())
+        .cast(frames=rf.datatype.video_path())
         .map(lambda row: row.update({"frames": row["frames"]}))
         .filter(rf.col("frames").is_not_null())
     )
@@ -461,7 +469,7 @@ def test_pipeline_exposes_final_row_schema_for_sink(tmp_path) -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: row.update({"frames": "clip.mp4"}),
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .write_parquet(tmp_path)
     )
@@ -477,7 +485,7 @@ def test_pipeline_exposes_final_row_schema_for_sink(tmp_path) -> None:
 def test_tabular_schema_flows_through_row_segment() -> None:
     table = datatype.apply_dtypes_to_table(
         pa.table({"frames": ["clip.mp4"]}),
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
 
     blocks = list(
@@ -506,7 +514,7 @@ def test_tabular_schema_flows_through_row_segment() -> None:
 def test_map_dtypes_attach_declared_schema_even_when_column_is_absent() -> None:
     pipeline = from_items([{"id": 1}]).map(
         lambda row: {"frames": "clip.mp4"},
-        dtypes={"missing": rf.datatype.video_file()},
+        dtypes={"missing": rf.datatype.video_path()},
     )
 
     blocks = list(pipeline.execute(pipeline.source.read()))
@@ -522,7 +530,7 @@ def test_map_dtypes_apply_to_downstream_tabular_blocks() -> None:
         from_items([{"id": 1}])
         .map(
             lambda row: {"frames": "clip.mp4"},
-            dtypes={"frames": rf.datatype.video_file()},
+            dtypes={"frames": rf.datatype.video_path()},
         )
         .filter(rf.col("frames").is_not_null())
     )
@@ -537,7 +545,7 @@ def test_map_dtypes_apply_to_downstream_tabular_blocks() -> None:
 def test_parquet_sink_and_reader_preserve_field_metadata(tmp_path) -> None:
     table = datatype.apply_dtypes_to_table(
         pa.table({"frames": ["clip.mp4"]}),
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
     sink = ParquetSink(tmp_path)
     sink.write_shard_block("train", Tabular(table))

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -107,7 +107,7 @@ def test_compile_pipeline_plan_flattens_vectorized_segment_ops() -> None:
         .filter(col("x") > 1)
         .with_columns(y=col("x") + 10)
         .select("y")
-        .cast(y=rf.datatype.video_file())
+        .cast(y=rf.datatype.video_path())
     )
     plan = compile_pipeline_plan(payload)
     steps = plan["stages"][0]["steps"]

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -126,7 +126,7 @@ def test_parquet_sink_uploads_asset_columns(tmp_path) -> None:
     worker_id = "worker-1"
     table = datatype.apply_dtypes_to_table(
         pa.table({"video": [str(source), None], "label": ["keep", "none"]}),
-        {"video": datatype.video_file()},
+        {"video": datatype.video_path()},
     )
     sink = ParquetSink(output_dir, upload_assets=True)
 
@@ -151,6 +151,42 @@ def test_parquet_sink_uploads_asset_columns(tmp_path) -> None:
     assert out.schema.field("video").metadata == {b"asset_type": b"video"}
 
 
+def test_parquet_sink_does_not_upload_embedded_assets(tmp_path) -> None:
+    output_dir = tmp_path / "embedded-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    field = datatype.image_bytes_with_path().with_name("image")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [{"bytes": b"image-bytes", "path": "source.png"}],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    sink = ParquetSink(output_dir, upload_assets=True)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    out = pq.read_table(written)
+    assert not (output_dir / "assets").exists()
+    assert out.column("image").to_pylist() == [
+        {"bytes": b"image-bytes", "path": "source.png"}
+    ]
+    assert datatype.asset_storage(out.schema.field("image")) == "bytes_with_path"
+
+
 def test_asset_upload_rejects_unsafe_assets_subdir(tmp_path) -> None:
     with pytest.raises(ValueError, match="assets_subdir"):
         JsonlSink(tmp_path / "jsonl-assets", upload_assets=True, assets_subdir="../x")
@@ -169,7 +205,7 @@ def test_asset_upload_sanitizes_column_path_segment(tmp_path) -> None:
     output_dir = tmp_path / "column-segment-assets"
     shard_id = "0123456789ab"
     worker_id = "worker-1"
-    field = datatype.image_file().with_name("../image")
+    field = datatype.image_path().with_name("../image")
     table = pa.Table.from_arrays(
         [pa.array([str(source)], type=field.type)],
         schema=pa.schema([field]),
@@ -204,8 +240,8 @@ def test_asset_upload_disambiguates_sanitized_column_segments(tmp_path) -> None:
     worker_id = "worker-1"
     schema = pa.schema(
         [
-            datatype.image_file().with_name("a/b"),
-            datatype.image_file().with_name("a?b"),
+            datatype.image_path().with_name("a/b"),
+            datatype.image_path().with_name("a?b"),
         ]
     )
     table = pa.Table.from_pydict(
@@ -259,7 +295,7 @@ def test_jsonl_sink_uploads_assets_with_shard_local_row_indexes(tmp_path) -> Non
         for path in [first, second]:
             table = datatype.apply_dtypes_to_table(
                 pa.table({"image": [str(path)]}),
-                {"image": datatype.image_file()},
+                {"image": datatype.image_path()},
             )
             sink.write_shard_block(shard_id, Tabular(table))
         sink.on_shard_complete(shard_id)
@@ -285,7 +321,7 @@ def test_jsonl_sink_uploads_assets_from_row_blocks_without_tabularizing(
     shard_id = "0123456789ab"
     worker_id = "worker-1"
     sink = JsonlSink(output_dir, upload_assets=True)
-    sink.set_input_schema(pa.schema([datatype.image_file().with_name("image")]))
+    sink.set_input_schema(pa.schema([datatype.image_path().with_name("image")]))
 
     with set_active_run_context(
         job_id="job",
@@ -324,7 +360,7 @@ def test_jsonl_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None:
         from_items([{"image": str(source)}])
         .map(
             lambda row: {"image": row["image"]},
-            dtypes={"image": datatype.image_file()},
+            dtypes={"image": datatype.image_path()},
         )
         .write_jsonl(output_dir, upload_assets=True)
     )
@@ -350,7 +386,7 @@ def test_parquet_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None
         from_items([{"image": str(source)}])
         .map(
             lambda row: {"image": row["image"]},
-            dtypes={"image": datatype.image_file()},
+            dtypes={"image": datatype.image_path()},
         )
         .write_parquet(output_dir, upload_assets=True)
     )
@@ -378,7 +414,7 @@ def test_parquet_sink_uploads_list_asset_columns(tmp_path) -> None:
     output_dir = tmp_path / "parquet-list-assets"
     shard_id = "0123456789ab"
     worker_id = "worker-1"
-    field = pa.field("images", pa.list_(datatype.image_file()))
+    field = pa.field("images", pa.list_(datatype.image_path()))
     table = pa.Table.from_arrays(
         [pa.array([[str(first), str(second)], None], type=field.type)],
         schema=pa.schema([field]),
@@ -420,7 +456,7 @@ def test_jsonl_sink_uploads_tuple_asset_columns(tmp_path) -> None:
     worker_id = "worker-1"
     sink = JsonlSink(output_dir, upload_assets=True)
     sink.set_input_schema(
-        pa.schema([pa.field("images", pa.list_(datatype.image_file()))])
+        pa.schema([pa.field("images", pa.list_(datatype.image_path()))])
     )
 
     with set_active_run_context(

--- a/tests/readers/test_csv_reader.py
+++ b/tests/readers/test_csv_reader.py
@@ -72,7 +72,7 @@ def test_csv_reader_applies_dtypes_to_arrow_and_python_paths(tmp_path):
     p = tmp_path / "data.csv"
     p.write_text("id,video\n0,clip.mp4\n")
 
-    arrow_reader = CsvReader(str(p), dtypes={"video": datatype.video_file()})
+    arrow_reader = CsvReader(str(p), dtypes={"video": datatype.video_path()})
     arrow_unit = next(iter(arrow_reader.read_shard(arrow_reader.list_shards()[0])))
     assert isinstance(arrow_unit, Tabular)
     assert arrow_unit.table.schema.field("video").metadata == {b"asset_type": b"video"}
@@ -80,7 +80,7 @@ def test_csv_reader_applies_dtypes_to_arrow_and_python_paths(tmp_path):
     python_reader = CsvReader(
         str(p),
         multiline_rows=True,
-        dtypes={"video": datatype.video_file()},
+        dtypes={"video": datatype.video_path()},
     )
     python_row = next(iter(python_reader.read_shard(python_reader.list_shards()[0])))
     assert not hasattr(python_row, "schema")

--- a/tests/readers/test_hf_dataset_reader.py
+++ b/tests/readers/test_hf_dataset_reader.py
@@ -69,47 +69,9 @@ def _parquet_builder(data_files: object) -> object:
     return builder
 
 
-def test_resolve_hf_relative_paths_rewrites_only_relative_file_values() -> None:
-    table = datatype.apply_dtypes_to_table(
-        pa.table(
-            {
-                "frames": [
-                    "relative/path.mp4",
-                    "./nested/path.mp4",
-                    "https://example.com/path.mp4",
-                    "hf://datasets/repo/path.mp4",
-                    "s3://bucket/path.mp4",
-                    "gs://bucket/path.mp4",
-                    "memory://bucket/path.mp4",
-                    "az+https://account/path.mp4",
-                    "/local/path.mp4",
-                    None,
-                ],
-                "text": ["unchanged"] * 10,
-            }
-        ),
-        {"frames": datatype.video_file()},
-    )
-
-    out = hf_dataset.resolve_hf_relative_paths(table, "org/repo")
-
-    assert out.column("frames").to_pylist() == [
-        "hf://datasets/org/repo/relative/path.mp4",
-        "hf://datasets/org/repo/nested/path.mp4",
-        "https://example.com/path.mp4",
-        "hf://datasets/repo/path.mp4",
-        "s3://bucket/path.mp4",
-        "gs://bucket/path.mp4",
-        "memory://bucket/path.mp4",
-        "az+https://account/path.mp4",
-        "/local/path.mp4",
-        None,
-    ]
-    assert out.column("text").to_pylist() == ["unchanged"] * 10
-    assert out.schema.field("frames").metadata == {b"asset_type": b"video"}
-
-
-def test_hf_dataset_reader_lists_parquet_and_resolves_file_dtypes(monkeypatch) -> None:
+def test_hf_dataset_reader_lists_parquet_and_preserves_asset_path_values(
+    monkeypatch,
+) -> None:
     _install_datasets(monkeypatch, config="cfg")
     calls: list[str] = []
     storage_options: list[object] = []
@@ -146,21 +108,13 @@ def test_hf_dataset_reader_lists_parquet_and_resolves_file_dtypes(monkeypatch) -
             table = pa.table(
                 {
                     "frames": ["clip.mp4", "https://example.com/clip.mp4"],
-                    "image": pa.array(
-                        [
-                            {"bytes": None, "path": "image.png"},
-                            {"bytes": None, "path": None},
-                        ],
-                        type=pa.struct(
-                            [
-                                pa.field("bytes", pa.binary()),
-                                pa.field("path", pa.string()),
-                            ]
-                        ),
-                    ),
+                    "image": ["image.png", None],
                     "audio": ["sound.wav", "hf://datasets/org/repo/sound.wav"],
                 }
             )
+            table = datatype.apply_dtypes_to_table(table, self.dtypes, strict=False)
+            if self.filter is not None:
+                table = hf_dataset.filter_table(table, self.filter)
             yield Tabular(table)
 
     monkeypatch.setattr(hf_dataset, "_get_json", fake_get_json)
@@ -171,9 +125,9 @@ def test_hf_dataset_reader_lists_parquet_and_resolves_file_dtypes(monkeypatch) -
         config="cfg",
         split="train",
         dtypes={
-            "frames": datatype.video_file(),
-            "image": datatype.image_file(),
-            "audio": datatype.audio_file(),
+            "frames": datatype.video_path(),
+            "image": datatype.image_path(),
+            "audio": datatype.audio_path(),
         },
         filter=col("image") == "image.png",
         hf_token="tok",
@@ -191,23 +145,21 @@ def test_hf_dataset_reader_lists_parquet_and_resolves_file_dtypes(monkeypatch) -
         "https://huggingface.co/datasets/org/repo/resolve/refs%2Fconvert%2Fparquet/cfg/train/0.parquet"
     ]
     assert storage_options[0] == {"headers": {"Authorization": "Bearer tok"}}
-    assert parquet_dtypes[0] is None
-    assert parquet_filters[0] is None
+    assert parquet_dtypes[0] == {
+        "frames": datatype.video_path(),
+        "image": datatype.image_path(),
+        "audio": datatype.audio_path(),
+    }
+    assert parquet_filters[0] is not None
     units = list(reader.read_shard(shard))
 
     assert calls
     assert isinstance(units[0], Tabular)
     table = units[0].table
     assert table.num_rows == 1
-    assert table.column("frames").to_pylist() == [
-        "hf://datasets/org/repo/clip.mp4",
-    ]
-    assert table.column("image").to_pylist() == [
-        "hf://datasets/org/repo/image.png",
-    ]
-    assert table.column("audio").to_pylist() == [
-        "hf://datasets/org/repo/sound.wav",
-    ]
+    assert table.column("frames").to_pylist() == ["clip.mp4"]
+    assert table.column("image").to_pylist() == ["image.png"]
+    assert table.column("audio").to_pylist() == ["sound.wav"]
     assert table.schema.field("frames").metadata == {b"asset_type": b"video"}
     assert table.schema.field("image").metadata == {b"asset_type": b"image"}
     assert table.schema.field("audio").metadata == {b"asset_type": b"audio"}
@@ -241,28 +193,41 @@ def test_hf_dataset_reader_infers_media_dtypes_from_features(monkeypatch) -> Non
 
         def read_shard(self, shard):
             del shard
-            yield Tabular(
-                pa.table(
-                    {
-                        "image": pa.array(
-                            [{"bytes": None, "path": "image.png"}],
-                            type=pa.struct(
-                                [
-                                    pa.field("bytes", pa.binary()),
-                                    pa.field("path", pa.string()),
-                                ]
-                            ),
+            table = pa.table(
+                {
+                    "image": pa.array(
+                        [{"bytes": None, "path": "image.png"}],
+                        type=pa.struct(
+                            [
+                                pa.field("bytes", pa.binary()),
+                                pa.field("path", pa.string()),
+                            ]
                         ),
-                        "audio": ["sound.wav"],
-                        "label": ["cat"],
-                    }
+                    ),
+                    "audio": pa.array(
+                        [{"bytes": None, "path": "sound.wav"}],
+                        type=pa.struct(
+                            [
+                                pa.field("bytes", pa.binary()),
+                                pa.field("path", pa.string()),
+                            ]
+                        ),
+                    ),
+                    "label": ["cat"],
+                }
+            )
+            yield Tabular(
+                datatype.apply_dtypes_to_table(
+                    table,
+                    self.dtypes,
+                    strict=False,
                 )
             )
 
     monkeypatch.setattr(hf_dataset, "_get_json", fake_get_json)
     monkeypatch.setattr(hf_dataset, "ParquetReader", FakeParquetReader)
 
-    reader = HFDatasetReader("org/repo", resolve_relative_paths=False)
+    reader = HFDatasetReader("org/repo")
 
     schema = reader.schema
     assert schema is not None
@@ -272,11 +237,13 @@ def test_hf_dataset_reader_infers_media_dtypes_from_features(monkeypatch) -> Non
     units = list(reader.read_shard(reader.list_shards()[0]))
     assert isinstance(units[0], Tabular)
     table = units[0].table
-    assert table.column("image").to_pylist() == ["image.png"]
-    assert table.column("audio").to_pylist() == ["sound.wav"]
+    assert table.column("image").to_pylist() == [{"bytes": None, "path": "image.png"}]
+    assert table.column("audio").to_pylist() == [{"bytes": None, "path": "sound.wav"}]
     assert table.column("label").to_pylist() == ["cat"]
     assert table.schema.field("image").metadata == {b"asset_type": b"image"}
     assert table.schema.field("audio").metadata == {b"asset_type": b"audio"}
+    assert datatype.asset_storage(table.schema.field("image")) == "bytes_with_path"
+    assert datatype.asset_storage(table.schema.field("audio")) == "bytes_with_path"
     assert calls == [
         "https://huggingface.co/api/datasets/org/repo/parquet/default/train"
     ]
@@ -399,11 +366,12 @@ def test_hf_dataset_reader_leaves_bytes_only_media_feature_raw(monkeypatch) -> N
     assert table.schema.field("image").metadata is None
 
 
-def test_hf_file_filter_loads_filter_column_before_final_projection(
+def test_hf_asset_path_filter_delegates_to_parquet_reader(
     monkeypatch,
 ) -> None:
     _install_datasets(monkeypatch)
     delegate_columns: list[tuple[str, ...] | None] = []
+    delegate_filters: list[object] = []
 
     def fake_get_json(url: str, *, hf_token: str | None, timeout: float) -> object:
         del hf_token, timeout
@@ -415,33 +383,27 @@ def test_hf_file_filter_loads_filter_column_before_final_projection(
         def __init__(self, inputs, **kwargs):
             del inputs
             self.columns_to_read = kwargs["columns_to_read"]
+            self.dtypes = kwargs["dtypes"]
+            self.filter = kwargs["filter"]
             delegate_columns.append(self.columns_to_read)
+            delegate_filters.append(self.filter)
 
         def list_shards(self):
             return [_parquet_shard()]
 
         def read_shard(self, shard):
             del shard
-            yield Tabular(
-                pa.table(
-                    {
-                        "audio": ["a.wav", "b.wav"],
-                        "image": pa.array(
-                            [
-                                {"bytes": None, "path": "keep.png"},
-                                {"bytes": None, "path": "drop.jpg"},
-                            ],
-                            type=pa.struct(
-                                [
-                                    pa.field("bytes", pa.binary()),
-                                    pa.field("path", pa.string()),
-                                ]
-                            ),
-                        ),
-                        "file_path": ["source.parquet", "source.parquet"],
-                    }
-                )
+            table = pa.table(
+                {
+                    "audio": ["a.wav", "b.wav"],
+                    "image": ["keep.png", "drop.jpg"],
+                    "file_path": ["source.parquet", "source.parquet"],
+                }
             )
+            table = datatype.apply_dtypes_to_table(table, self.dtypes, strict=False)
+            if self.filter is not None:
+                table = hf_dataset.filter_table(table, self.filter)
+            yield Tabular(table)
 
     monkeypatch.setattr(hf_dataset, "_get_json", fake_get_json)
     monkeypatch.setattr(hf_dataset, "ParquetReader", FakeParquetReader)
@@ -450,19 +412,20 @@ def test_hf_file_filter_loads_filter_column_before_final_projection(
         "org/repo",
         columns_to_read=("audio",),
         dtypes={
-            "audio": datatype.audio_file(),
-            "image": datatype.image_file(),
+            "audio": datatype.audio_path(),
+            "image": datatype.image_path(),
         },
         filter=col("image") == "keep.png",
     )
 
     units = list(reader.read_shard(reader.list_shards()[0]))
 
-    assert delegate_columns == [("audio", "image")]
+    assert delegate_columns == [("audio",)]
+    assert delegate_filters[0] is not None
     assert isinstance(units[0], Tabular)
     table = units[0].table
     assert table.column_names == ["audio", "file_path"]
-    assert table.column("audio").to_pylist() == ["hf://datasets/org/repo/a.wav"]
+    assert table.column("audio").to_pylist() == ["a.wav"]
     assert table.column("file_path").to_pylist() == ["source.parquet"]
 
 
@@ -662,7 +625,18 @@ def test_hf_dataset_reader_falls_back_to_datasets_streaming(monkeypatch) -> None
                 {
                     "id": [str(base_id), str(base_id + 1)],
                     "label": ["drop", "keep"],
-                    "video": ["drop.mp4", "keep.mp4"],
+                    "video": pa.array(
+                        [
+                            {"bytes": None, "path": "drop.mp4"},
+                            {"bytes": None, "path": "keep.mp4"},
+                        ],
+                        type=pa.struct(
+                            [
+                                pa.field("bytes", pa.binary()),
+                                pa.field("path", pa.string()),
+                            ]
+                        ),
+                    ),
                 }
             )
 
@@ -696,8 +670,9 @@ def test_hf_dataset_reader_falls_back_to_datasets_streaming(monkeypatch) -> None
     assert table.column("id").type == pa.int64()
     assert table.column("file_path").to_pylist() == [None]
     assert table.column("label").to_pylist() == ["keep"]
-    assert table.column("video").to_pylist() == ["hf://datasets/org/repo/keep.mp4"]
+    assert table.column("video").to_pylist() == [{"bytes": None, "path": "keep.mp4"}]
     assert table.schema.field("video").metadata == {b"asset_type": b"video"}
+    assert datatype.asset_storage(table.schema.field("video")) == "bytes_with_path"
 
 
 def test_hf_dataset_fallback_errors_when_requested_shards_exceed_source_shards(

--- a/tests/readers/test_jsonl_reader.py
+++ b/tests/readers/test_jsonl_reader.py
@@ -41,7 +41,7 @@ def test_jsonl_reader_applies_dtypes(tmp_path):
     p = tmp_path / "data.jsonl"
     p.write_bytes(orjson.dumps({"video": "clip.mp4"}) + b"\n")
 
-    reader = JsonlReader(str(p), dtypes={"video": datatype.video_file()})
+    reader = JsonlReader(str(p), dtypes={"video": datatype.video_path()})
     unit = next(iter(reader.read_shard(reader.list_shards()[0])))
 
     assert isinstance(unit, Tabular)
@@ -52,7 +52,7 @@ def test_jsonl_reader_schema_exposes_dtype_overrides(tmp_path):
     p = tmp_path / "data.jsonl"
     p.write_bytes(orjson.dumps({"video": "clip.mp4"}) + b"\n")
 
-    reader = JsonlReader(str(p), dtypes={"video": datatype.video_file()})
+    reader = JsonlReader(str(p), dtypes={"video": datatype.video_path()})
 
     assert reader.schema is not None
     assert reader.schema.field("video").metadata == {b"asset_type": b"video"}

--- a/tests/readers/test_parquet_reader.py
+++ b/tests/readers/test_parquet_reader.py
@@ -108,7 +108,7 @@ def test_parquet_reader_schema_exposes_only_dtype_overrides(tmp_path):
     reader = ParquetReader(
         str(p),
         columns_to_read=("x",),
-        dtypes={"x": datatype.video_file()},
+        dtypes={"x": datatype.video_path()},
     )
 
     schema = reader.schema
@@ -180,7 +180,7 @@ def test_parquet_dtype_override_clears_stale_file_metadata(tmp_path):
     p = tmp_path / "metadata.parquet"
     table = datatype.apply_dtypes_to_table(
         pa.table({"frames": ["123"]}),
-        {"frames": datatype.video_file()},
+        {"frames": datatype.video_path()},
     )
     pq.write_table(table, p)
 


### PR DESCRIPTION
## Summary
- add path, bytes, and bytes-with-path asset dtype constructors keyed by `asset_type` metadata
- remove the old `*_file()` dtype aliases in favor of explicit `*_path()` helpers
- expose storage/type inspection helpers for asset fields
- infer Hugging Face media features as embedded `bytes_with_path` assets instead of path assets
- leave path values unchanged; remove HF-specific relative path rewriting
- restrict asset uploading to path-backed asset columns

## Validation
- `uv run ruff check src/refiner/pipeline/sources/readers/hf_dataset.py src/refiner/pipeline/pipeline.py tests/readers/test_hf_dataset_reader.py`
- `uv run ty check src/refiner/pipeline/sources/readers/hf_dataset.py src/refiner/pipeline/pipeline.py tests/readers/test_hf_dataset_reader.py`
- `uv run pytest tests/readers/test_hf_dataset_reader.py tests/pipeline/test_planning.py`
- `uv run pytest tests/readers/test_csv_reader.py tests/readers/test_jsonl_reader.py tests/readers/test_parquet_reader.py tests/pipeline/test_datatype.py tests/pipeline/test_sinks.py tests/readers/test_hf_dataset_reader.py tests/pipeline/test_planning.py`