### PR TITLE
[codex] Add missing asset policy for sinks

### DIFF
--- a/docs/reading-and-writing.md
+++ b/docs/reading-and-writing.md
@@ -201,7 +201,18 @@ copies those files without decoding them, and rewrites the column values to the
 copied asset paths. Assets are written under
 `{output}/assets/{shard_id}__w{worker_id}/...` by default; use `assets_subdir` to
 change the subfolder name and `max_asset_uploads_in_flight` to bound per-worker
-copy concurrency. Missing or unreadable asset paths fail the shard.
+copy concurrency.
+
+Missing or unreadable asset paths are controlled by `missing_asset_policy`:
+
+| policy | behavior |
+| --- | --- |
+| `"error"` | fail the shard on the first missing asset path |
+| `"drop_row"` | skip rows with missing asset paths |
+| `"set_null"` | replace missing asset paths with null values |
+
+For list-typed asset columns, `"drop_row"` drops the row when any copied list
+item is missing, while `"set_null"` nulls only the missing list items.
 
 Mark path columns as assets with `dtypes=...` on row transforms or with
 `cast(...)`:

--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -37,7 +37,7 @@ class AsyncWindow(Generic[T]):
 
         self._futures.add(submit(_tagged()))
 
-    def submit_ready(self, value: T) -> None:
+    def submit_result(self, value: T) -> None:
         idx = self._next_submit
         self._next_submit += 1
         if self.preserve_order:

--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -45,14 +45,14 @@ class AsyncWindow(Generic[T]):
         else:
             self._buffered.append(value)
 
-    def poll(self) -> list[T]:
+    def take_completed(self) -> list[T]:
         done = {future for future in self._futures if future.done()}
         out = self._take_buffered()
         out.extend(self._consume_done(done))
         out.extend(self._take_ready_ordered())
         return out
 
-    def flush(self) -> list[T]:
+    def drain(self) -> list[T]:
         out = self._take_buffered()
         out.extend(self._take_ready_ordered())
         while self._futures:

--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -37,14 +37,24 @@ class AsyncWindow(Generic[T]):
 
         self._futures.add(submit(_tagged()))
 
+    def submit_ready(self, value: T) -> None:
+        idx = self._next_submit
+        self._next_submit += 1
+        if self.preserve_order:
+            heapq.heappush(self._ready, (idx, value))
+        else:
+            self._buffered.append(value)
+
     def poll(self) -> list[T]:
         done = {future for future in self._futures if future.done()}
         out = self._take_buffered()
         out.extend(self._consume_done(done))
+        out.extend(self._take_ready_ordered())
         return out
 
     def flush(self) -> list[T]:
         out = self._take_buffered()
