### PR TITLE
[codex] add secrets CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,51 @@ macrodata run --attach path/to/cloud_pipeline.py
 
 See [Auth](auth.md) for the shared credential lookup order and credential file location.
 
+## Workspace Secrets
+
+Secrets are scoped to the workspace attached to your current API key. The CLI only prints secret names and environments, never values.
+
+### `macrodata secrets list`
+
+Options:
+
+- `--env <name>`
+- `--json`
+
+```bash
+macrodata secrets list
+macrodata secrets list --env production
+```
+
+### `macrodata secrets set`
+
+Adds or replaces a secret. Values are read from an interactive prompt by default or from stdin with `--value-stdin`.
+
+Options:
+
+- `--env <name>`; defaults to `default`
+- `--value-stdin`
+- `--json`
+
+```bash
+macrodata secrets set HF_TOKEN
+printf '%s' "$HF_TOKEN" | macrodata secrets set HF_TOKEN --env production --value-stdin
+```
+
+### `macrodata secrets remove`
+
+Deletes a secret by name. `delete` is accepted as an alias for `remove`.
+
+Options:
+
+- `--env <name>`; defaults to `default`
+- `--json`
+
+```bash
+macrodata secrets remove HF_TOKEN
+macrodata secrets delete HF_TOKEN --env production
+```
+
 ## Job Inspection
 
 Inspect jobs in the workspace attached to your current API key:

