### PR TITLE
[codex] remove vllm extra kwargs handling

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -79,15 +79,6 @@ pipeline = mdr.read_jsonl("input.jsonl").map_async(
 )
 ```
 
-Pass extra VLLM server arguments through `extra_kwargs` on the provider:
-
-```python
-provider = mdr.inference.VLLMProvider(
-    model="Qwen/Qwen3.5-9B",
-    extra_kwargs={"limit-mm-per-prompt": '{"video": 1}'},
-)
-```
-
 #### Supported models
 Only the following models are currently supported. If you are missing one, please create an issue:
 - `Qwen/Qwen3.5-9B`

--- a/src/refiner/inference/providers.py
+++ b/src/refiner/inference/providers.py
@@ -1,5 +1,4 @@
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from refiner.services import VLLMServiceDefinition
@@ -32,24 +31,17 @@ class OpenAIEndpointProvider:
 class VLLMProvider:
     model: str
     model_max_context: int | None = None
-    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.model.strip():
             raise ValueError("model_name_or_path must be non-empty")
         if self.model_max_context is not None and self.model_max_context <= 0:
             raise ValueError("model_max_context must be > 0 when provided")
-        for key, value in dict(self.extra_kwargs).items():
-            if not str(key).strip():
-                raise ValueError("extra_kwargs keys must be non-empty")
-            if value is None:
-                raise ValueError("extra_kwargs values must be non-null")
 
     def service_definition(self) -> VLLMServiceDefinition:
         return VLLMServiceDefinition(
             model_name_or_path=self.model,
             model_max_context=self.model_max_context,
-            extra_kwargs=self.extra_kwargs,
         )
 
     def to_builtin_args(self) -> dict[str, object]:
@@ -59,8 +51,6 @@ class VLLMProvider:
         }
         if self.model_max_context is not None:
             payload["model_max_context"] = self.model_max_context
-        if self.extra_kwargs:
-            payload["extra_kwargs"] = dict(self.extra_kwargs)
         return payload
 
 

--- a/src/refiner/services/vllm.py
+++ b/src/refiner/services/vllm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from refiner.services.base import RuntimeServiceBinding, RuntimeServiceSpec
@@ -13,7 +13,6 @@ from refiner.services.base import RuntimeServiceBinding, RuntimeServiceSpec
 class VLLMServiceDefinition:
     model_name_or_path: str
     model_max_context: int | None = None
-    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
     kind: str = "llm"
 
     def __post_init__(self) -> None:
@@ -21,11 +20,6 @@ class VLLMServiceDefinition:
             raise ValueError("model_name_or_path must be non-empty")
         if self.model_max_context is not None and self.model_max_context <= 0:
             raise ValueError("model_max_context must be > 0 when provided")
-        for key, value in dict(self.extra_kwargs).items():
-            if not str(key).strip():
-                raise ValueError("extra_kwargs keys must be non-empty")
-            if value is None:
-                raise ValueError("extra_kwargs values must be non-null")
 
     @property
     def name(self) -> str:
@@ -33,7 +27,6 @@ class VLLMServiceDefinition:
             {
                 "model_name_or_path": self.model_name_or_path,
                 "model_max_context": self.model_max_context,
-                "extra_kwargs": self.extra_kwargs,
             },
             separators=(",", ":"),
         )
@@ -43,8 +36,6 @@ class VLLMServiceDefinition:
         config: dict[str, Any] = {"model_name_or_path": self.model_name_or_path}
         if self.model_max_context is not None:
             config["model_max_context"] = self.model_max_context
-        if self.extra_kwargs:
-            config["extra_kwargs"] = dict(self.extra_kwargs)
         return RuntimeServiceSpec(name=self.name, kind=self.kind, config=config)
 
 

--- a/tests/services/test_discovery.py
+++ b/tests/services/test_discovery.py
@@ -15,7 +15,7 @@ def test_collect_pipeline_services_supports_nested_service_config() -> None:
             fn=_noop_inference,
             provider=mdr.inference.VLLMProvider(
                 model="Qwen/Qwen2.5-VL-7B-Instruct",
-                extra_kwargs={"limit-mm-per-prompt": "video=1"},
+                model_max_context=32768,
             ),
         )
     )
@@ -25,5 +25,5 @@ def test_collect_pipeline_services_supports_nested_service_config() -> None:
     assert len(services) == 1
     assert services[0].config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
+        "model_max_context": 32768,
     }

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -236,11 +236,10 @@ def test_service_manager_times_out_when_service_never_becomes_ready(
         asyncio.run(manager.get("llm-a"))
 
 
-def test_vllm_service_definition_includes_extra_kwargs_in_name_and_config() -> None:
+def test_vllm_service_definition_includes_model_context_in_name_and_config() -> None:
     service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
         model_max_context=32768,
-        extra_kwargs={"limit-mm-per-prompt": "video=1"},
     )
 
     spec = service.to_spec()
@@ -248,29 +247,17 @@ def test_vllm_service_definition_includes_extra_kwargs_in_name_and_config() -> N
     assert spec.config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
         "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
     }
     assert service.name.startswith("vllm-")
 
 
-def test_vllm_service_definition_name_preserves_extra_kwargs_value_types() -> None:
-    int_service = VLLMServiceDefinition(
+def test_vllm_service_definition_name_includes_model_context() -> None:
+    default_context_service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs={"max-num-seqs": 2048},
     )
-    str_service = VLLMServiceDefinition(
+    explicit_context_service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs={"max-num-seqs": "2048"},
-    )
-
-    assert int_service.name != str_service.name
-
-
-def test_vllm_service_definition_name_accepts_mixed_extra_kwargs_key_types() -> None:
-    extra_kwargs = cast(Mapping[str, Any], {1: "one", "2": "two"})
-    service = VLLMServiceDefinition(
-        model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs=extra_kwargs,
+        model_max_context=32768,
     )
 
-    assert service.name.startswith("vllm-")
+    assert default_context_service.name != explicit_context_service.name

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -421,23 +421,20 @@ def test_vllm_provider_includes_model_in_requests(monkeypatch) -> None:
     }
 
 
-def test_vllm_provider_includes_extra_kwargs_in_service_definition() -> None:
+def test_vllm_provider_includes_model_context_in_service_definition() -> None:
     provider = VLLMProvider(
         model="Qwen/Qwen2.5-VL-7B-Instruct",
         model_max_context=32768,
-        extra_kwargs={"limit-mm-per-prompt": "video=1"},
     )
 
     assert provider.to_builtin_args() == {
         "type": "vllm",
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
         "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
     }
     assert provider.service_definition().to_spec().config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
         "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
     }
 
 


### PR DESCRIPTION
## Summary
- remove extra_kwargs from VLLMProvider and VLLMServiceDefinition
- stop serializing extra_kwargs into built-in args or runtime service specs
- update tests and inference docs for the narrower VLLM provider surface

## Why
Cloud worker runtime code failed when branch code removed VLLMProvider.extra_kwargs but older serialized service config still expected it. This removes the field from the Refiner API and service spec instead of adding a compatibility shim.

## Validation
- uv run pytest tests/test_inference.py tests/services/test_manager.py tests/services/test_discovery.py