+        out.extend(self._take_ready_ordered())
         while self._futures:
             done, pending = wait(
                 self._futures,
@@ -62,11 +72,7 @@ class AsyncWindow(Generic[T]):
         if self.preserve_order:
             for future in done:
                 heapq.heappush(self._ready, future.result())
-            while self._ready and self._ready[0][0] == self._next_yield:
-                _, value = heapq.heappop(self._ready)
-                self._next_yield += 1
-                out.append(value)
-            return out
+            return self._take_ready_ordered()
 
         for future in done:
             _, value = future.result()
@@ -82,6 +88,14 @@ class AsyncWindow(Generic[T]):
     def _take_buffered(self) -> list[T]:
         out = self._buffered
         self._buffered = []
+        return out
+
+    def _take_ready_ordered(self) -> list[T]:
+        out: list[T] = []
+        while self._ready and self._ready[0][0] == self._next_yield:
+            _, value = heapq.heappop(self._ready)
+            self._next_yield += 1
+            out.append(value)
         return out
 
     def __len__(self) -> int:

--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -13,11 +13,26 @@ T = TypeVar("T")
 
 @dataclass(slots=True)
 class AsyncWindow(Generic[T]):
+    """Bound concurrent coroutine execution while optionally preserving output order.
+
+    Fields:
+        max_in_flight: Maximum number of submitted futures allowed before submit
+            blocks for at least one completion.
+        preserve_order: If true, completed values are yielded in submit order.
+        _futures: Futures currently running in the shared async runtime.
+        _ready: Completed values that can be returned immediately. This is used
+            for unordered completions and for values unblocked by submit backpressure.
+        _drain_queue: Min-heap of ordered completions keyed by submit index. Values
+            stay here until every earlier submission has been yielded.
+        _next_submit: Submit index to assign to the next coroutine or direct result.
+        _next_yield: Next submit index allowed to leave `_drain_queue`.
+    """
+
     max_in_flight: int
     preserve_order: bool = True
     _futures: set[Future[tuple[int, T]]] = field(default_factory=set, init=False)
-    _ready: list[tuple[int, T]] = field(default_factory=list, init=False)
-    _buffered: list[T] = field(default_factory=list, init=False)
+    _ready: list[T] = field(default_factory=list, init=False)
+    _drain_queue: list[tuple[int, T]] = field(default_factory=list, init=False)
     _next_submit: int = field(default=0, init=False)
     _next_yield: int = field(default=0, init=False)
 
@@ -26,8 +41,9 @@ class AsyncWindow(Generic[T]):
             raise ValueError("max_in_flight must be > 0")
 
     def submit_blocking(self, coro: Coroutine[object, object, T]) -> None:
+        """Submit a coroutine, blocking first if the in-flight window is full."""
         if len(self._futures) >= self.max_in_flight:
-            self._drain_until_available()
+            self._wait_until(return_when=FIRST_COMPLETED)
 
         idx = self._next_submit
         self._next_submit += 1
@@ -38,64 +54,62 @@ class AsyncWindow(Generic[T]):
         self._futures.add(submit(_tagged()))
 
     def submit_result(self, value: T) -> None:
+        """Submit an already-computed value through the same ordering path."""
         idx = self._next_submit
         self._next_submit += 1
-        if self.preserve_order:
-            heapq.heappush(self._ready, (idx, value))
-        else:
-            self._buffered.append(value)
+        self._store_result(idx, value)
 
     def take_completed(self) -> list[T]:
-        done = {future for future in self._futures if future.done()}
-        out = self._take_buffered()
-        out.extend(self._consume_done(done))
-        out.extend(self._take_ready_ordered())
-        return out
+        """Return currently available results without waiting for more futures."""
+        self._collect_done({future for future in self._futures if future.done()})
+        return self._take_ready()
 
     def drain(self) -> list[T]:
-        out = self._take_buffered()
-        out.extend(self._take_ready_ordered())
-        while self._futures:
-            done, pending = wait(
-                self._futures,
-                return_when=ALL_COMPLETED,
-            )
-            self._futures = set(pending)
-            out.extend(self._consume_done(done))
-        return out
+        """Wait for all in-flight work, then return every available result."""
+        self._wait_until(return_when=ALL_COMPLETED)
+        return self._take_ready()
 
-    def _consume_done(self, done: set[Future[tuple[int, T]]]) -> list[T]:
+    def cancel_pending(self) -> None:
+        """Best-effort cancel of in-flight work and discard buffered results."""
+        for future in self._futures:
+            future.cancel()
+        self._futures.clear()
+        self._ready.clear()
+        self._drain_queue.clear()
+
+    def _collect_done(self, done: set[Future[tuple[int, T]]]) -> None:
+        """Remove completed futures from the window and store their results."""
         if not done:
-            return []
+            return
         self._futures.difference_update(done)
-        out: list[T] = []
-        if self.preserve_order:
-            for future in done:
-                heapq.heappush(self._ready, future.result())
-            return self._take_ready_ordered()
-
         for future in done:
-            _, value = future.result()
-            out.append(value)
-        return out
+            idx, value = future.result()
+            self._store_result(idx, value)
 
-    def _drain_until_available(self) -> None:
-        while self._futures and len(self._futures) >= self.max_in_flight:
-            done, pending = wait(self._futures, return_when=FIRST_COMPLETED)
-            self._futures = set(pending)
-            self._buffered.extend(self._consume_done(done))
+    def _wait_until(self, *, return_when: str) -> None:
+        """Block until the requested completion condition and collect results."""
+        while self._futures and (
+            return_when == ALL_COMPLETED or len(self._futures) >= self.max_in_flight
+        ):
+            done, _ = wait(self._futures, return_when=return_when)
+            self._collect_done(done)
 
-    def _take_buffered(self) -> list[T]:
-        out = self._buffered
-        self._buffered = []
-        return out
+    def _store_result(self, idx: int, value: T) -> None:
+        """Route one completed value into `_ready`, respecting submit order."""
+        if not self.preserve_order:
+            self._ready.append(value)
+            return
 
-    def _take_ready_ordered(self) -> list[T]:
-        out: list[T] = []
-        while self._ready and self._ready[0][0] == self._next_yield:
-            _, value = heapq.heappop(self._ready)
+        heapq.heappush(self._drain_queue, (idx, value))
+        while self._drain_queue and self._drain_queue[0][0] == self._next_yield:
+            _, value = heapq.heappop(self._drain_queue)
             self._next_yield += 1
-            out.append(value)
+            self._ready.append(value)
+
+    def _take_ready(self) -> list[T]:
+        """Return and clear the ready-to-yield result buffer."""
+        out = self._ready
+        self._ready = []
         return out
 
     def __len__(self) -> int:

--- a/src/refiner/execution/operators/row.py
+++ b/src/refiner/execution/operators/row.py
@@ -97,9 +97,9 @@ def execute_row_steps(
                 for row in inp.take_all():
                     row.log_throughput("rows_processed", 1, unit="rows")
                     window.submit_blocking(_run_async_step(step=step, row=row))
-                out.extend(window.poll())
+                out.extend(window.take_completed())
                 if flush_all:
-                    out.extend(window.flush())
+                    out.extend(window.drain())
                 return
 
             if isinstance(step, FilterRowStep):

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -28,6 +28,7 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.pipeline.sinks import BaseSink, JsonlSink, ParquetSink
+from refiner.pipeline.sinks.assets import MissingAssetPolicy
 from refiner.pipeline.sources import (
     BaseSource,
     CsvReader,
@@ -330,6 +331,7 @@ class RefinerPipeline:
         upload_assets: bool = False,
         assets_subdir: str = "assets",
         max_asset_uploads_in_flight: int = 16,
+        missing_asset_policy: MissingAssetPolicy = "error",
     ) -> "RefinerPipeline":
         return self.with_sink(
             JsonlSink(
@@ -338,6 +340,7 @@ class RefinerPipeline:
                 upload_assets=upload_assets,
                 assets_subdir=assets_subdir,
                 max_asset_uploads_in_flight=max_asset_uploads_in_flight,
+                missing_asset_policy=missing_asset_policy,
             )
         )
 
@@ -350,6 +353,7 @@ class RefinerPipeline:
         upload_assets: bool = False,
         assets_subdir: str = "assets",
         max_asset_uploads_in_flight: int = 16,
+        missing_asset_policy: MissingAssetPolicy = "error",
     ) -> "RefinerPipeline":
         return self.with_sink(
             ParquetSink(
@@ -359,6 +363,7 @@ class RefinerPipeline:
                 upload_assets=upload_assets,
                 assets_subdir=assets_subdir,
                 max_asset_uploads_in_flight=max_asset_uploads_in_flight,
+                missing_asset_policy=missing_asset_policy,
             )
         )
 

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Sequence
 import posixpath
 import re
 from typing import Literal
@@ -99,7 +99,7 @@ class AssetUploadManager:
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
         start = self._next_row_index.get(shard_id, 0)
         out = table
-        pending: list[tuple[str, pa.Field, list[object]]] = []
+        result_columns: list[tuple[str, pa.Field]] = []
         # Tables may already carry asset metadata, while row-derived tables rely on
         # the schema passed through set_input_schema().
         columns = dict(self._asset_columns)
@@ -112,9 +112,10 @@ class AssetUploadManager:
             if idx < 0:
                 continue
             field = out.schema.field(idx)
-            values = out.column(idx).to_pylist()
+            column = out.column(idx)
+            values = column.to_pylist()
             rewritten = [
-                self._rewrite_asset_path(
+                self._rewrite_path(
                     value,
                     shard_id=shard_id,
                     column_name=column_name,
@@ -123,24 +124,38 @@ class AssetUploadManager:
                 )
                 for row_offset, value in enumerate(values)
             ]
-            pending.append((column_name, field, rewritten))
-
-        upload_results = iter(self._window.flush())
-        keep: pa.Array | None = None
-        for column_name, field, rewritten in pending:
-            finalized = [
-                self._finalize_asset_value(value, upload_results) for value in rewritten
-            ]
-            rewritten_array = pa.array(finalized, type=field.type)
+            rewritten_array = pa.array(rewritten, type=field.type)
             out = set_or_append_column(
                 out,
                 column_name,
                 rewritten_array,
             )
-            if self.missing_asset_policy == "drop_row" and rewritten_array.null_count:
-                valid = pc.call_function("is_valid", [rewritten_array])
-                keep = valid if keep is None else pc.call_function("and", [keep, valid])
+            result_columns.append((column_name, field))
+        # Do not expose output rows that point at assets until those copies have
+        # completed; otherwise a later copy failure leaves dangling references.
+        results = self._window.flush()
         self._next_row_index[shard_id] = start + table.num_rows
+        keep: pa.Array | None = None
+        offset = 0
+        for column_name, field in result_columns:
+            column_results = results[offset : offset + table.num_rows]
+            offset += table.num_rows
+            if all(column_results):
+                continue
+            valid = pa.array(column_results, type=pa.bool_())
+            if self.missing_asset_policy == "set_null":
+                idx = out.schema.get_field_index(column_name)
+                column = out.column(idx)
+                out = set_or_append_column(
+                    out,
+                    column_name,
+                    pc.call_function(
+                        "if_else",
+                        [valid, column, pa.nulls(out.num_rows, type=field.type)],
+                    ),
+                )
+            elif self.missing_asset_policy == "drop_row":
+                keep = valid if keep is None else pc.call_function("and", [keep, valid])
         if keep is not None:
             rows_before_filter = out.num_rows
             out = out.filter(keep)
@@ -159,17 +174,16 @@ class AssetUploadManager:
             return rows
 
         start = self._next_row_index.get(shard_id, 0)
-        pending: list[tuple[Row, dict[str, object], dict[str, object]]] = []
+        pending_rows: list[tuple[Row, dict[str, object], list[str]]] = []
         row_count = 0
         for row_index, row in enumerate(rows, start=start):
             row_count += 1
             patch: dict[str, object] = {}
-            original: dict[str, object] = {}
+            result_columns: list[str] = []
             for column_name, kind in self._asset_columns.items():
                 if column_name not in row:
                     continue
-                original[column_name] = row[column_name]
-                value = self._rewrite_asset_path(
+                value = self._rewrite_path(
                     row[column_name],
                     shard_id=shard_id,
                     column_name=column_name,
@@ -177,29 +191,29 @@ class AssetUploadManager:
                     list_items=kind == "list",
                 )
                 patch[column_name] = value
-            pending.append((row, patch, original))
-        upload_results = iter(self._window.flush())
+                result_columns.append(column_name)
+            pending_rows.append((row, patch, result_columns))
+        # Keep row-mode JSONL writes atomic at the block level for asset references.
+        results = self._window.flush()
+        self._next_row_index[shard_id] = start + row_count
         out: list[Row] = []
         dropped = 0
-        for row, patch, original in pending:
-            patch = {
-                column_name: self._finalize_asset_value(value, upload_results)
-                for column_name, value in patch.items()
-            }
-            drop_row = False
-            for column_name, value in patch.items():
-                if (
-                    self.missing_asset_policy == "drop_row"
-                    and original[column_name] is not None
-                    and value is None
-                ):
-                    drop_row = True
-                    break
-            if drop_row:
+        offset = 0
+        for row, patch, result_columns in pending_rows:
+            row_results = results[offset : offset + len(result_columns)]
+            offset += len(result_columns)
+            if self.missing_asset_policy == "drop_row" and not all(row_results):
                 dropped += 1
                 continue
+            if self.missing_asset_policy == "set_null":
+                for column_name, copied in zip(
+                    result_columns,
+                    row_results,
+                    strict=True,
+                ):
+                    if not copied:
+                        patch[column_name] = None
             out.append(row.update(patch) if patch else row)
-        self._next_row_index[shard_id] = start + row_count
         if dropped:
             log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
         return out
@@ -207,84 +221,15 @@ class AssetUploadManager:
     def flush(self) -> None:
         self._window.flush()
 
-    def _finalize_asset_value(
+    def _asset_relpath(
         self,
-        value: object,
-        upload_results: Iterator[bool],
-    ) -> object:
-        if isinstance(value, str):
-            return value if next(upload_results) else None
-        if value is None:
-            return None
-        if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
-            return value
-
-        out: list[object] = []
-        for item in value:
-            if item is None:
-                out.append(None)
-                continue
-            if isinstance(item, str) and not next(upload_results):
-                # A missing list element drops the row for drop_row, but set_null
-                # preserves the list and nulls only the missing item.
-                if self.missing_asset_policy == "drop_row":
-                    return None
-                out.append(None)
-            else:
-                out.append(item)
-        return out
-
-    def _rewrite_asset_path(
-        self,
-        value: object,
-        *,
-        shard_id: str,
-        column_name: str,
-        row_index: int,
-        list_items: bool,
-    ) -> object:
-        if value is None:
-            return None
-        if list_items:
-            if not isinstance(value, Sequence) or isinstance(
-                value,
-                (str, bytes, bytearray),
-            ):
-                raise TypeError(f"Asset column {column_name!r} expected list values")
-            out: list[object] = []
-            for item_index, item in enumerate(value):
-                if item is None:
-                    out.append(None)
-                    continue
-                rewritten = self._rewrite_path(
-                    item,
-                    shard_id=shard_id,
-                    column_name=column_name,
-                    row_index=row_index,
-                    item_index=item_index,
-                )
-                out.append(rewritten)
-            return out
-        return self._rewrite_path(
-            value,
-            shard_id=shard_id,
-            column_name=column_name,
-            row_index=row_index,
-            item_index=None,
-        )
-
-    def _rewrite_path(
-        self,
-        value: object,
+        value: str,
         *,
         shard_id: str,
         column_name: str,
         row_index: int,
         item_index: int | None,
     ) -> str:
-        if not isinstance(value, str) or not value:
-            raise TypeError(f"Asset value for column {column_name!r} must be a path")
-
         basename = unquote(posixpath.basename(urlsplit(value).path.rstrip("/")))
         basename = _SAFE_NAME_RE.sub("_", basename.replace("\\", "_")).strip("._-")
         if not basename:
@@ -294,34 +239,92 @@ class AssetUploadManager:
         # Attempt directories are keyed by shard and worker so reducers can delete
         # whole failed attempts without inspecting individual asset files.
         attempt_dir = f"{shard_id}__w{get_active_worker_token()}"
-        relpath = (
+        return (
             f"{self.assets_subdir}/{attempt_dir}/{column_segment}/{prefix}-{basename}"
         )
 
-        output_path = self.output.abs_path(relpath)
+    def _copy_asset(self, value: str, relpath: str, *, shard_id: str) -> bool:
+        try:
+            DataFile.resolve(value).copy(self.output.file(relpath))
+        except Exception as e:
+            message = str(e).lower()
+            missing = isinstance(e, FileNotFoundError) or any(
+                text in message for text in ("404", "entry not found", "no such file")
+            )
+            if self.missing_asset_policy == "error" or not missing:
+                raise
+            log_throughput("asset_uploads_failed", 1, shard_id, unit="assets")
+            return False
+        log_throughput("assets_uploaded", 1, shard_id=shard_id, unit="assets")
+        return True
 
-        def copy_asset_sync() -> bool:
-            try:
-                DataFile.resolve(value).copy(self.output.file(relpath))
-            except Exception as e:
-                message = str(e).lower()
-                missing = isinstance(e, FileNotFoundError) or any(
-                    text in message
-                    for text in ("404", "entry not found", "no such file")
+    def _rewrite_path(
+        self,
+        value: object,
+        *,
+        shard_id: str,
+        column_name: str,
+        row_index: int,
+        list_items: bool,
+    ) -> object:
+        if value is None:
+            self._window.submit_ready(True)
+            return None
+        if list_items:
+            if not isinstance(value, Sequence) or isinstance(
+                value,
+                (str, bytes, bytearray),
+            ):
+                raise TypeError(f"Asset column {column_name!r} expected list values")
+            rewritten: list[object] = []
+            copies: list[tuple[str, str]] | tuple[str, str] = []
+            for item_index, item in enumerate(value):
+                if item is None:
+                    rewritten.append(None)
+                    continue
+                if not isinstance(item, str) or not item:
+                    raise TypeError(
+                        f"Asset value for column {column_name!r} must be a path"
+                    )
+                relpath = self._asset_relpath(
+                    item,
+                    shard_id=shard_id,
+                    column_name=column_name,
+                    row_index=row_index,
+                    item_index=item_index,
                 )
-                if self.missing_asset_policy == "error" or not missing:
-                    raise
-                log_throughput("assets_uploads_failed", 1, shard_id, unit="assets")
-                return False
-            log_throughput("assets_uploaded", 1, shard_id=shard_id, unit="assets")
-            return True
+                rewritten.append(self.output.abs_path(relpath))
+                copies.append((item, relpath))
+        else:
+            if not isinstance(value, str) or not value:
+                raise TypeError(
+                    f"Asset value for column {column_name!r} must be a path"
+                )
+            relpath = self._asset_relpath(
+                value,
+                shard_id=shard_id,
+                column_name=column_name,
+                row_index=row_index,
+                item_index=None,
+            )
+            rewritten = self.output.abs_path(relpath)
+            copies = (value, relpath)
 
-        async def copy_asset() -> bool:
+        def copy_assets_sync() -> bool:
+            if isinstance(copies, list):
+                return all(
+                    self._copy_asset(item, relpath, shard_id=shard_id)
+                    for item, relpath in copies
+                )
+            item, relpath = copies
+            return self._copy_asset(item, relpath, shard_id=shard_id)
+
+        async def copy_assets() -> bool:
             loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(io_executor(), copy_asset_sync)
+            return await loop.run_in_executor(io_executor(), copy_assets_sync)
 
-        self._window.submit_blocking(copy_asset())
-        return output_path
+        self._window.submit_blocking(copy_assets())
+        return rewritten
 
 
 ASSET_ATTEMPT_DIR_RE = re.compile(

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -133,7 +133,7 @@ class AssetUploadManager:
             result_columns.append((column_name, field))
         # Do not expose output rows that point at assets until those copies have
         # completed; otherwise a later copy failure leaves dangling references.
-        results = self._window.flush()
+        results = self._window.drain()
         self._next_row_index[shard_id] = start + table.num_rows
         keep: pa.Array | None = None
         offset = 0
@@ -194,7 +194,7 @@ class AssetUploadManager:
                 result_columns.append(column_name)
             pending_rows.append((row, patch, result_columns))
         # Keep row-mode JSONL writes atomic at the block level for asset references.
-        results = self._window.flush()
+        results = self._window.drain()
         self._next_row_index[shard_id] = start + row_count
         out: list[Row] = []
         dropped = 0
@@ -219,7 +219,7 @@ class AssetUploadManager:
         return out
 
     def flush(self) -> None:
-        self._window.flush()
+        self._window.drain()
 
     def _asset_relpath(
         self,

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Sequence
-from functools import partial
+from collections.abc import Iterable, Iterator, Sequence
 import posixpath
 import re
+from typing import Literal
 from urllib.parse import unquote, urlsplit
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from refiner.execution.asyncio.runtime import io_executor
 from refiner.execution.asyncio.window import AsyncWindow
@@ -20,6 +21,7 @@ from refiner.worker.context import get_active_worker_token
 from refiner.worker.metrics.api import log_throughput
 
 _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+MissingAssetPolicy = Literal["error", "drop_row", "set_null"]
 
 
 class AssetUploadManager:
@@ -30,7 +32,12 @@ class AssetUploadManager:
         assets_subdir: str,
         filename_template: str,
         max_uploads_in_flight: int,
+        missing_asset_policy: MissingAssetPolicy = "error",
     ) -> None:
+        if missing_asset_policy not in {"error", "drop_row", "set_null"}:
+            raise ValueError(
+                "missing_asset_policy must be one of: 'error', 'drop_row', 'set_null'"
+            )
         self.output = output
         # Assets live in a writer-managed subtree, so both the assets directory and
         # the sink's output template must stay relative and disjoint.
@@ -54,14 +61,15 @@ class AssetUploadManager:
             f"{self.assets_subdir}/"
         ):
             raise ValueError("filename_template must not write into assets_subdir")
-        self._window = AsyncWindow[None](
+        self._window = AsyncWindow[bool](
             max_in_flight=max_uploads_in_flight,
-            preserve_order=False,
+            preserve_order=True,
         )
         self._next_row_index: dict[str, int] = {}
         self._asset_columns: dict[str, str] = {}
         self._asset_column_segments: dict[str, str] = {}
         self._input_schema_set = False
+        self.missing_asset_policy = missing_asset_policy
 
     def set_input_schema(self, schema: pa.Schema | None) -> None:
         self._set_asset_columns(asset_columns_from_schema(schema))
@@ -91,6 +99,7 @@ class AssetUploadManager:
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
         start = self._next_row_index.get(shard_id, 0)
         out = table
+        pending: list[tuple[str, pa.Field, list[object]]] = []
         # Tables may already carry asset metadata, while row-derived tables rely on
         # the schema passed through set_input_schema().
         columns = dict(self._asset_columns)
@@ -103,6 +112,7 @@ class AssetUploadManager:
             if idx < 0:
                 continue
             field = out.schema.field(idx)
+            values = out.column(idx).to_pylist()
             rewritten = [
                 self._rewrite_asset_path(
                     value,
@@ -111,17 +121,32 @@ class AssetUploadManager:
                     row_index=start + row_offset,
                     list_items=kind == "list",
                 )
-                for row_offset, value in enumerate(out.column(idx).to_pylist())
+                for row_offset, value in enumerate(values)
             ]
+            pending.append((column_name, field, rewritten))
+
+        upload_results = iter(self._window.flush())
+        keep: pa.Array | None = None
+        for column_name, field, rewritten in pending:
+            finalized = [
+                self._finalize_asset_value(value, upload_results) for value in rewritten
+            ]
+            rewritten_array = pa.array(finalized, type=field.type)
             out = set_or_append_column(
                 out,
                 column_name,
-                pa.array(rewritten, type=field.type),
+                rewritten_array,
             )
-        # Do not expose output rows that point at assets until those copies have
-        # completed; otherwise a later copy failure leaves dangling references.
-        self._window.flush()
+            if self.missing_asset_policy == "drop_row" and rewritten_array.null_count:
+                valid = pc.call_function("is_valid", [rewritten_array])
+                keep = valid if keep is None else pc.call_function("and", [keep, valid])
         self._next_row_index[shard_id] = start + table.num_rows
+        if keep is not None:
+            rows_before_filter = out.num_rows
+            out = out.filter(keep)
+            dropped = rows_before_filter - out.num_rows
+            if dropped:
+                log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
         return out
 
     def rewrite_rows(
@@ -134,29 +159,80 @@ class AssetUploadManager:
             return rows
 
         start = self._next_row_index.get(shard_id, 0)
-        out: list[Row] = []
+        pending: list[tuple[Row, dict[str, object], dict[str, object]]] = []
         row_count = 0
         for row_index, row in enumerate(rows, start=start):
             row_count += 1
             patch: dict[str, object] = {}
+            original: dict[str, object] = {}
             for column_name, kind in self._asset_columns.items():
                 if column_name not in row:
                     continue
-                patch[column_name] = self._rewrite_asset_path(
+                original[column_name] = row[column_name]
+                value = self._rewrite_asset_path(
                     row[column_name],
                     shard_id=shard_id,
                     column_name=column_name,
                     row_index=row_index,
                     list_items=kind == "list",
                 )
+                patch[column_name] = value
+            pending.append((row, patch, original))
+        upload_results = iter(self._window.flush())
+        out: list[Row] = []
+        dropped = 0
+        for row, patch, original in pending:
+            patch = {
+                column_name: self._finalize_asset_value(value, upload_results)
+                for column_name, value in patch.items()
+            }
+            drop_row = False
+            for column_name, value in patch.items():
+                if (
+                    self.missing_asset_policy == "drop_row"
+                    and original[column_name] is not None
+                    and value is None
+                ):
+                    drop_row = True
+                    break
+            if drop_row:
+                dropped += 1
+                continue
             out.append(row.update(patch) if patch else row)
-        # Keep row-mode JSONL writes atomic at the block level for asset references.
-        self._window.flush()
         self._next_row_index[shard_id] = start + row_count
+        if dropped:
+            log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
         return out
 
     def flush(self) -> None:
         self._window.flush()
+
+    def _finalize_asset_value(
+        self,
+        value: object,
+        upload_results: Iterator[bool],
+    ) -> object:
+        if isinstance(value, str):
+            return value if next(upload_results) else None
+        if value is None:
+            return None
+        if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+            return value
+
+        out: list[object] = []
+        for item in value:
+            if item is None:
+                out.append(None)
+                continue
+            if isinstance(item, str) and not next(upload_results):
+                # A missing list element drops the row for drop_row, but set_null
+                # preserves the list and nulls only the missing item.
+                if self.missing_asset_policy == "drop_row":
+                    return None
+                out.append(None)
+            else:
+                out.append(item)
+        return out
 
     def _rewrite_asset_path(
         self,
@@ -175,18 +251,20 @@ class AssetUploadManager:
                 (str, bytes, bytearray),
             ):
                 raise TypeError(f"Asset column {column_name!r} expected list values")
-            return [
-                None
-                if item is None
-                else self._rewrite_path(
+            out: list[object] = []
+            for item_index, item in enumerate(value):
+                if item is None:
+                    out.append(None)
+                    continue
+                rewritten = self._rewrite_path(
                     item,
                     shard_id=shard_id,
                     column_name=column_name,
                     row_index=row_index,
                     item_index=item_index,
                 )
-                for item_index, item in enumerate(value)
-            ]
+                out.append(rewritten)
+            return out
         return self._rewrite_path(
             value,
             shard_id=shard_id,
@@ -220,19 +298,30 @@ class AssetUploadManager:
             f"{self.assets_subdir}/{attempt_dir}/{column_segment}/{prefix}-{basename}"
         )
 
-        async def copy_asset() -> None:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(
-                io_executor(),
-                partial(
-                    DataFile.resolve(value).copy,
-                    self.output.file(relpath),
-                ),
-            )
+        output_path = self.output.abs_path(relpath)
+
+        def copy_asset_sync() -> bool:
+            try:
+                DataFile.resolve(value).copy(self.output.file(relpath))
+            except Exception as e:
+                message = str(e).lower()
+                missing = isinstance(e, FileNotFoundError) or any(
+                    text in message
+                    for text in ("404", "entry not found", "no such file")
+                )
+                if self.missing_asset_policy == "error" or not missing:
+                    raise
+                log_throughput("assets_uploads_failed", 1, shard_id, unit="assets")
+                return False
             log_throughput("assets_uploaded", 1, shard_id=shard_id, unit="assets")
+            return True
+
+        async def copy_asset() -> bool:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(io_executor(), copy_asset_sync)
 
         self._window.submit_blocking(copy_asset())
-        return self.output.abs_path(relpath)
+        return output_path
 
 
 ASSET_ATTEMPT_DIR_RE = re.compile(
@@ -258,4 +347,4 @@ def asset_columns_from_schema(schema: pa.Schema | None) -> dict[str, str]:
     return columns
 
 
-__all__ = ["AssetUploadManager"]
+__all__ = ["AssetUploadManager", "MissingAssetPolicy"]

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -268,7 +268,7 @@ class AssetUploadManager:
         list_items: bool,
     ) -> object:
         if value is None:
-            self._window.submit_ready(True)
+            self._window.submit_result(True)
             return None
         if list_items:
             if not isinstance(value, Sequence) or isinstance(

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from collections.abc import Iterable, Sequence
 import posixpath
 import re
@@ -8,7 +9,6 @@ from typing import Literal
 from urllib.parse import unquote, urlsplit
 
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from refiner.execution.asyncio.runtime import io_executor
 from refiner.execution.asyncio.window import AsyncWindow
@@ -22,6 +22,7 @@ from refiner.worker.metrics.api import log_throughput
 
 _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
 MissingAssetPolicy = Literal["error", "drop_row", "set_null"]
+AssetCopyResult = bool | list[bool]
 
 
 class AssetUploadManager:
@@ -61,8 +62,11 @@ class AssetUploadManager:
             f"{self.assets_subdir}/"
         ):
             raise ValueError("filename_template must not write into assets_subdir")
-        self._window = AsyncWindow[bool](
+        self._window = AsyncWindow[AssetCopyResult](
             max_in_flight=max_uploads_in_flight,
+            # Row-mode writers release rows as their asset-cell copies finish.
+            # Preserve result order so a later row cannot be yielded before an
+            # earlier row whose copies are still in flight.
             preserve_order=True,
         )
         self._next_row_index: dict[str, int] = {}
@@ -96,6 +100,9 @@ class AssetUploadManager:
                 "dtypes=... or cast(...), or call set_input_schema(...)."
             )
 
+    def close(self) -> None:
+        self._window.cancel_pending()
+
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
         start = self._next_row_index.get(shard_id, 0)
         out = table
@@ -114,16 +121,20 @@ class AssetUploadManager:
             field = out.schema.field(idx)
             column = out.column(idx)
             values = column.to_pylist()
-            rewritten = [
-                self._rewrite_path(
-                    value,
-                    shard_id=shard_id,
-                    column_name=column_name,
-                    row_index=start + row_offset,
-                    list_items=kind == "list",
+            rewritten = []
+            for row_offset, value in enumerate(values):
+                if self.missing_asset_policy == "error" and value is None:
+                    rewritten.append(None)
+                    continue
+                rewritten.append(
+                    self._rewrite_path(
+                        value,
+                        shard_id=shard_id,
+                        column_name=column_name,
+                        row_index=start + row_offset,
+                        list_items=kind == "list",
+                    )
                 )
-                for row_offset, value in enumerate(values)
-            ]
             rewritten_array = pa.array(rewritten, type=field.type)
             out = set_or_append_column(
                 out,
@@ -135,33 +146,51 @@ class AssetUploadManager:
         # completed; otherwise a later copy failure leaves dangling references.
         results = self._window.drain()
         self._next_row_index[shard_id] = start + table.num_rows
-        keep: pa.Array | None = None
-        offset = 0
-        for column_name, field in result_columns:
-            column_results = results[offset : offset + table.num_rows]
-            offset += table.num_rows
-            if all(column_results):
-                continue
-            valid = pa.array(column_results, type=pa.bool_())
-            if self.missing_asset_policy == "set_null":
+        if self.missing_asset_policy == "set_null":
+            # Each result lines up with one rewritten table cell. Scalar cells
+            # return bool; list cells return one bool per non-null path element.
+            offset = 0
+            for column_name, field in result_columns:
+                column_results = results[offset : offset + table.num_rows]
+                offset += table.num_rows
                 idx = out.schema.get_field_index(column_name)
                 column = out.column(idx)
+                values = [
+                    _set_null_value(value, result)
+                    for value, result in zip(
+                        column.to_pylist(),
+                        column_results,
+                        strict=True,
+                    )
+                ]
                 out = set_or_append_column(
                     out,
                     column_name,
-                    pc.call_function(
-                        "if_else",
-                        [valid, column, pa.nulls(out.num_rows, type=field.type)],
-                    ),
+                    pa.array(values, type=field.type),
                 )
-            elif self.missing_asset_policy == "drop_row":
-                keep = valid if keep is None else pc.call_function("and", [keep, valid])
-        if keep is not None:
-            rows_before_filter = out.num_rows
-            out = out.filter(keep)
-            dropped = rows_before_filter - out.num_rows
-            if dropped:
-                log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
+        elif self.missing_asset_policy == "drop_row":
+            # Drop-row only needs row-level validity, so list cell results collapse
+            # with all(...): any failed path element drops the whole row.
+            keep = [True] * table.num_rows
+            offset = 0
+            for _column_name, _field in result_columns:
+                column_results = results[offset : offset + table.num_rows]
+                offset += table.num_rows
+                for row_offset, result in enumerate(column_results):
+                    keep[row_offset] = keep[row_offset] and (
+                        all(result) if isinstance(result, list) else result
+                    )
+            if not all(keep):
+                rows_before_filter = out.num_rows
+                out = out.filter(pa.array(keep, type=pa.bool_()))
+                dropped = rows_before_filter - out.num_rows
+                if dropped:
+                    log_throughput(
+                        "asset_rows_dropped",
+                        dropped,
+                        shard_id,
+                        unit="rows",
+                    )
         return out
 
     def rewrite_rows(
@@ -171,17 +200,53 @@ class AssetUploadManager:
     ) -> Iterable[Row]:
         self.require_input_schema()
         if not self._asset_columns:
-            return rows
+            yield from rows
+            return
 
         start = self._next_row_index.get(shard_id, 0)
-        pending_rows: list[tuple[Row, dict[str, object], list[str]]] = []
+        # Results are ordered by the same nested loop used to build patches:
+        # row, then asset column. Keep only rows whose copy results are still
+        # pending instead of materializing the full input block.
+        pending_rows: deque[tuple[Row, dict[str, object], list[str]]] = deque()
+        results: deque[AssetCopyResult] = deque()
+        dropped = 0
         row_count = 0
+
+        def emit_ready() -> Iterable[Row]:
+            nonlocal dropped
+            while pending_rows:
+                row, patch, result_columns = pending_rows[0]
+                result_count = len(result_columns)
+                if len(results) < result_count:
+                    break
+                pending_rows.popleft()
+                row_results = [results.popleft() for _ in range(result_count)]
+                if self.missing_asset_policy == "drop_row" and not all(
+                    all(result) if isinstance(result, list) else result
+                    for result in row_results
+                ):
+                    dropped += 1
+                    continue
+                if self.missing_asset_policy == "set_null":
+                    for column_name, copied in zip(
+                        result_columns,
+                        row_results,
+                        strict=True,
+                    ):
+                        patch[column_name] = _set_null_value(
+                            patch[column_name],
+                            copied,
+                        )
+                yield row.update(patch) if patch else row
+
         for row_index, row in enumerate(rows, start=start):
             row_count += 1
             patch: dict[str, object] = {}
             result_columns: list[str] = []
             for column_name, kind in self._asset_columns.items():
                 if column_name not in row:
+                    continue
+                if self.missing_asset_policy == "error" and row[column_name] is None:
                     continue
                 value = self._rewrite_path(
                     row[column_name],
@@ -192,34 +257,22 @@ class AssetUploadManager:
                 )
                 patch[column_name] = value
                 result_columns.append(column_name)
+
             pending_rows.append((row, patch, result_columns))
-        # Keep row-mode JSONL writes atomic at the block level for asset references.
-        results = self._window.drain()
+            # Error policy must remain block-atomic for row sinks: JSONL writes
+            # rows as they are yielded, so do not expose any rewritten asset paths
+            # until every copy in the block has succeeded.
+            if self.missing_asset_policy != "error":
+                # Non-error policies can stream bounded rows as soon as their
+                # copy results are available.
+                results.extend(self._window.take_completed())
+                yield from emit_ready()
+
+        results.extend(self._window.drain())
+        yield from emit_ready()
         self._next_row_index[shard_id] = start + row_count
-        out: list[Row] = []
-        dropped = 0
-        offset = 0
-        for row, patch, result_columns in pending_rows:
-            row_results = results[offset : offset + len(result_columns)]
-            offset += len(result_columns)
-            if self.missing_asset_policy == "drop_row" and not all(row_results):
-                dropped += 1
-                continue
-            if self.missing_asset_policy == "set_null":
-                for column_name, copied in zip(
-                    result_columns,
-                    row_results,
-                    strict=True,
-                ):
-                    if not copied:
-                        patch[column_name] = None
-            out.append(row.update(patch) if patch else row)
         if dropped:
             log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
-        return out
-
-    def flush(self) -> None:
-        self._window.drain()
 
     def _asset_relpath(
         self,
@@ -310,16 +363,16 @@ class AssetUploadManager:
             rewritten = self.output.abs_path(relpath)
             copies = (value, relpath)
 
-        def copy_assets_sync() -> bool:
+        def copy_assets_sync() -> AssetCopyResult:
             if isinstance(copies, list):
-                return all(
+                return [
                     self._copy_asset(item, relpath, shard_id=shard_id)
                     for item, relpath in copies
-                )
+                ]
             item, relpath = copies
             return self._copy_asset(item, relpath, shard_id=shard_id)
 
-        async def copy_assets() -> bool:
+        async def copy_assets() -> AssetCopyResult:
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(io_executor(), copy_assets_sync)
 
@@ -348,6 +401,30 @@ def asset_columns_from_schema(schema: pa.Schema | None) -> dict[str, str]:
         ) and datatype.is_asset_path_field(field_type.value_field):
             columns[field.name] = "list"
     return columns
+
+
+def _set_null_value(value: object, result: AssetCopyResult) -> object:
+    # Scalar copy result: failed copy nulls the whole cell.
+    if isinstance(result, bool):
+        return value if result else None
+    if value is None:
+        return None
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError("Asset list result cannot be applied to non-list value")
+    # List copy result: failed copy nulls only that path element. Existing None
+    # values do not produce copy results, so they do not consume result entries.
+    result_iter = iter(result)
+    out: list[object] = []
+    for item in value:
+        if item is None:
+            out.append(None)
+            continue
+        out.append(item if next(result_iter) else None)
+    try:
+        next(result_iter)
+    except StopIteration:
+        return out
+    raise ValueError("Asset list result has more entries than list path values")
 
 
 __all__ = ["AssetUploadManager", "MissingAssetPolicy"]

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -19,26 +19,31 @@ class BaseSink(ABC):
     sinks.
     """
 
-    def write_block(self, block: Block) -> dict[str, int]:
+    def write_block(self, block: Block) -> tuple[dict[str, int], int]:
         """Split a mixed block by shard and dispatch each shard-local block.
 
         This is the normal entry point and should usually be inherited as-is.
         """
         blocks_by_shard, counts = split_block_by_shard(block)
+        output_rows = 0
         for shard_id, shard_block in blocks_by_shard.items():
-            self.write_shard_block(shard_id, shard_block)
+            actual_count = self.write_shard_block(shard_id, shard_block)
+            output_count = counts[shard_id] if actual_count is None else actual_count
             log_throughput(
                 "rows_written",
-                counts[shard_id],
+                output_count,
                 shard_id=shard_id,
                 unit="rows",
             )
-        return counts
+            output_rows += output_count
+        return counts, output_rows
 
-    def write_shard_block(self, shard_id: str, block: Block) -> None:
+    def write_shard_block(self, shard_id: str, block: Block) -> int | None:
         """Write one already shard-local block.
 
         This is the main method concrete shard-writing sinks should implement.
+        Return the actual row count when the sink can drop or expand rows;
+        otherwise return None to use the input block count.
         """
         del shard_id, block
         raise NotImplementedError
@@ -89,8 +94,9 @@ class BaseSink(ABC):
 class NullSink(BaseSink):
     """Sink that discards data and only reports shard counts."""
 
-    def write_block(self, block: Block) -> dict[str, int]:
-        return count_block_by_shard(block)
+    def write_block(self, block: Block) -> tuple[dict[str, int], int]:
+        counts = count_block_by_shard(block)
+        return counts, sum(counts.values())
 
 
 __all__ = ["BaseSink", "NullSink"]

--- a/src/refiner/pipeline/sinks/jsonl.py
+++ b/src/refiner/pipeline/sinks/jsonl.py
@@ -67,31 +67,34 @@ class JsonlSink(BaseSink):
         self._files[shard_id] = file
         return file
 
-    def _write_rows(self, shard_id: str, rows: Iterable[Mapping[str, object]]) -> None:
+    def _write_rows(self, shard_id: str, rows: Iterable[Mapping[str, object]]) -> int:
         file = self._file(shard_id)
+        count = 0
         for row in rows:
             file.write(
                 self._encoder.encode(row.to_dict() if isinstance(row, Row) else row)
             )
             file.write("\n")
+            count += 1
+        return count
 
-    def _write_table_rows(self, shard_id: str, table: pa.Table) -> None:
+    def _write_table_rows(self, shard_id: str, table: pa.Table) -> int:
         if self._assets is not None:
-            self._write_rows(
+            return self._write_rows(
                 shard_id, self._assets.rewrite_table(shard_id, table).to_pylist()
             )
-            return
+        count = 0
         for batch in table.to_batches(max_chunksize=4096):
-            self._write_rows(shard_id, batch.to_pylist())
+            count += self._write_rows(shard_id, batch.to_pylist())
+        return count
 
-    def write_shard_block(self, shard_id: str, block: Block) -> None:
+    def write_shard_block(self, shard_id: str, block: Block) -> int:
         if isinstance(block, Tabular):
-            self._write_table_rows(shard_id, block.table)
-        else:
-            rows = block
-            if self._assets is not None:
-                rows = self._assets.rewrite_rows(shard_id, rows)
-            self._write_rows(shard_id, rows)
+            return self._write_table_rows(shard_id, block.table)
+        rows = block
+        if self._assets is not None:
+            rows = self._assets.rewrite_rows(shard_id, rows)
+        return self._write_rows(shard_id, rows)
 
     def on_shard_complete(self, shard_id: str) -> None:
         file = self._files.pop(shard_id, None)
@@ -102,7 +105,7 @@ class JsonlSink(BaseSink):
     def close(self) -> None:
         try:
             if self._assets is not None:
-                self._assets.flush()
+                self._assets.close()
         finally:
             for file in self._files.values():
                 file.close()

--- a/src/refiner/pipeline/sinks/jsonl.py
+++ b/src/refiner/pipeline/sinks/jsonl.py
@@ -10,7 +10,7 @@ from refiner.io.datafolder import DataFolder, DataFolderLike
 from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular
-from refiner.pipeline.sinks.assets import AssetUploadManager
+from refiner.pipeline.sinks.assets import AssetUploadManager, MissingAssetPolicy
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
@@ -26,11 +26,13 @@ class JsonlSink(BaseSink):
         upload_assets: bool = False,
         assets_subdir: str = "assets",
         max_asset_uploads_in_flight: int = 16,
+        missing_asset_policy: MissingAssetPolicy = "error",
     ):
         self.output = DataFolder.resolve(output)
         self.filename_template = filename_template
         self.upload_assets = upload_assets
         self.assets_subdir = assets_subdir
+        self.missing_asset_policy = missing_asset_policy
         self._files: dict[str, IO[str]] = {}
         self._encoder = json.JSONEncoder(ensure_ascii=True, separators=(",", ":"))
         self._assets = (
@@ -39,6 +41,7 @@ class JsonlSink(BaseSink):
                 assets_subdir=assets_subdir,
                 filename_template=filename_template,
                 max_uploads_in_flight=max_asset_uploads_in_flight,
+                missing_asset_policy=missing_asset_policy,
             )
             if upload_assets
             else None
@@ -113,6 +116,7 @@ class JsonlSink(BaseSink):
         if self.upload_assets:
             args["upload_assets"] = True
             args["assets_subdir"] = self.assets_subdir
+            args["missing_asset_policy"] = self.missing_asset_policy
         return ("write_jsonl", "writer", args)
 
     def build_reducer(self) -> BaseSink | None:

--- a/src/refiner/pipeline/sinks/lerobot.py
+++ b/src/refiner/pipeline/sinks/lerobot.py
@@ -132,14 +132,14 @@ class LeRobotWriterSink(BaseSink):
     def on_shard_complete(self, shard_id: str) -> None:
         """Flush pending async work and persist one shard-local output chunk."""
         # TODO: We don't have to flush the whole thing we just need to flush the shard rows
-        self._async_window.flush()
+        self._async_window.drain()
         state = self._states.pop(shard_id, None)
         if state is not None:
             self._commit_shard(state)
 
     def close(self) -> None:
         """Flush any remaining shard-local work before sink shutdown."""
-        self._async_window.flush()
+        self._async_window.drain()
         for state in self._states.values():
             self._commit_shard(state)
         self._states.clear()

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -68,7 +68,7 @@ class ParquetSink(BaseSink):
         self._writers[shard_id] = writer
         return writer
 
-    def write_shard_block(self, shard_id: str, block: Block) -> None:
+    def write_shard_block(self, shard_id: str, block: Block) -> int:
         if isinstance(block, Tabular):
             table = block.table
         else:
@@ -83,11 +83,12 @@ class ParquetSink(BaseSink):
             table = table.drop_columns([SHARD_ID_COLUMN])
         if self._assets is None:
             self._writer(shard_id, table.schema).write_table(table)
-            return
+            return table.num_rows
         self._writer(
             shard_id,
             (table := self._assets.rewrite_table(shard_id, table)).schema,
         ).write_table(table)
+        return table.num_rows
 
     def on_shard_complete(self, shard_id: str) -> None:
         writer = self._writers.pop(shard_id, None)
@@ -98,7 +99,7 @@ class ParquetSink(BaseSink):
     def close(self) -> None:
         try:
             if self._assets is not None:
-                self._assets.flush()
+                self._assets.close()
         finally:
             for writer in self._writers.values():
                 writer.close()

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -7,7 +7,7 @@ from refiner.io.datafolder import DataFolder, DataFolderLike
 from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.shard import SHARD_ID_COLUMN
 from refiner.pipeline.data.tabular import Tabular
-from refiner.pipeline.sinks.assets import AssetUploadManager
+from refiner.pipeline.sinks.assets import AssetUploadManager, MissingAssetPolicy
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.pipeline.sinks.reducer.file import FileCleanupReducerSink
 from refiner.worker.context import get_active_worker_token
@@ -24,12 +24,14 @@ class ParquetSink(BaseSink):
         upload_assets: bool = False,
         assets_subdir: str = "assets",
         max_asset_uploads_in_flight: int = 16,
+        missing_asset_policy: MissingAssetPolicy = "error",
     ):
         self.output = DataFolder.resolve(output)
         self.filename_template = filename_template
         self.compression = compression
         self.upload_assets = upload_assets
         self.assets_subdir = assets_subdir
+        self.missing_asset_policy = missing_asset_policy
         self._writers: dict[str, pq.ParquetWriter] = {}
         self._schema: pa.Schema | None = None
         self._assets = (
@@ -38,6 +40,7 @@ class ParquetSink(BaseSink):
                 assets_subdir=assets_subdir,
                 filename_template=filename_template,
                 max_uploads_in_flight=max_asset_uploads_in_flight,
+                missing_asset_policy=missing_asset_policy,
             )
             if upload_assets
             else None
@@ -111,6 +114,7 @@ class ParquetSink(BaseSink):
         if self.upload_assets:
             args["upload_assets"] = True
             args["assets_subdir"] = self.assets_subdir
+            args["missing_asset_policy"] = self.missing_asset_policy
         return ("write_parquet", "writer", args)
 
     def build_reducer(self) -> BaseSink | None:

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -446,10 +446,10 @@ class CommonCrawlWarcIndexSource(BaseSource):
         )
         for row in self._iter_index_rows(shard):
             window.submit_blocking(self._fetch_index_row_payload_async(row))
-            for payload in window.poll():
+            for payload in window.take_completed():
                 if payload is not None:
                     yield DictRow(payload)
-        for payload in window.flush():
+        for payload in window.drain():
             if payload is not None:
                 yield DictRow(payload)
 

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -250,7 +250,7 @@ class Worker:
                         if heartbeat_error is not None:
                             raise RuntimeError(f"heartbeat failed: {heartbeat_error}")
                         with set_active_step_index(sink_step_index):
-                            written = sink.write_block(block)
+                            written, written_output_rows = sink.write_block(block)
                         _apply_row_delta(
                             {
                                 shard_id: -count
@@ -259,7 +259,7 @@ class Worker:
                             }
                         )
                         if sink.counts_output_rows:
-                            output_rows += block_num_rows(block)
+                            output_rows += written_output_rows
                 except Exception as e:
                     execution_error = e
                     failed_error = str(e).strip() or type(e).__name__

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -11,3 +12,7 @@ def pytest_configure() -> None:
     # Keep subprocess workers aligned with the same import path.
     existing = os.environ.get("PYTHONPATH", "")
     os.environ["PYTHONPATH"] = f"{src}{os.pathsep}{existing}" if existing else str(src)
+    # Tests should not report local launcher runs to a real Macrodata account just
+    # because the developer shell has credentials configured.
+    os.environ.pop("MACRODATA_API_KEY", None)
+    os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp(prefix="refiner-test-config-")

--- a/tests/execution/test_async_window.py
+++ b/tests/execution/test_async_window.py
@@ -42,7 +42,7 @@ def test_async_window_ready_results_preserve_order() -> None:
     window = AsyncWindow[int](max_in_flight=2, preserve_order=True)
 
     assert window.submit_blocking(_delayed_value(1, 0.03)) is None
-    assert window.submit_ready(2) is None
+    assert window.submit_result(2) is None
 
     assert window.take_completed() == []
     assert window.drain() == [1, 2]

--- a/tests/execution/test_async_window.py
+++ b/tests/execution/test_async_window.py
@@ -36,3 +36,13 @@ def test_async_window_poll_returns_ready_results_without_blocking() -> None:
 
     assert sorted(polled) == [1, 2]
     assert window.flush() == []
+
+
+def test_async_window_ready_results_preserve_order() -> None:
+    window = AsyncWindow[int](max_in_flight=2, preserve_order=True)
+
+    assert window.submit_blocking(_delayed_value(1, 0.03)) is None
+    assert window.submit_ready(2) is None
+
+    assert window.poll() == []
+    assert window.flush() == [1, 2]

--- a/tests/execution/test_async_window.py
+++ b/tests/execution/test_async_window.py
@@ -21,21 +21,21 @@ def test_async_window_submit_blocking_enforces_max_in_flight() -> None:
     elapsed = time.perf_counter() - start
 
     assert elapsed >= 0.02
-    assert window.poll() == [1]
-    assert window.flush() == [2]
+    assert window.take_completed() == [1]
+    assert window.drain() == [2]
 
 
-def test_async_window_poll_returns_ready_results_without_blocking() -> None:
+def test_async_window_take_completed_returns_ready_results_without_blocking() -> None:
     window = AsyncWindow[int](max_in_flight=2, preserve_order=False)
 
     assert window.submit_blocking(_delayed_value(1, 0.03)) is None
     assert window.submit_blocking(_delayed_value(2, 0.0)) is None
 
     time.sleep(0.05)
-    polled = window.poll()
+    polled = window.take_completed()
 
     assert sorted(polled) == [1, 2]
-    assert window.flush() == []
+    assert window.drain() == []
 
 
 def test_async_window_ready_results_preserve_order() -> None:
@@ -44,5 +44,5 @@ def test_async_window_ready_results_preserve_order() -> None:
     assert window.submit_blocking(_delayed_value(1, 0.03)) is None
     assert window.submit_ready(2) is None
 
-    assert window.poll() == []
-    assert window.flush() == [1, 2]
+    assert window.take_completed() == []
+    assert window.drain() == [1, 2]

--- a/tests/execution/test_async_window.py
+++ b/tests/execution/test_async_window.py
@@ -46,3 +46,16 @@ def test_async_window_ready_results_preserve_order() -> None:
 
     assert window.take_completed() == []
     assert window.drain() == [1, 2]
+
+
+def test_async_window_cancel_pending_clears_window() -> None:
+    window = AsyncWindow[int](max_in_flight=2, preserve_order=True)
+
+    assert window.submit_blocking(_delayed_value(1, 1.0)) is None
+    assert window.submit_result(2) is None
+
+    window.cancel_pending()
+
+    assert len(window) == 0
+    assert window.take_completed() == []
+    assert window.drain() == []

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -38,7 +38,7 @@ class FakeReader(BaseReader):
 class UndescribedSink(BaseSink):
     def write_block(self, block):
         del block
-        return {}
+        return {}, 0
 
 
 def _score_filter_lambda():
@@ -234,7 +234,7 @@ def test_compile_pipeline_plan_redacts_sink_callable_args() -> None:
     class CallableSink(BaseSink):
         def write_block(self, block):
             del block
-            return {}
+            return {}, 0
 
         def describe(self):
             return (

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -187,6 +187,112 @@ def test_parquet_sink_does_not_upload_embedded_assets(tmp_path) -> None:
     assert datatype.asset_storage(out.schema.field("image")) == "bytes_with_path"
 
 
+def test_parquet_sink_can_drop_rows_with_missing_assets(tmp_path) -> None:
+    source = tmp_path / "source.png"
+    missing = tmp_path / "missing.png"
+    source.write_bytes(b"image")
+    output_dir = tmp_path / "parquet-drop-missing-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    table = datatype.apply_dtypes_to_table(
+        pa.table(
+            {
+                "image": [str(source), str(source), str(missing)],
+                "images": [[str(source)], [str(source), str(missing)], [str(source)]],
+                "label": ["keep", "drop-list", "drop-scalar"],
+            }
+        ),
+        {
+            "image": datatype.image_path(),
+            "images": datatype.list(datatype.image_path()),
+        },
+    )
+    sink = ParquetSink(output_dir, upload_assets=True, missing_asset_policy="drop_row")
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset = output_dir / "assets" / f"{shard_id}__w{worker}" / "image" / "0-source.png"
+    list_asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "images" / "0-0-source.png"
+    )
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    out = pq.read_table(written)
+    assert asset.read_bytes() == b"image"
+    assert list_asset.read_bytes() == b"image"
+    assert out.column("image").to_pylist() == [str(asset)]
+    assert out.column("images").to_pylist() == [[str(list_asset)]]
+    assert out.column("label").to_pylist() == ["keep"]
+
+
+def test_jsonl_sink_can_set_missing_assets_to_null(tmp_path) -> None:
+    source = tmp_path / "source.png"
+    missing = tmp_path / "missing.png"
+    source.write_bytes(b"image")
+    output_dir = tmp_path / "jsonl-null-missing-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    sink = JsonlSink(output_dir, upload_assets=True, missing_asset_policy="set_null")
+    sink.set_input_schema(
+        pa.schema(
+            [
+                datatype.image_path().with_name("image"),
+                pa.field("images", pa.list_(datatype.image_path())),
+            ]
+        )
+    )
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(
+            shard_id,
+            [
+                DictRow(
+                    {
+                        "image": str(source),
+                        "images": [str(source), str(missing)],
+                        "label": "keep",
+                    }
+                ),
+                DictRow(
+                    {
+                        "image": str(missing),
+                        "images": [str(missing)],
+                        "label": "null",
+                    }
+                ),
+            ],
+        )
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset = output_dir / "assets" / f"{shard_id}__w{worker}" / "image" / "0-source.png"
+    list_asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "images" / "0-0-source.png"
+    )
+    jsonl = output_dir / f"{shard_id}__w{worker}.jsonl"
+    rows = [json.loads(line) for line in jsonl.read_text(encoding="utf-8").splitlines()]
+    assert asset.read_bytes() == b"image"
+    assert list_asset.read_bytes() == b"image"
+    assert rows == [
+        {"image": str(asset), "images": [str(list_asset), None], "label": "keep"},
+        {"image": None, "images": [None], "label": "null"},
+    ]
+
+
 def test_asset_upload_rejects_unsafe_assets_subdir(tmp_path) -> None:
     with pytest.raises(ValueError, match="assets_subdir"):
         JsonlSink(tmp_path / "jsonl-assets", upload_assets=True, assets_subdir="../x")

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -288,8 +288,8 @@ def test_jsonl_sink_can_set_missing_assets_to_null(tmp_path) -> None:
     assert asset.read_bytes() == b"image"
     assert list_asset.read_bytes() == b"image"
     assert rows == [
-        {"image": str(asset), "images": [str(list_asset), None], "label": "keep"},
-        {"image": None, "images": [None], "label": "null"},
+        {"image": str(asset), "images": None, "label": "keep"},
+        {"image": None, "images": None, "label": "null"},
     ]
 
 

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -233,6 +233,45 @@ def test_parquet_sink_can_drop_rows_with_missing_assets(tmp_path) -> None:
     assert out.column("label").to_pylist() == ["keep"]
 
 
+def test_parquet_sink_can_set_missing_list_assets_to_null(tmp_path) -> None:
+    source = tmp_path / "source.png"
+    missing = tmp_path / "missing.png"
+    source.write_bytes(b"image")
+    output_dir = tmp_path / "parquet-null-missing-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    table = datatype.apply_dtypes_to_table(
+        pa.table(
+            {
+                "images": [[str(source), str(missing)], [str(missing)]],
+                "label": ["partial", "missing"],
+            }
+        ),
+        {"images": datatype.list(datatype.image_path())},
+    )
+    sink = ParquetSink(output_dir, upload_assets=True, missing_asset_policy="set_null")
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    asset = (
+        output_dir / "assets" / f"{shard_id}__w{worker}" / "images" / "0-0-source.png"
+    )
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    out = pq.read_table(written)
+    assert asset.read_bytes() == b"image"
+    assert out.column("images").to_pylist() == [[str(asset), None], [None]]
+    assert out.column("label").to_pylist() == ["partial", "missing"]
+
+
 def test_jsonl_sink_can_set_missing_assets_to_null(tmp_path) -> None:
     source = tmp_path / "source.png"
     missing = tmp_path / "missing.png"
@@ -288,9 +327,36 @@ def test_jsonl_sink_can_set_missing_assets_to_null(tmp_path) -> None:
     assert asset.read_bytes() == b"image"
     assert list_asset.read_bytes() == b"image"
     assert rows == [
-        {"image": str(asset), "images": None, "label": "keep"},
-        {"image": None, "images": None, "label": "null"},
+        {"image": str(asset), "images": [str(list_asset), None], "label": "keep"},
+        {"image": None, "images": [None], "label": "null"},
     ]
+
+
+def test_jsonl_sink_error_policy_raises_on_later_failed_asset(tmp_path) -> None:
+    source = tmp_path / "source.png"
+    missing = tmp_path / "missing.png"
+    source.write_bytes(b"image")
+    output_dir = tmp_path / "jsonl-error-missing-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    sink = JsonlSink(output_dir, upload_assets=True)
+    sink.set_input_schema(pa.schema([datatype.image_path().with_name("image")]))
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        with pytest.raises(FileNotFoundError):
+            sink.write_shard_block(
+                shard_id,
+                [
+                    DictRow({"image": str(source), "label": "valid"}),
+                    DictRow({"image": str(missing), "label": "missing"}),
+                ],
+            )
 
 
 def test_asset_upload_rejects_unsafe_assets_subdir(tmp_path) -> None:
@@ -482,6 +548,38 @@ def test_jsonl_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None:
     assert stats.output_rows == 1
     assert asset.read_bytes() == b"frame"
     assert json.loads(written.read_text(encoding="utf-8")) == {"image": str(asset)}
+
+
+def test_jsonl_pipeline_counts_rows_after_missing_asset_drop(tmp_path) -> None:
+    source = tmp_path / "frame.png"
+    missing = tmp_path / "missing.png"
+    source.write_bytes(b"frame")
+    output_dir = tmp_path / "jsonl-pipeline-drop-assets"
+    pipeline = (
+        from_items([{"image": str(source)}, {"image": str(missing)}])
+        .map(
+            lambda row: {"image": row["image"]},
+            dtypes={"image": datatype.image_path()},
+        )
+        .write_jsonl(
+            output_dir,
+            upload_assets=True,
+            missing_asset_policy="drop_row",
+        )
+    )
+
+    stats = pipeline.launch_local(
+        name="jsonl-drop-asset-counts",
+        num_workers=1,
+        rundir=str(tmp_path / "run"),
+    )
+
+    written = next(output_dir.glob("*.jsonl"))
+    rows = [
+        json.loads(line) for line in written.read_text(encoding="utf-8").splitlines()
+    ]
+    assert stats.output_rows == 1
+    assert len(rows) == 1
 
 
 def test_parquet_pipeline_uploads_row_assets_from_dtype_schema(tmp_path) -> None:

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -101,7 +101,7 @@ class _RecordingSink(BaseSink):
         self.written_counts: list[dict[str, int]] = []
         self.completed_shards: list[str] = []
 
-    def write_block(self, block) -> dict[str, int]:
+    def write_block(self, block) -> tuple[dict[str, int], int]:
         if isinstance(block, list):
             counts: dict[str, int] = {}
             for row in block:
@@ -112,7 +112,7 @@ class _RecordingSink(BaseSink):
             for shard_id in block.column("__shard_id").to_pylist():
                 counts[shard_id] = counts.get(shard_id, 0) + 1
         self.written_counts.append(counts)
-        return counts
+        return counts, sum(counts.values())
 
     def on_shard_complete(self, shard_id: str) -> None:
         self.completed_shards.append(shard_id)
@@ -124,9 +124,9 @@ class _CloseFailingSink(_RecordingSink):
 
 
 class _ShortWriteAndCloseFailingSink(_CloseFailingSink):
-    def write_block(self, block) -> dict[str, int]:
-        counts = super().write_block(block)
-        return {shard_id: 1 for shard_id in counts}
+    def write_block(self, block) -> tuple[dict[str, int], int]:
+        counts, _output_rows = super().write_block(block)
+        return {shard_id: 1 for shard_id in counts}, 1
 
 
 class _MetricRecordingTelemetryEmitter(_NoopTelemetryEmitter):


### PR DESCRIPTION
## Summary

Adds `missing_asset_policy` to JSONL and Parquet sinks with three policies for uploaded asset paths:

- `error`: preserve existing behavior and fail on missing assets
- `drop_row`: skip rows whose asset copy reports missing
- `set_null`: keep rows and set missing asset values to `null`

The implementation avoids preflight `.exists()` checks, so it handles missing files from the actual copy failure without adding resolver/API calls.

Also isolates pytest runs from local Macrodata credentials by clearing `MACRODATA_API_KEY` and pointing `XDG_CONFIG_HOME` at an empty temporary config directory.

## Validation

- `uv run python -m py_compile src/refiner/pipeline/sinks/assets.py src/refiner/pipeline/sinks/parquet.py src/refiner/pipeline/sinks/jsonl.py src/refiner/pipeline/pipeline.py tests/conftest.py tests/pipeline/test_sinks.py`
- `uv run ruff check src/refiner/pipeline/sinks/assets.py src/refiner/pipeline/sinks/parquet.py src/refiner/pipeline/sinks/jsonl.py src/refiner/pipeline/pipeline.py tests/conftest.py tests/pipeline/test_sinks.py`
- `uv run ty check src/refiner/pipeline/sinks/assets.py`
- `uv run pytest tests/pipeline/test_sinks.py::test_parquet_sink_can_drop_rows_with_missing_assets tests/pipeline/test_sinks.py::test_jsonl_sink_can_set_missing_assets_to_null`
- commit hook: `ruff`, `ruff format`, `ty`