--- a/src/refiner/cli/commands/secrets.py
+++ b/src/refiner/cli/commands/secrets.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+
+from refiner.cli.secrets import cmd_secrets_list, cmd_secrets_remove, cmd_secrets_set
+
+
+def register_secrets_command(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    secrets = subparsers.add_parser("secrets", help="Manage workspace secrets")
+
+    def _show_secrets_help(_args: argparse.Namespace) -> int:
+        _ = _args
+        secrets.print_help()
+        return 0
+
+    secrets.set_defaults(handler=_show_secrets_help)
+    secrets_subparsers = secrets.add_subparsers(dest="secrets_command")
+
+    secrets_list = secrets_subparsers.add_parser(
+        "list", help="List workspace secret names"
+    )
+    secrets_list.add_argument("--env", default=None, help="Secret environment to list")
+    secrets_list.add_argument(
+        "--json", action="store_true", help="Print raw JSON response"
+    )
+    secrets_list.set_defaults(handler=cmd_secrets_list)
+
+    secrets_set = secrets_subparsers.add_parser(
+        "set", help="Add or replace a workspace secret"
+    )
+    secrets_set.add_argument("name", help="Secret name")
+    secrets_set.add_argument("--env", default="default", help="Secret environment")
+    secrets_set.add_argument(
+        "--value-stdin",
+        action="store_true",
+        help="Read the secret value from stdin",
+    )
+    secrets_set.add_argument(
+        "--json", action="store_true", help="Print raw JSON response"
+    )
+    secrets_set.set_defaults(handler=cmd_secrets_set)
+
+    secrets_remove = secrets_subparsers.add_parser(
+        "remove", aliases=["delete"], help="Remove a workspace secret"
+    )
+    secrets_remove.add_argument("name", help="Secret name")
+    secrets_remove.add_argument("--env", default="default", help="Secret environment")
+    secrets_remove.add_argument(
+        "--json", action="store_true", help="Print raw JSON response"
+    )
+    secrets_remove.set_defaults(handler=cmd_secrets_remove)

--- a/src/refiner/cli/common.py
+++ b/src/refiner/cli/common.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+from refiner.cli.ui.terminal import stdout_is_interactive
+from refiner.platform.client import MacrodataClient
+from refiner.platform.client.api import sanitize_terminal_text
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_ANSI_RESET = "\x1b[0m"
+_DIM_COLOR = "\x1b[38;5;245m"
+
+
+def create_client() -> MacrodataClient:
+    return MacrodataClient()
+
+
+def print_json(payload: dict[str, Any]) -> int:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def safe_text(value: Any) -> str:
+    if value is None:
+        return "-"
+    return sanitize_terminal_text(str(value))
+
+
+def dim_text(value: Any) -> str:
+    text = safe_text(value)
+    if not stdout_is_interactive():
+        return text
+    return f"{_DIM_COLOR}{text}{_ANSI_RESET}"
+
+
+def print_table(rows: list[list[str]]) -> None:
+    if not rows:
+        return
+    column_count = len(rows[0])
+
+    def visible_width(text: str) -> int:
+        return len(_ANSI_RE.sub("", text))
+
+    def pad_right(text: str, width: int) -> str:
+        return text + (" " * max(0, width - visible_width(text)))
+
+    widths = [
+        max(visible_width(row[index]) if index < len(row) else 0 for row in rows)
+        for index in range(column_count)
+    ]
+    for row_index, row in enumerate(rows):
+        padded = "  ".join(
+            pad_right(row[index] if index < len(row) else "", widths[index])
+            for index in range(column_count)
+        )
+        print(padded.rstrip())
+        if row_index == 0:
+            print("  ".join("-" * width for width in widths))
+
+
+def handle_error(err: Exception) -> int:
+    print(safe_text(str(err)), file=sys.stderr)
+    return 1

--- a/src/refiner/cli/jobs/attach.py
+++ b/src/refiner/cli/jobs/attach.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from argparse import Namespace
 import sys
 
-from refiner.cli.jobs.common import _client, _executor_text, _handle_error
+from refiner.cli.common import create_client
+from refiner.cli.common import handle_error
+from refiner.cli.jobs.common import _executor_text
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import MacrodataApiError
 
@@ -12,10 +14,10 @@ def cmd_jobs_attach(args: Namespace) -> int:
     from refiner.cli.run import cloud
 
     try:
-        client = _client()
+        client = create_client()
         payload = client.cli_get_job(job_id=args.job_id)
     except (MacrodataApiError, MacrodataCredentialsError) as err:
-        return _handle_error(err)
+        return handle_error(err)
 
     job = payload.get("job")
     if not isinstance(job, dict):
@@ -45,4 +47,4 @@ def cmd_jobs_attach(args: Namespace) -> int:
         print(str(code), file=sys.stderr)
         return 1
     except (MacrodataApiError, MacrodataCredentialsError) as err:
-        return _handle_error(err)
+        return handle_error(err)

--- a/src/refiner/cli/jobs/common.py
+++ b/src/refiner/cli/jobs/common.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import json
-import re
 import shlex
-import sys
 from typing import Any
 
+from refiner.cli.common import handle_error
+from refiner.cli.common import print_json
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.ui.terminal import stdout_is_interactive
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import MacrodataApiError
-from refiner.platform.client import MacrodataClient
 
 _Payload = dict[str, Any]
 _PayloadFetcher = Callable[[], _Payload]
@@ -41,16 +39,6 @@ _LEVEL_COLORS = {
     "ERROR": "\x1b[1;38;5;203m",
     "CRITICAL": "\x1b[1;38;5;203m",
 }
-_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
-
-
-def _client() -> MacrodataClient:
-    return MacrodataClient()
-
-
-def _print_json(payload: dict[str, Any]) -> int:
-    print(json.dumps(payload, indent=2, sort_keys=True))
-    return 0
 
 
 def _status_text(value: Any) -> str:
@@ -120,36 +108,6 @@ def _error_text(value: Any) -> str:
     return f"{_ERROR_COLOR}{text}{_ANSI_RESET}"
 
 
-def _print_table(rows: list[list[str]]) -> None:
-    if not rows:
-        return
-    column_count = len(rows[0])
-
-    def _visible_width(text: str) -> int:
-        return len(_ANSI_RE.sub("", text))
-
-    def _pad_right(text: str, width: int) -> str:
-        return text + (" " * max(0, width - _visible_width(text)))
-
-    widths = [
-        max(_visible_width(row[i]) if i < len(row) else 0 for row in rows)
-        for i in range(column_count)
-    ]
-    for index, row in enumerate(rows):
-        padded = "  ".join(
-            _pad_right(row[i] if i < len(row) else "", widths[i])
-            for i in range(column_count)
-        )
-        print(padded.rstrip())
-        if index == 0:
-            print("  ".join("-" * width for width in widths))
-
-
-def _handle_error(err: Exception) -> int:
-    print(_safe_text(str(err)), file=sys.stderr)
-    return 1
-
-
 def _shell_command(parts: list[str]) -> str:
     return " ".join(shlex.quote(part) for part in parts)
 
@@ -169,8 +127,8 @@ def _run_job_command(
     try:
         payload = fetch()
     except (MacrodataApiError, MacrodataCredentialsError) as err:
-        return _handle_error(err)
-    return _print_json(payload) if as_json else renderer(payload)
+        return handle_error(err)
+    return print_json(payload) if as_json else renderer(payload)
 
 
 def _executor_text(value: Any) -> str:

--- a/src/refiner/cli/jobs/control.py
+++ b/src/refiner/cli/jobs/control.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from argparse import Namespace
 
+from refiner.cli.common import create_client
 from refiner.cli.jobs.follow import safe_text as _safe_text
-from refiner.cli.jobs.common import _client, _run_job_command
+from refiner.cli.jobs.common import _run_job_command
 
 
 def _render_cancel(payload: dict[str, object]) -> int:
@@ -24,6 +25,6 @@ def _render_cancel(payload: dict[str, object]) -> int:
 def cmd_jobs_cancel(args: Namespace) -> int:
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_cancel_job(job_id=args.job_id),
+        fetch=lambda: create_client().cli_cancel_job(job_id=args.job_id),
         renderer=_render_cancel,
     )

--- a/src/refiner/cli/jobs/get.py
+++ b/src/refiner/cli/jobs/get.py
@@ -4,16 +4,16 @@ from argparse import Namespace
 import sys
 from typing import Any
 
+from refiner.cli.common import create_client
+from refiner.cli.common import print_table
 from refiner.cli.jobs.follow import format_ts as _format_ts
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.jobs.common import (
-    _client,
     _dim_text,
     _error_text,
     _executor_text,
     _kind_text,
     _label_text,
-    _print_table,
     _run_job_command,
     _section_text,
     _status_text,
@@ -87,7 +87,7 @@ def _url_text(value: str) -> str:
 
 
 def _tracking_url(job: dict[str, Any]) -> str:
-    client = _client()
+    client = create_client()
     if not hasattr(client, "base_url"):
         return "-"
     workspace_slug = job.get("workspaceSlug")
@@ -200,7 +200,7 @@ def _render_job(payload: dict[str, Any]) -> int:
                     _stage_gpu_text(runtime_config),
                 ]
             )
-        _print_table(rows)
+        print_table(rows)
         step_rows = [["Stage", "Step", "Type", "Name", "Summary"]]
         has_steps = False
         for stage in stages:
@@ -225,13 +225,13 @@ def _render_job(payload: dict[str, Any]) -> int:
         if has_steps:
             print(f"\n{_section_text('Steps')}")
             step_rows[0] = [_dim_text(cell) for cell in step_rows[0]]
-            _print_table(step_rows)
+            print_table(step_rows)
     return 0
 
 
 def cmd_jobs_get(args: Namespace) -> int:
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_get_job(job_id=args.job_id),
+        fetch=lambda: create_client().cli_get_job(job_id=args.job_id),
         renderer=_render_job,
     )

--- a/src/refiner/cli/jobs/list.py
+++ b/src/refiner/cli/jobs/list.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 from argparse import Namespace
 from typing import Any
 
+from refiner.cli.common import create_client
+from refiner.cli.common import print_table
 from refiner.cli.jobs.follow import format_ts as _format_ts
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.jobs.common import (
-    _client,
     _dim_text,
     _executor_text,
     _kind_text,
     _print_next_command,
-    _print_table,
     _progress_text,
     _run_job_command,
     _started_by_text,
@@ -67,7 +67,7 @@ def _render_list(payload: dict[str, Any], *, args: Namespace) -> int:
                 _started_by_text(item),
             ]
         )
-    _print_table(rows)
+    print_table(rows)
     _print_next_command(payload.get("nextCursor"), _list_command_parts(args))
     return 0
 
@@ -75,7 +75,7 @@ def _render_list(payload: dict[str, Any], *, args: Namespace) -> int:
 def cmd_jobs_list(args: Namespace) -> int:
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_list_jobs(
+        fetch=lambda: create_client().cli_list_jobs(
             status=args.status,
             executor_kind=args.kind,
             me=args.me,

--- a/src/refiner/cli/jobs/logs.py
+++ b/src/refiner/cli/jobs/logs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from argparse import Namespace
 from datetime import datetime as _real_datetime
 from datetime import datetime, timezone
-import json
 from loguru import logger
 import re
 import sys
@@ -23,7 +22,9 @@ from refiner.cli.jobs.follow import (
     retry_delay,
     safe_text as _safe_text,
 )
-from refiner.cli.jobs.common import _client, _handle_error
+from refiner.cli.common import create_client
+from refiner.cli.common import handle_error
+from refiner.cli.common import print_json
 from refiner.cli.ui.terminal import stdout_is_interactive
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import MacrodataApiError
@@ -333,7 +334,7 @@ def _stream_logs(
     args: Namespace,
     limit: int,
 ) -> int:
-    client = _client()
+    client = create_client()
     logs_available = True
     poller = ForwardLogPoller(
         start_ms=_now_ms(),
@@ -520,14 +521,14 @@ def cmd_jobs_logs(args: Namespace) -> int:
 
     if args.follow:
         try:
-            startup_job_payload = _client().cli_get_job(job_id=args.job_id)
+            startup_job_payload = create_client().cli_get_job(job_id=args.job_id)
         except KeyboardInterrupt:
             return 130
         except (MacrodataApiError, MacrodataCredentialsError) as err:
             if isinstance(err, MacrodataApiError) and _is_retryable_api_error(err):
                 startup_job_payload = None
             else:
-                return _handle_error(err)
+                return handle_error(err)
         if (
             isinstance(startup_job_payload, dict)
             and _job_status(startup_job_payload) in TERMINAL_JOB_STATUSES
@@ -547,10 +548,10 @@ def cmd_jobs_logs(args: Namespace) -> int:
                 print("Stopped following logs.", file=sys.stderr)
                 return 130
             except (MacrodataApiError, MacrodataCredentialsError) as err:
-                return _handle_error(err)
+                return handle_error(err)
 
     try:
-        payload = _client().cli_get_job_logs(
+        payload = create_client().cli_get_job_logs(
             job_id=args.job_id,
             start_ms=start_ms,
             end_ms=end_ms,
@@ -567,8 +568,7 @@ def cmd_jobs_logs(args: Namespace) -> int:
     except KeyboardInterrupt:
         return 130
     except (MacrodataApiError, MacrodataCredentialsError) as err:
-        return _handle_error(err)
+        return handle_error(err)
     if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
+        return print_json(payload)
     return _render_logs(payload)

--- a/src/refiner/cli/jobs/manifest.py
+++ b/src/refiner/cli/jobs/manifest.py
@@ -4,12 +4,12 @@ from argparse import Namespace
 import sys
 from typing import Any
 
+from refiner.cli.common import create_client
+from refiner.cli.common import handle_error
+from refiner.cli.common import print_json
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.jobs.common import (
-    _client,
-    _handle_error,
     _label_text,
-    _print_json,
     _section_text,
     _value_text,
 )
@@ -141,16 +141,16 @@ def _render_manifest(
 
 def cmd_jobs_manifest(args: Namespace) -> int:
     try:
-        payload = _client().cli_get_job_manifest(job_id=args.job_id)
+        payload = create_client().cli_get_job_manifest(job_id=args.job_id)
     except (MacrodataApiError, MacrodataCredentialsError) as err:
-        return _handle_error(err)
+        return handle_error(err)
     filtered_payload = _filtered_manifest_payload(
         payload,
         show_deps=args.deps,
         show_code=args.code,
     )
     if args.json:
-        return _print_json(filtered_payload)
+        return print_json(filtered_payload)
     return _render_manifest(
         payload,
         show_deps=args.deps,

--- a/src/refiner/cli/jobs/metrics.py
+++ b/src/refiner/cli/jobs/metrics.py
@@ -4,13 +4,13 @@ from argparse import Namespace
 import sys
 from typing import Any
 
+from refiner.cli.common import create_client
+from refiner.cli.common import print_table
 from refiner.cli.jobs.follow import format_ts as _format_ts
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.jobs.common import (
-    _client,
     _dim_text,
     _label_text,
-    _print_table,
     _run_job_command,
     _section_text,
     _timestamp_text,
@@ -32,7 +32,7 @@ def _render_inventory_table(metrics: list[dict[str, Any]]) -> None:
                 _metric_details_text(metric),
             ]
         )
-    _print_table(rows)
+    print_table(rows)
 
 
 def _print_metric_field(label: str, value: Any) -> None:
@@ -84,7 +84,7 @@ def _render_metric_rankings(
                     _safe_text(worker.get("ratePerSec")),
                 ]
             )
-        _print_table(rows)
+        print_table(rows)
         return
     if kind == "gauge":
         rows = [
@@ -104,7 +104,7 @@ def _render_metric_rankings(
                     _safe_text(worker.get("maxLast5m")),
                 ]
             )
-        _print_table(rows)
+        print_table(rows)
 
 
 def _render_value_metrics(
@@ -299,7 +299,7 @@ def cmd_jobs_metrics(args: Namespace) -> int:
     sort = "asc" if args.asc else "desc" if args.desc else None
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_get_job_step_metrics(
+        fetch=lambda: create_client().cli_get_job_step_metrics(
             job_id=args.job_id,
             stage_index=args.stage_index,
             step_index=args.step,
@@ -333,7 +333,7 @@ def cmd_jobs_resource_metrics(args: Namespace) -> int:
         return 1
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_get_job_metrics(
+        fetch=lambda: create_client().cli_get_job_metrics(
             job_id=args.job_id,
             range_value=args.range,
             start_ms=args.start_ms,

--- a/src/refiner/cli/jobs/workers.py
+++ b/src/refiner/cli/jobs/workers.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from argparse import Namespace
 from typing import Any
 
+from refiner.cli.common import create_client
+from refiner.cli.common import print_table
 from refiner.cli.jobs.follow import format_ts as _format_ts
 from refiner.cli.jobs.follow import safe_text as _safe_text
 from refiner.cli.jobs.common import (
-    _client,
     _dim_text,
     _print_next_command,
-    _print_table,
     _run_job_command,
     _status_text,
     _timestamp_text,
@@ -67,7 +67,7 @@ def _render_workers(payload: dict[str, Any], *, args: Namespace) -> int:
                 _timestamp_text(_format_ts(item.get("endedAt"))),
             ]
         )
-    _print_table(rows)
+    print_table(rows)
     page = payload.get("page")
     if isinstance(page, dict):
         _print_next_command(page.get("nextCursor"), _workers_command_parts(args))
@@ -77,7 +77,7 @@ def _render_workers(payload: dict[str, Any], *, args: Namespace) -> int:
 def cmd_jobs_workers(args: Namespace) -> int:
     return _run_job_command(
         as_json=args.json,
-        fetch=lambda: _client().cli_get_job_workers(
+        fetch=lambda: create_client().cli_get_job_workers(
             job_id=args.job_id,
             stage_index=args.stage,
             limit=args.limit,

--- a/src/refiner/cli/main.py
+++ b/src/refiner/cli/main.py
@@ -6,6 +6,7 @@ import sys
 from refiner.cli.commands.auth import register_auth_commands
 from refiner.cli.commands.jobs import register_jobs_command
 from refiner.cli.commands.run import register_run_command
+from refiner.cli.commands.secrets import register_secrets_command
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -14,6 +15,7 @@ def build_parser() -> argparse.ArgumentParser:
     register_auth_commands(subparsers)
     register_run_command(subparsers)
     register_jobs_command(subparsers)
+    register_secrets_command(subparsers)
 
     return parser
 

--- a/src/refiner/cli/secrets.py
+++ b/src/refiner/cli/secrets.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+
+from refiner.cli.common import create_client
+from refiner.cli.common import dim_text
+from refiner.cli.common import handle_error
+from refiner.cli.common import print_json
+from refiner.cli.common import print_table
+from refiner.cli.common import safe_text
+from refiner.cli.ui import stdin_is_interactive
+from refiner.platform.auth import MacrodataCredentialsError
+from refiner.platform.client import MacrodataApiError
+
+SECRET_VALUE_MAX_CHARS = 32768
+
+
+def _read_stdin_value() -> str:
+    value = sys.stdin.read(SECRET_VALUE_MAX_CHARS + 2)
+    value = value.removesuffix("\n").removesuffix("\r")
+    if len(value) > SECRET_VALUE_MAX_CHARS:
+        raise RuntimeError("Secret value is too large")
+    if value:
+        return value
+    raise RuntimeError("No secret value provided on stdin")
+
+
+def _read_secret_value(args: argparse.Namespace) -> str:
+    if args.value_stdin:
+        return _read_stdin_value()
+
+    if not stdin_is_interactive():
+        return _read_stdin_value()
+
+    value = getpass.getpass(f"Secret value for {args.name}: ")
+    if not value:
+        raise RuntimeError("No secret value provided")
+    return value
+
+
+def cmd_secrets_list(args: argparse.Namespace) -> int:
+    try:
+        payload = create_client().cli_list_secrets(env=args.env)
+    except (MacrodataApiError, MacrodataCredentialsError) as err:
+        return handle_error(err)
+
+    if args.json:
+        return print_json(payload)
+
+    secrets = payload.get("secrets")
+    if not isinstance(secrets, list) or not secrets:
+        print("No secrets found.")
+        return 0
+
+    rows = [[dim_text("Env"), dim_text("Name"), dim_text("Updated")]]
+    for secret in secrets:
+        if not isinstance(secret, dict):
+            continue
+        rows.append(
+            [
+                safe_text(secret.get("env")),
+                safe_text(secret.get("name")),
+                safe_text(secret.get("updatedAt")),
+            ]
+        )
+    print_table(rows)
+    return 0
+
+
+def cmd_secrets_set(args: argparse.Namespace) -> int:
+    try:
+        value = _read_secret_value(args)
+        payload = create_client().cli_set_secret(
+            name=args.name, env=args.env, value=value
+        )
+    except (MacrodataApiError, MacrodataCredentialsError, RuntimeError) as err:
+        return handle_error(err)
+
+    if args.json:
+        return print_json(payload)
+
+    secret_metadata = payload.get("secret")
+    if isinstance(secret_metadata, dict):
+        print(
+            f"Saved secret {safe_text(secret_metadata.get('env'))}/"
+            f"{safe_text(secret_metadata.get('name'))}."
+        )
+    else:
+        print("Saved secret.")
+    return 0
+
+
+def cmd_secrets_remove(args: argparse.Namespace) -> int:
+    try:
+        payload = create_client().cli_delete_secret(name=args.name, env=args.env)
+    except (MacrodataApiError, MacrodataCredentialsError) as err:
+        return handle_error(err)
+
+    if args.json:
+        return print_json(payload)
+
+    print(f"Removed secret {safe_text(args.env)}/{safe_text(args.name)}.")
+    return 0

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -4,7 +4,7 @@ import importlib.metadata
 import os
 from dataclasses import dataclass
 from typing import Any, TypeVar
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 import httpx
 import msgspec
@@ -435,6 +435,29 @@ class MacrodataClient:
 
     def cli_cancel_job(self, *, job_id: str) -> dict[str, Any]:
         return self._request_raw(method="POST", path=f"/api/cli/jobs/{job_id}/cancel")
+
+    def cli_list_secrets(self, *, env: str | None = None) -> dict[str, Any]:
+        return self._request_raw(
+            method="GET",
+            path="/api/cli/secrets",
+            query_params={"env": env},
+        )
+
+    def cli_set_secret(
+        self, *, name: str, value: str, env: str = "default"
+    ) -> dict[str, Any]:
+        return self._request_raw(
+            method="POST",
+            path="/api/cli/secrets",
+            json_payload={"env": env, "name": name, "value": value},
+        )
+
+    def cli_delete_secret(self, *, name: str, env: str = "default") -> dict[str, Any]:
+        return self._request_raw(
+            method="DELETE",
+            path=f"/api/cli/secrets/{quote(name, safe='')}",
+            query_params={"env": env},
+        )
 
     def start_worker_services(
         self,

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, cast
 
-from refiner.cli.jobs import common as jobs_common
+from refiner.cli.common import print_table
 from refiner.cli.jobs.attach import cmd_jobs_attach
 from refiner.cli.jobs.control import cmd_jobs_cancel
 from refiner.cli.jobs.get import cmd_jobs_get
@@ -221,14 +221,14 @@ class _FakeClient:
 
 
 def _patch_job_client(monkeypatch, factory) -> None:
-    monkeypatch.setattr(jobs_list_module, "_client", factory)
-    monkeypatch.setattr(jobs_get_module, "_client", factory)
-    monkeypatch.setattr(jobs_attach_module, "_client", factory)
-    monkeypatch.setattr(jobs_logs, "_client", factory)
-    monkeypatch.setattr(jobs_manifest_module, "_client", factory)
-    monkeypatch.setattr(jobs_metrics_module, "_client", factory)
-    monkeypatch.setattr(jobs_workers_module, "_client", factory)
-    monkeypatch.setattr(jobs_control_module, "_client", factory)
+    monkeypatch.setattr(jobs_list_module, "create_client", factory)
+    monkeypatch.setattr(jobs_get_module, "create_client", factory)
+    monkeypatch.setattr(jobs_attach_module, "create_client", factory)
+    monkeypatch.setattr(jobs_logs, "create_client", factory)
+    monkeypatch.setattr(jobs_manifest_module, "create_client", factory)
+    monkeypatch.setattr(jobs_metrics_module, "create_client", factory)
+    monkeypatch.setattr(jobs_workers_module, "create_client", factory)
+    monkeypatch.setattr(jobs_control_module, "create_client", factory)
 
 
 def test_jobs_list_plain_output(monkeypatch, capsys) -> None:
@@ -2954,7 +2954,7 @@ def test_jobs_error_reports_to_stderr(monkeypatch, capsys) -> None:
 
 
 def test_print_table_handles_ragged_rows(capsys) -> None:
-    jobs_common._print_table([["A", "B", "C"], ["1", "2"], ["3"]])
+    print_table([["A", "B", "C"], ["1", "2"], ["3"]])
     out = capsys.readouterr()
 
     assert "A  B  C" in out.out
@@ -2962,7 +2962,7 @@ def test_print_table_handles_ragged_rows(capsys) -> None:
 
 
 def test_print_table_handles_ansi_colored_cells(capsys) -> None:
-    jobs_common._print_table(
+    print_table(
         [
             ["\x1b[38;5;245mIdx\x1b[0m", "\x1b[38;5;245mStatus\x1b[0m", "Name"],
             ["0", "\x1b[1;38;5;77mcompleted\x1b[0m", "stage_0"],

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -49,6 +49,15 @@ def test_parser_has_jobs_commands() -> None:
     assert args.me is True
 
 
+def test_parser_has_secrets_commands() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["secrets", "set", "HF_TOKEN", "--env", "production"])
+    assert args.command == "secrets"
+    assert args.secrets_command == "set"
+    assert args.name == "HF_TOKEN"
+    assert args.env == "production"
+
+
 def test_parser_has_jobs_logs_follow_flag() -> None:
     parser = build_parser()
     args = parser.parse_args(["jobs", "logs", "job-1", "--follow"])

--- a/tests/cli/test_secrets_commands.py
+++ b/tests/cli/test_secrets_commands.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from refiner.cli import secrets
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.set_calls: list[dict[str, str]] = []
+        self.delete_calls: list[dict[str, str]] = []
+
+    def cli_list_secrets(self, *, env: str | None = None) -> dict[str, object]:
+        return {
+            "secrets": [
+                {
+                    "env": env or "default",
+                    "name": "HF_TOKEN",
+                    "updatedAt": "2026-05-11T10:00:00.000Z",
+                }
+            ]
+        }
+
+    def cli_set_secret(self, *, name: str, env: str, value: str) -> dict[str, object]:
+        self.set_calls.append({"name": name, "env": env, "value": value})
+        return {"secret": {"env": env, "name": name}}
+
+    def cli_delete_secret(self, *, name: str, env: str) -> dict[str, object]:
+        self.delete_calls.append({"name": name, "env": env})
+        return {"success": True}
+
+
+def test_secrets_list_prints_names(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(secrets, "create_client", lambda: _FakeClient())
+
+    rc = secrets.cmd_secrets_list(Namespace(env="production", json=False))
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "production" in out.out
+    assert "HF_TOKEN" in out.out
+
+
+def test_secrets_set_reads_value_from_stdin(monkeypatch, capsys) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(secrets, "create_client", lambda: client)
+    monkeypatch.setattr(secrets.sys.stdin, "read", lambda _size=-1: "hf_secret\r\n")
+
+    rc = secrets.cmd_secrets_set(
+        Namespace(name="HF_TOKEN", env="production", value_stdin=True, json=False)
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert client.set_calls == [
+        {"name": "HF_TOKEN", "env": "production", "value": "hf_secret"}
+    ]
+    assert "hf_secret" not in out.out
+    assert "production/HF_TOKEN" in out.out
+
+
+def test_secrets_set_allows_max_size_value_with_trailing_newline(
+    monkeypatch, capsys
+) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(secrets, "create_client", lambda: client)
+    monkeypatch.setattr(
+        secrets.sys.stdin,
+        "read",
+        lambda _size=-1: ("x" * secrets.SECRET_VALUE_MAX_CHARS) + "\n",
+    )
+
+    rc = secrets.cmd_secrets_set(
+        Namespace(name="HF_TOKEN", env="production", value_stdin=True, json=False)
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert client.set_calls == [
+        {
+            "name": "HF_TOKEN",
+            "env": "production",
+            "value": "x" * secrets.SECRET_VALUE_MAX_CHARS,
+        }
+    ]
+    assert "too large" not in out.err
+
+
+def test_secrets_set_rejects_large_stdin(monkeypatch, capsys) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(secrets, "create_client", lambda: client)
+    monkeypatch.setattr(
+        secrets.sys.stdin,
+        "read",
+        lambda _size=-1: "x" * (secrets.SECRET_VALUE_MAX_CHARS + 1),
+    )
+
+    rc = secrets.cmd_secrets_set(
+        Namespace(name="HF_TOKEN", env="production", value_stdin=True, json=False)
+    )
+    out = capsys.readouterr()
+
+    assert rc == 1
+    assert client.set_calls == []
+    assert "too large" in out.err
+
+
+def test_secrets_remove_calls_delete(monkeypatch, capsys) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(secrets, "create_client", lambda: client)
+
+    rc = secrets.cmd_secrets_remove(
+        Namespace(name="HF_TOKEN", env="production", json=False)
+    )
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert client.delete_calls == [{"name": "HF_TOKEN", "env": "production"}]
+    assert "production/HF_TOKEN" in out.out

--- a/tests/platform/test_client.py
+++ b/tests/platform/test_client.py
@@ -141,3 +141,19 @@ def test_cli_get_job_logs_omits_unset_bounds(monkeypatch) -> None:
     )
 
     assert captured["path"] == "/api/cli/jobs/job-1/logs?anchor=latest"
+
+
+def test_cli_delete_secret_encodes_name_and_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request_json(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr("refiner.platform.client.api.request_json", fake_request_json)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    client.cli_delete_secret(name="HF/TOKEN", env="production")
+
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/api/cli/secrets/HF%2FTOKEN?env=production"


### PR DESCRIPTION
## Summary
- add macrodata secrets list/set/remove commands
- read secret values from stdin or an interactive prompt without echoing values
- add client methods, docs, and CLI/client tests for the new commands

## Validation
- uv run ruff check --force-exclude src/refiner/cli/main.py src/refiner/cli/secrets.py src/refiner/cli/commands/secrets.py src/refiner/platform/client/api.py tests/cli/test_main.py tests/cli/test_secrets_commands.py tests/platform/test_client.py
- uv run ty check src/refiner/platform/client/api.py src/refiner/cli/main.py src/refiner/cli/secrets.py src/refiner/cli/commands/secrets.py tests/cli/test_secrets_commands.py tests/cli/test_main.py tests/platform/test_client.py
- uv run pytest tests/cli/test_secrets_commands.py tests/cli/test_main.py tests/platform/test_client.py