### PR TITLE
[codex] add structured cloud gpu config

### DIFF
--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -21,7 +21,7 @@ pipeline = (
 stats = pipeline.launch_local(
     name="local-job",
     num_workers=2,
-    gpus_per_worker=1,
+    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.4"),
 )
 ```
 
@@ -38,7 +38,7 @@ Returned stats include:
 
 - workers always run as subprocesses, even when `num_workers=1`
 - local launch does not pin worker CPUs; if `num_workers` exceeds available CPUs, Refiner logs a warning and still launches the requested worker count
-- `gpus_per_worker` optionally exposes a fixed number of visible GPU devices to each local worker
+- `gpu` optionally exposes a fixed number of visible GPU devices to each local worker; local launch ignores `cuda_version`
 - `REFINER_LOGS` controls the live local console stream when set:
   - `all`: stream every worker log line
   - `none`: suppress live worker log output

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -70,8 +70,7 @@ result = pipeline.launch_cloud(
     num_workers=8,
     cpus_per_worker=2,
     mem_mb_per_worker=4096,
-    gpus_per_worker=1,
-    gpu_type="h100",
+    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.4"),
 )
 ```
 
@@ -86,6 +85,7 @@ Returned result includes:
 - `num_workers`: requested logical worker count
 - `cpus_per_worker`: scheduler hint for worker CPU sizing
 - `mem_mb_per_worker`: scheduler hint for worker memory sizing
+- `gpu`: structured scheduler hint for GPU count, GPU type, and CUDA version
 - `gpus_per_worker`: scheduler hint for GPU count per worker
 - `gpu_type`: required when `gpus_per_worker` is set
 - `sync_local_dependencies`: whether to install the submitting environment's dependencies into the cloud image
@@ -96,6 +96,11 @@ Returned result includes:
 - `unsafe_continue`: allow continue when the reused stage boundary no longer matches the current pipeline
 
 `secrets` and `env` are both mounted into the cloud runtime, but only `secrets` participate in captured-code redaction.
+
+`gpu` cannot be combined with `gpus_per_worker` or `gpu_type`. Current SDK literals are:
+
+- GPU type: `"h100"`
+- CUDA versions: `"12.4"`, `"12.6"`, `"12.8"`
 
 ### Continuing cloud work
 

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -86,8 +86,6 @@ Returned result includes:
 - `cpus_per_worker`: scheduler hint for worker CPU sizing
 - `mem_mb_per_worker`: scheduler hint for worker memory sizing
 - `gpu`: structured scheduler hint for GPU count, GPU type, and CUDA version
-- `gpus_per_worker`: scheduler hint for GPU count per worker
-- `gpu_type`: required when `gpus_per_worker` is set
 - `sync_local_dependencies`: whether to install the submitting environment's dependencies into the cloud image
 - `secrets`: env vars sent as secrets
 - `env`: env vars sent as plain runtime environment values
@@ -97,7 +95,7 @@ Returned result includes:
 
 `secrets` and `env` are both mounted into the cloud runtime, but only `secrets` participate in captured-code redaction.
 
-`gpu` cannot be combined with `gpus_per_worker` or `gpu_type`. Current SDK literals are:
+Current SDK GPU literals are:
 
 - GPU type: `"h100"`
 - CUDA versions: `"12.4"`, `"12.6"`, `"12.8"`

--- a/examples/gpu/verify_visible_gpus.py
+++ b/examples/gpu/verify_visible_gpus.py
@@ -56,10 +56,10 @@ def main() -> None:
     parser.add_argument("--name", default="gpu-probe")
     parser.add_argument("--num-workers", type=int, default=1)
     parser.add_argument("--num-tasks", type=int, default=1)
-    parser.add_argument("--gpus-per-worker", type=int, default=1)
+    parser.add_argument("--gpu-count", type=int, default=1)
     parser.add_argument("--cpus-per-worker", type=int, default=None)
     parser.add_argument("--mem-mb-per-worker", type=int, default=None)
-    parser.add_argument("--gpu-type", choices=mdr.SUPPORTED_GPU_TYPES, default=None)
+    parser.add_argument("--gpu-type", choices=mdr.SUPPORTED_GPU_TYPES, default="h100")
     parser.add_argument(
         "--cuda-version",
         choices=mdr.SUPPORTED_CUDA_VERSIONS,
@@ -73,14 +73,15 @@ def main() -> None:
         stats = pipeline.launch_local(
             name=args.name,
             num_workers=args.num_workers,
-            gpus_per_worker=args.gpus_per_worker,
+            gpu=mdr.GPU(
+                count=args.gpu_count,
+                type=args.gpu_type,
+                cuda_version=args.cuda_version,
+            ),
         )
         print(f"local launch complete: {stats}")
         print("worker probe results were logged by each worker process")
         return
-
-    if not args.gpu_type:
-        raise SystemExit("--gpu-type is required when --launcher=cloud")
 
     result = pipeline.launch_cloud(
         name=args.name,
@@ -88,7 +89,7 @@ def main() -> None:
         cpus_per_worker=args.cpus_per_worker,
         mem_mb_per_worker=args.mem_mb_per_worker,
         gpu=mdr.GPU(
-            count=args.gpus_per_worker,
+            count=args.gpu_count,
             type=args.gpu_type,
             cuda_version=args.cuda_version,
         ),

--- a/examples/gpu/verify_visible_gpus.py
+++ b/examples/gpu/verify_visible_gpus.py
@@ -59,7 +59,12 @@ def main() -> None:
     parser.add_argument("--gpus-per-worker", type=int, default=1)
     parser.add_argument("--cpus-per-worker", type=int, default=None)
     parser.add_argument("--mem-mb-per-worker", type=int, default=None)
-    parser.add_argument("--gpu-type", default=None)
+    parser.add_argument("--gpu-type", choices=mdr.SUPPORTED_GPU_TYPES, default=None)
+    parser.add_argument(
+        "--cuda-version",
+        choices=mdr.SUPPORTED_CUDA_VERSIONS,
+        default=None,
+    )
     args = parser.parse_args()
 
     pipeline = mdr.task(_probe_worker, num_tasks=args.num_tasks)
@@ -82,8 +87,11 @@ def main() -> None:
         num_workers=args.num_workers,
         cpus_per_worker=args.cpus_per_worker,
         mem_mb_per_worker=args.mem_mb_per_worker,
-        gpus_per_worker=args.gpus_per_worker,
-        gpu_type=args.gpu_type,
+        gpu=mdr.GPU(
+            count=args.gpus_per_worker,
+            type=args.gpu_type,
+            cuda_version=args.cuda_version,
+        ),
     )
     print(f"cloud launch submitted: {result}")
     print("worker probe results will be emitted in worker logs")

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -6,6 +6,9 @@ import refiner.text as text
 import refiner.video as video
 from refiner.pipeline.data import datatype
 from refiner.pipeline import (
+    CUDAVersion,
+    GPU,
+    GPUType,
     from_items,
     from_source,
     read_csv,
@@ -13,6 +16,8 @@ from refiner.pipeline import (
     read_jsonl,
     read_lerobot,
     read_parquet,
+    SUPPORTED_CUDA_VERSIONS,
+    SUPPORTED_GPU_TYPES,
     task,
 )
 from refiner.pipeline.expressions import coalesce, col, if_else, lit
@@ -29,6 +34,11 @@ robot = robotics
 
 __all__ = [
     # sources
+    "CUDAVersion",
+    "GPU",
+    "GPUType",
+    "SUPPORTED_CUDA_VERSIONS",
+    "SUPPORTED_GPU_TYPES",
     "read_csv",
     "read_hf_dataset",
     "read_jsonl",

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -105,6 +105,11 @@ class BaseLauncher(ABC):
                 if compute.gpu_type is not None
                 else getattr(self, "gpu_type", None)
             ),
+            cuda_version=(
+                compute.cuda_version
+                if compute.cuda_version is not None
+                else getattr(self, "cuda_version", None)
+            ),
         )
 
     def _run_manifest(

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -13,6 +13,7 @@ from refiner.pipeline.planning import (
     compile_planned_stages,
     plan_pipeline_stages,
 )
+from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import build_run_manifest
 
 if TYPE_CHECKING:
@@ -27,7 +28,7 @@ class BaseLauncher(ABC):
         name: str,
         num_workers: int = 1,
         cpus_per_worker: int | None = None,
-        gpus_per_worker: int | None = None,
+        gpu: GPU | None = None,
     ):
         if not name.strip():
             raise ValueError("name must be non-empty")
@@ -39,9 +40,7 @@ class BaseLauncher(ABC):
         if cpus_per_worker is not None and cpus_per_worker <= 0:
             raise ValueError("cpus_per_worker must be > 0")
         self.cpus_per_worker = cpus_per_worker
-        if gpus_per_worker is not None and gpus_per_worker <= 0:
-            raise ValueError("gpus_per_worker must be > 0")
-        self.gpus_per_worker = gpus_per_worker
+        self.gpu = gpu
 
     @staticmethod
     def _build_local_job_id(name: str) -> str:
@@ -95,21 +94,7 @@ class BaseLauncher(ABC):
                 if compute.memory_mb_per_worker is not None
                 else getattr(self, "mem_mb_per_worker", None)
             ),
-            gpus_per_worker=(
-                compute.gpus_per_worker
-                if compute.gpus_per_worker is not None
-                else getattr(self, "gpus_per_worker", None)
-            ),
-            gpu_type=(
-                compute.gpu_type
-                if compute.gpu_type is not None
-                else getattr(self, "gpu_type", None)
-            ),
-            cuda_version=(
-                compute.cuda_version
-                if compute.cuda_version is not None
-                else getattr(self, "cuda_version", None)
-            ),
+            gpu=compute.gpu if compute.gpu is not None else getattr(self, "gpu", None),
         )
 
     def _run_manifest(

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -23,13 +23,14 @@ from refiner.platform.client import (
     serialize_pipeline_inline,
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
-from refiner.pipeline.resources import CUDAVersion, GPU, GPUType, SUPPORTED_GPU_TYPES
+from refiner.pipeline.resources import GPU
 
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
+    from refiner.pipeline.planning import PlannedStage
 
 
 _FALLBACK_ENV_VAR = "MACRODATA_FALLBACK_TO_LATEST_PYPI"
@@ -89,8 +90,7 @@ class CloudLauncher(BaseLauncher):
         num_workers: Requested logical worker count for cloud execution.
         cpus_per_worker: Optional requested CPU cores per worker.
         mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
-        gpus_per_worker: Optional requested GPU count per worker for cloud scheduling.
-        gpu_type: Optional requested GPU type per worker for cloud scheduling.
+        gpu: Optional GPU runtime request for cloud scheduling.
         sync_local_dependencies: Whether to sync submitting environment dependencies.
         secrets: Optional secrets mounted into the cloud runtime.
         env: Optional plain environment variables mounted into the cloud runtime.
@@ -104,8 +104,6 @@ class CloudLauncher(BaseLauncher):
         num_workers: int = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
-        gpus_per_worker: int | None = None,
-        gpu_type: GPUType | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
         secrets: dict[str, object | None] | None = None,
@@ -118,37 +116,17 @@ class CloudLauncher(BaseLauncher):
             name=name,
             num_workers=num_workers,
             cpus_per_worker=cpus_per_worker,
-            gpus_per_worker=gpus_per_worker,
+            gpus_per_worker=gpu.count if gpu is not None else None,
         )
         normalized_continue_from_job = _parse_continue_from_job(continue_from_job)
         if unsafe_continue and normalized_continue_from_job is None:
             raise ValueError("unsafe_continue requires continue_from_job")
         if mem_mb_per_worker is not None and mem_mb_per_worker <= 0:
             raise ValueError("mem_mb_per_worker must be > 0")
-        if gpu is not None and (gpus_per_worker is not None or gpu_type is not None):
-            raise ValueError("gpu cannot be combined with gpus_per_worker or gpu_type")
-        if gpu is not None:
-            gpus_per_worker = gpu.count
-            gpu_type = gpu.type
-            cuda_version: CUDAVersion | None = gpu.cuda_version
-        else:
-            cuda_version = None
-        if gpus_per_worker is not None and gpus_per_worker <= 0:
-            raise ValueError("gpus_per_worker must be > 0")
-        if gpus_per_worker is not None and gpu_type is None:
-            raise ValueError("gpu_type is required when gpus_per_worker is set")
-        if gpu_type is not None and not gpu_type.strip():
-            raise ValueError("gpu_type must be non-empty")
-        if gpu_type is not None and gpu_type not in SUPPORTED_GPU_TYPES:
-            supported = ", ".join(SUPPORTED_GPU_TYPES)
-            raise ValueError(f"gpu_type must be one of: {supported}")
-        if gpu_type is not None and gpus_per_worker is None:
-            raise ValueError("gpus_per_worker is required when gpu_type is set")
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
-        self.gpus_per_worker = gpus_per_worker
-        self.gpu_type = gpu_type
-        self.cuda_version = cuda_version
+        self.gpu_type = gpu.type if gpu is not None else None
+        self.cuda_version = gpu.cuda_version if gpu is not None else None
         self.sync_local_dependencies = sync_local_dependencies
         self.secrets = secrets
         self.env = env
@@ -228,6 +206,50 @@ class CloudLauncher(BaseLauncher):
             f"Set {_FALLBACK_ENV_VAR}=1 to allow fallback to the latest PyPI version."
         )
 
+    @staticmethod
+    def _cloud_plan_with_structured_gpu(plan: dict[str, object]) -> dict[str, object]:
+        stages = plan.get("stages")
+        if not isinstance(stages, list):
+            return plan
+        resolved_stages: list[object] = []
+        changed = False
+        for stage in stages:
+            if not isinstance(stage, dict):
+                resolved_stages.append(stage)
+                continue
+            stage_dict = cast(dict[str, object], stage)
+            gpu_count = stage_dict.get("gpus_per_worker")
+            gpu_type = stage_dict.get("gpu_type")
+            if not isinstance(gpu_count, int) or not isinstance(gpu_type, str):
+                resolved_stages.append(stage)
+                continue
+            resolved_stage = dict(stage_dict)
+            resolved_stage.pop("gpus_per_worker", None)
+            resolved_stage.pop("gpu_type", None)
+            cuda_version = resolved_stage.pop("cuda_version", None)
+            gpu_payload: dict[str, object] = {
+                "count": gpu_count,
+                "type": gpu_type,
+            }
+            if isinstance(cuda_version, str):
+                gpu_payload["cuda_version"] = cuda_version
+            resolved_stage["gpu"] = gpu_payload
+            resolved_stages.append(resolved_stage)
+            changed = True
+        if not changed:
+            return plan
+        return {**plan, "stages": resolved_stages}
+
+    @staticmethod
+    def _stage_gpu(stage: PlannedStage) -> GPU | None:
+        if stage.compute.gpus_per_worker is None or stage.compute.gpu_type is None:
+            return None
+        return GPU(
+            count=stage.compute.gpus_per_worker,
+            type=stage.compute.gpu_type,
+            cuda_version=stage.compute.cuda_version,
+        )
+
     def launch(self) -> CloudLaunchResult:
         try:
             client = MacrodataClient()
@@ -241,9 +263,12 @@ class CloudLauncher(BaseLauncher):
         secret_values = tuple(resolved_secrets.values()) if resolved_secrets else ()
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
+        plan = self._cloud_plan_with_structured_gpu(
+            self._compiled_plan(stages, secret_values=secret_values)
+        )
         request = CloudRunCreateRequest(
             name=self.name,
-            plan=self._compiled_plan(stages, secret_values=secret_values),
+            plan=plan,
             stage_payloads=[
                 StagePayload(
                     stage_index=stage.index,
@@ -252,9 +277,7 @@ class CloudLauncher(BaseLauncher):
                         num_workers=stage.compute.num_workers,
                         cpus_per_worker=stage.compute.cpus_per_worker,
                         mem_mb_per_worker=stage.compute.memory_mb_per_worker,
-                        gpus_per_worker=stage.compute.gpus_per_worker,
-                        gpu_type=stage.compute.gpu_type,
-                        cuda_version=stage.compute.cuda_version,
+                        gpu=self._stage_gpu(stage),
                     ),
                 )
                 for stage in stages

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -116,7 +116,7 @@ class CloudLauncher(BaseLauncher):
             name=name,
             num_workers=num_workers,
             cpus_per_worker=cpus_per_worker,
-            gpus_per_worker=gpu.count if gpu is not None else None,
+            gpu=gpu,
         )
         normalized_continue_from_job = _parse_continue_from_job(continue_from_job)
         if unsafe_continue and normalized_continue_from_job is None:
@@ -125,8 +125,6 @@ class CloudLauncher(BaseLauncher):
             raise ValueError("mem_mb_per_worker must be > 0")
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
-        self.gpu_type = gpu.type if gpu is not None else None
-        self.cuda_version = gpu.cuda_version if gpu is not None else None
         self.sync_local_dependencies = sync_local_dependencies
         self.secrets = secrets
         self.env = env
@@ -207,48 +205,8 @@ class CloudLauncher(BaseLauncher):
         )
 
     @staticmethod
-    def _cloud_plan_with_structured_gpu(plan: dict[str, object]) -> dict[str, object]:
-        stages = plan.get("stages")
-        if not isinstance(stages, list):
-            return plan
-        resolved_stages: list[object] = []
-        changed = False
-        for stage in stages:
-            if not isinstance(stage, dict):
-                resolved_stages.append(stage)
-                continue
-            stage_dict = cast(dict[str, object], stage)
-            gpu_count = stage_dict.get("gpus_per_worker")
-            gpu_type = stage_dict.get("gpu_type")
-            if not isinstance(gpu_count, int) or not isinstance(gpu_type, str):
-                resolved_stages.append(stage)
-                continue
-            resolved_stage = dict(stage_dict)
-            resolved_stage.pop("gpus_per_worker", None)
-            resolved_stage.pop("gpu_type", None)
-            cuda_version = resolved_stage.pop("cuda_version", None)
-            gpu_payload: dict[str, object] = {
-                "count": gpu_count,
-                "type": gpu_type,
-            }
-            if isinstance(cuda_version, str):
-                gpu_payload["cuda_version"] = cuda_version
-            resolved_stage["gpu"] = gpu_payload
-            resolved_stages.append(resolved_stage)
-            changed = True
-        if not changed:
-            return plan
-        return {**plan, "stages": resolved_stages}
-
-    @staticmethod
     def _stage_gpu(stage: PlannedStage) -> GPU | None:
-        if stage.compute.gpus_per_worker is None or stage.compute.gpu_type is None:
-            return None
-        return GPU(
-            count=stage.compute.gpus_per_worker,
-            type=stage.compute.gpu_type,
-            cuda_version=stage.compute.cuda_version,
-        )
+        return stage.compute.gpu
 
     def launch(self) -> CloudLaunchResult:
         try:
@@ -263,9 +221,7 @@ class CloudLauncher(BaseLauncher):
         secret_values = tuple(resolved_secrets.values()) if resolved_secrets else ()
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
-        plan = self._cloud_plan_with_structured_gpu(
-            self._compiled_plan(stages, secret_values=secret_values)
-        )
+        plan = self._compiled_plan(stages, secret_values=secret_values)
         request = CloudRunCreateRequest(
             name=self.name,
             plan=plan,

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -30,7 +30,6 @@ from refiner.launchers.base import BaseLauncher
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
-    from refiner.pipeline.planning import PlannedStage
 
 
 _FALLBACK_ENV_VAR = "MACRODATA_FALLBACK_TO_LATEST_PYPI"
@@ -204,10 +203,6 @@ class CloudLauncher(BaseLauncher):
             f"Set {_FALLBACK_ENV_VAR}=1 to allow fallback to the latest PyPI version."
         )
 
-    @staticmethod
-    def _stage_gpu(stage: PlannedStage) -> GPU | None:
-        return stage.compute.gpu
-
     def launch(self) -> CloudLaunchResult:
         try:
             client = MacrodataClient()
@@ -233,7 +228,7 @@ class CloudLauncher(BaseLauncher):
                         num_workers=stage.compute.num_workers,
                         cpus_per_worker=stage.compute.cpus_per_worker,
                         mem_mb_per_worker=stage.compute.memory_mb_per_worker,
-                        gpu=self._stage_gpu(stage),
+                        gpu=stage.compute.gpu,
                     ),
                 )
                 for stage in stages

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -23,6 +23,7 @@ from refiner.platform.client import (
     serialize_pipeline_inline,
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
+from refiner.pipeline.resources import CUDAVersion, GPU, GPUType, SUPPORTED_GPU_TYPES
 
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
@@ -104,7 +105,8 @@ class CloudLauncher(BaseLauncher):
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpus_per_worker: int | None = None,
-        gpu_type: str | None = None,
+        gpu_type: GPUType | None = None,
+        gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
         secrets: dict[str, object | None] | None = None,
         env: dict[str, object | None] | None = None,
@@ -123,18 +125,30 @@ class CloudLauncher(BaseLauncher):
             raise ValueError("unsafe_continue requires continue_from_job")
         if mem_mb_per_worker is not None and mem_mb_per_worker <= 0:
             raise ValueError("mem_mb_per_worker must be > 0")
+        if gpu is not None and (gpus_per_worker is not None or gpu_type is not None):
+            raise ValueError("gpu cannot be combined with gpus_per_worker or gpu_type")
+        if gpu is not None:
+            gpus_per_worker = gpu.count
+            gpu_type = gpu.type
+            cuda_version: CUDAVersion | None = gpu.cuda_version
+        else:
+            cuda_version = None
         if gpus_per_worker is not None and gpus_per_worker <= 0:
             raise ValueError("gpus_per_worker must be > 0")
         if gpus_per_worker is not None and gpu_type is None:
             raise ValueError("gpu_type is required when gpus_per_worker is set")
         if gpu_type is not None and not gpu_type.strip():
             raise ValueError("gpu_type must be non-empty")
+        if gpu_type is not None and gpu_type not in SUPPORTED_GPU_TYPES:
+            supported = ", ".join(SUPPORTED_GPU_TYPES)
+            raise ValueError(f"gpu_type must be one of: {supported}")
         if gpu_type is not None and gpus_per_worker is None:
             raise ValueError("gpus_per_worker is required when gpu_type is set")
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
         self.gpus_per_worker = gpus_per_worker
-        self.gpu_type = gpu_type.strip() if gpu_type is not None else None
+        self.gpu_type = gpu_type
+        self.cuda_version = cuda_version
         self.sync_local_dependencies = sync_local_dependencies
         self.secrets = secrets
         self.env = env
@@ -240,6 +254,7 @@ class CloudLauncher(BaseLauncher):
                         mem_mb_per_worker=stage.compute.memory_mb_per_worker,
                         gpus_per_worker=stage.compute.gpus_per_worker,
                         gpu_type=stage.compute.gpu_type,
+                        cuda_version=stage.compute.cuda_version,
                     ),
                 )
                 for stage in stages

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -22,6 +22,7 @@ from refiner.cli.ui.terminal import stdout_is_interactive
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
 from refiner.pipeline.planning import PlannedStage
+from refiner.pipeline.resources import GPU
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
 from refiner.platform.client.api import MacrodataClient, request_json
 from refiner.worker.context import logger
@@ -48,13 +49,13 @@ class LocalLauncher(BaseLauncher):
         name: str,
         num_workers: int = 1,
         rundir: str | None = None,
-        gpus_per_worker: int | None = None,
+        gpu: GPU | None = None,
     ):
         super().__init__(
             pipeline=pipeline,
             name=name,
             num_workers=num_workers,
-            gpus_per_worker=gpus_per_worker,
+            gpus_per_worker=gpu.count if gpu is not None else None,
         )
         self.job_id: str | None = None
         self.rundir: str | None = (

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -55,7 +55,7 @@ class LocalLauncher(BaseLauncher):
             pipeline=pipeline,
             name=name,
             num_workers=num_workers,
-            gpus_per_worker=gpu.count if gpu is not None else None,
+            gpu=gpu,
         )
         self.job_id: str | None = None
         self.rundir: str | None = (
@@ -287,9 +287,9 @@ class LocalLauncher(BaseLauncher):
         gpu_sets = (
             build_gpu_sets(
                 num_workers=stage_workers,
-                gpus_per_worker=stage.compute.gpus_per_worker,
+                gpu_count_per_worker=stage.compute.gpu.count,
             )
-            if stage.compute.gpus_per_worker is not None
+            if stage.compute.gpu is not None
             else [[] for _ in range(stage_workers)]
         )
         completed_shard_ids = {

--- a/src/refiner/pipeline/__init__.py
+++ b/src/refiner/pipeline/__init__.py
@@ -11,11 +11,23 @@ from refiner.pipeline.pipeline import (
     read_parquet,
     task,
 )
+from refiner.pipeline.resources import (
+    CUDAVersion,
+    GPU,
+    GPUType,
+    SUPPORTED_CUDA_VERSIONS,
+    SUPPORTED_GPU_TYPES,
+)
 
 __all__ = [
+    "CUDAVersion",
+    "GPU",
+    "GPUType",
     "RefinerPipeline",
     "Row",
     "Shard",
+    "SUPPORTED_CUDA_VERSIONS",
+    "SUPPORTED_GPU_TYPES",
     "read_csv",
     "read_hf_dataset",
     "read_jsonl",

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -6,7 +6,7 @@ from fsspec import AbstractFileSystem
 from refiner.io.datafolder import DataFolderLike
 from refiner.pipeline.expressions import Expr, lit
 from refiner.io.fileset import DataFileSetLike
-from refiner.pipeline.resources import GPU, GPUType
+from refiner.pipeline.resources import GPU
 from refiner.pipeline.steps import (
     AsyncMapFn,
     BatchFn,
@@ -405,8 +405,6 @@ class RefinerPipeline:
         num_workers: int = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
-        gpus_per_worker: int | None = None,
-        gpu_type: GPUType | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
         secrets: Mapping[str, object | None] | None = None,
@@ -421,10 +419,7 @@ class RefinerPipeline:
             num_workers: Requested logical worker count.
             cpus_per_worker: Optional requested CPU cores per worker.
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
-            gpus_per_worker: Optional requested GPU count per worker for cloud scheduling.
-            gpu_type: Optional requested GPU type per worker for cloud scheduling.
-            gpu: Optional structured GPU request. Cannot be combined with
-                `gpus_per_worker` or `gpu_type`.
+            gpu: Optional structured GPU request.
             sync_local_dependencies: Sync submitting environment dependencies in cloud image.
             secrets: Extra environment variables to mount inside the cloud image.
                 `None` values are loaded from the submitting environment.
@@ -444,8 +439,6 @@ class RefinerPipeline:
             num_workers=num_workers,
             cpus_per_worker=cpus_per_worker,
             mem_mb_per_worker=mem_mb_per_worker,
-            gpus_per_worker=gpus_per_worker,
-            gpu_type=gpu_type,
             gpu=gpu,
             sync_local_dependencies=sync_local_dependencies,
             secrets=dict(secrets) if secrets is not None else None,

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -6,6 +6,7 @@ from fsspec import AbstractFileSystem
 from refiner.io.datafolder import DataFolderLike
 from refiner.pipeline.expressions import Expr, lit
 from refiner.io.fileset import DataFileSetLike
+from refiner.pipeline.resources import GPU, GPUType
 from refiner.pipeline.steps import (
     AsyncMapFn,
     BatchFn,
@@ -405,7 +406,8 @@ class RefinerPipeline:
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpus_per_worker: int | None = None,
-        gpu_type: str | None = None,
+        gpu_type: GPUType | None = None,
+        gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
         secrets: Mapping[str, object | None] | None = None,
         env: Mapping[str, object | None] | None = None,
@@ -421,6 +423,8 @@ class RefinerPipeline:
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
             gpus_per_worker: Optional requested GPU count per worker for cloud scheduling.
             gpu_type: Optional requested GPU type per worker for cloud scheduling.
+            gpu: Optional structured GPU request. Cannot be combined with
+                `gpus_per_worker` or `gpu_type`.
             sync_local_dependencies: Sync submitting environment dependencies in cloud image.
             secrets: Extra environment variables to mount inside the cloud image.
                 `None` values are loaded from the submitting environment.
@@ -442,6 +446,7 @@ class RefinerPipeline:
             mem_mb_per_worker=mem_mb_per_worker,
             gpus_per_worker=gpus_per_worker,
             gpu_type=gpu_type,
+            gpu=gpu,
             sync_local_dependencies=sync_local_dependencies,
             secrets=dict(secrets) if secrets is not None else None,
             env=dict(env) if env is not None else None,

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -377,7 +377,7 @@ class RefinerPipeline:
         name: str,
         num_workers: int = 1,
         rundir: str | None = None,
-        gpus_per_worker: int | None = None,
+        gpu: GPU | None = None,
     ) -> "LaunchStats":
         """Launch the pipeline locally.
 
@@ -385,7 +385,8 @@ class RefinerPipeline:
             name: Human-readable run name.
             num_workers: Number of local worker processes.
             rundir: Optional explicit local run directory. Reuse it to resume a prior local run.
-            gpus_per_worker: Optional GPU devices exposed per worker.
+            gpu: Optional GPU devices exposed per worker. `cuda_version` is accepted
+                for API consistency but ignored by local launch.
         """
         from refiner.launchers.local import LocalLauncher
 
@@ -394,7 +395,7 @@ class RefinerPipeline:
             name=name,
             num_workers=num_workers,
             rundir=rundir,
-            gpus_per_worker=gpus_per_worker,
+            gpu=gpu,
         )
         return launcher.launch()
 

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -23,7 +23,7 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.pipeline.data.datatype import dtype_to_plan
-from refiner.pipeline.resources import CUDAVersion, GPUType
+from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import _redact_captured_text
 from refiner.services import RuntimeServiceSpec
 
@@ -39,9 +39,7 @@ class StageComputeRequirements:
     num_workers: int
     cpus_per_worker: int | None = None
     memory_mb_per_worker: int | None = None
-    gpus_per_worker: int | None = None
-    gpu_type: GPUType | None = None
-    cuda_version: CUDAVersion | None = None
+    gpu: GPU | None = None
     inherit_launcher_resources: bool = True
 
     def to_stage_plan_dict(self) -> dict[str, Any]:
@@ -50,12 +48,8 @@ class StageComputeRequirements:
             payload["cpus_per_worker"] = self.cpus_per_worker
         if self.memory_mb_per_worker is not None:
             payload["memory_mb_per_worker"] = self.memory_mb_per_worker
-        if self.gpus_per_worker is not None:
-            payload["gpus_per_worker"] = self.gpus_per_worker
-        if self.gpu_type is not None:
-            payload["gpu_type"] = self.gpu_type
-        if self.cuda_version is not None:
-            payload["cuda_version"] = self.cuda_version
+        if self.gpu is not None:
+            payload["gpu"] = self.gpu.to_dict()
         return payload
 
 

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -23,6 +23,7 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.pipeline.data.datatype import dtype_to_plan
+from refiner.pipeline.resources import CUDAVersion, GPUType
 from refiner.platform.manifest import _redact_captured_text
 from refiner.services import RuntimeServiceSpec
 
@@ -39,7 +40,8 @@ class StageComputeRequirements:
     cpus_per_worker: int | None = None
     memory_mb_per_worker: int | None = None
     gpus_per_worker: int | None = None
-    gpu_type: str | None = None
+    gpu_type: GPUType | None = None
+    cuda_version: CUDAVersion | None = None
     inherit_launcher_resources: bool = True
 
     def to_stage_plan_dict(self) -> dict[str, Any]:
@@ -52,6 +54,8 @@ class StageComputeRequirements:
             payload["gpus_per_worker"] = self.gpus_per_worker
         if self.gpu_type is not None:
             payload["gpu_type"] = self.gpu_type
+        if self.cuda_version is not None:
+            payload["cuda_version"] = self.cuda_version
         return payload
 
 

--- a/src/refiner/pipeline/resources.py
+++ b/src/refiner/pipeline/resources.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, get_args
+from typing import Any, Literal, get_args
 
 GPUType = Literal["h100"]
 CUDAVersion = Literal["12.4", "12.6", "12.8"]
@@ -28,6 +28,15 @@ class GPU:
         ):
             supported = ", ".join(SUPPORTED_CUDA_VERSIONS)
             raise ValueError(f"gpu.cuda_version must be one of: {supported}")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "count": self.count,
+            "type": self.type,
+        }
+        if self.cuda_version is not None:
+            payload["cuda_version"] = self.cuda_version
+        return payload
 
 
 __all__ = [

--- a/src/refiner/pipeline/resources.py
+++ b/src/refiner/pipeline/resources.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, get_args
+
+GPUType = Literal["h100"]
+CUDAVersion = Literal["12.4", "12.6", "12.8"]
+
+SUPPORTED_GPU_TYPES: tuple[str, ...] = get_args(GPUType)
+SUPPORTED_CUDA_VERSIONS: tuple[str, ...] = get_args(CUDAVersion)
+
+
+@dataclass(frozen=True, slots=True)
+class GPU:
+    count: int
+    type: GPUType
+    cuda_version: CUDAVersion | None = None
+
+    def __post_init__(self) -> None:
+        if self.count <= 0:
+            raise ValueError("gpu.count must be > 0")
+        if self.type not in SUPPORTED_GPU_TYPES:
+            supported = ", ".join(SUPPORTED_GPU_TYPES)
+            raise ValueError(f"gpu.type must be one of: {supported}")
+        if (
+            self.cuda_version is not None
+            and self.cuda_version not in SUPPORTED_CUDA_VERSIONS
+        ):
+            supported = ", ".join(SUPPORTED_CUDA_VERSIONS)
+            raise ValueError(f"gpu.cuda_version must be one of: {supported}")
+
+
+__all__ = [
+    "CUDAVersion",
+    "GPU",
+    "GPUType",
+    "SUPPORTED_CUDA_VERSIONS",
+    "SUPPORTED_GPU_TYPES",
+]

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import msgspec
 
-from refiner.pipeline.resources import CUDAVersion, GPUType
+from refiner.pipeline.resources import GPU
 from refiner.pipeline.data.shard import Shard
 from refiner.worker.lifecycle import FinalizedShardWorker
 
@@ -123,9 +123,7 @@ class CloudRuntimeConfig:
     num_workers: int
     cpus_per_worker: int | None = None
     mem_mb_per_worker: int | None = None
-    gpus_per_worker: int | None = None
-    gpu_type: GPUType | None = None
-    cuda_version: CUDAVersion | None = None
+    gpu: GPU | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -135,12 +133,8 @@ class CloudRuntimeConfig:
             payload["cpus_per_worker"] = self.cpus_per_worker
         if self.mem_mb_per_worker is not None:
             payload["mem_mb_per_worker"] = self.mem_mb_per_worker
-        if self.gpus_per_worker is not None:
-            payload["gpus_per_worker"] = self.gpus_per_worker
-        if self.gpu_type is not None:
-            payload["gpu_type"] = self.gpu_type
-        if self.cuda_version is not None:
-            payload["cuda_version"] = self.cuda_version
+        if self.gpu is not None:
+            payload["gpu"] = self.gpu.to_dict()
         return payload
 
 

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import msgspec
 
+from refiner.pipeline.resources import CUDAVersion, GPUType
 from refiner.pipeline.data.shard import Shard
 from refiner.worker.lifecycle import FinalizedShardWorker
 
@@ -123,7 +124,8 @@ class CloudRuntimeConfig:
     cpus_per_worker: int | None = None
     mem_mb_per_worker: int | None = None
     gpus_per_worker: int | None = None
-    gpu_type: str | None = None
+    gpu_type: GPUType | None = None
+    cuda_version: CUDAVersion | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -137,6 +139,8 @@ class CloudRuntimeConfig:
             payload["gpus_per_worker"] = self.gpus_per_worker
         if self.gpu_type is not None:
             payload["gpu_type"] = self.gpu_type
+        if self.cuda_version is not None:
+            payload["cuda_version"] = self.cuda_version
         return payload
 
 

--- a/src/refiner/worker/resources/gpu.py
+++ b/src/refiner/worker/resources/gpu.py
@@ -51,19 +51,19 @@ def available_gpu_ids() -> list[str]:
     return gpu_ids
 
 
-def build_gpu_sets(*, num_workers: int, gpus_per_worker: int) -> list[list[str]]:
-    if gpus_per_worker <= 0:
-        raise ValueError("gpus_per_worker must be > 0")
+def build_gpu_sets(*, num_workers: int, gpu_count_per_worker: int) -> list[list[str]]:
+    if gpu_count_per_worker <= 0:
+        raise ValueError("gpu_count_per_worker must be > 0")
     gpu_ids = available_gpu_ids()
-    needed = num_workers * gpus_per_worker
+    needed = num_workers * gpu_count_per_worker
     if needed > len(gpu_ids):
         raise ValueError(
-            f"Requested {needed} GPUs ({num_workers} workers x {gpus_per_worker}) but only {len(gpu_ids)} are available"
+            f"Requested {needed} GPUs ({num_workers} workers x {gpu_count_per_worker}) but only {len(gpu_ids)} are available"
         )
     out: list[list[str]] = []
     for index in range(num_workers):
-        start = index * gpus_per_worker
-        out.append(gpu_ids[start : start + gpus_per_worker])
+        start = index * gpu_count_per_worker
+        out.append(gpu_ids[start : start + gpu_count_per_worker])
     return out
 
 

--- a/tests/launchers/test_base_launcher.py
+++ b/tests/launchers/test_base_launcher.py
@@ -10,6 +10,7 @@ from refiner.pipeline.planning import (
     PlannedStage,
     StageComputeRequirements,
 )
+from refiner.pipeline.resources import GPU
 
 
 class _DummyLauncher(BaseLauncher):
@@ -24,7 +25,7 @@ class _ResourceHintLauncher(_DummyLauncher):
         return StageComputeRequirements(
             num_workers=compute.num_workers,
             cpus_per_worker=1,
-            gpus_per_worker=2,
+            gpu=GPU(count=2, type="h100", cuda_version="12.4"),
         )
 
 
@@ -127,7 +128,7 @@ def test_compiled_plan_includes_stage_resource_hints(monkeypatch) -> None:
             "index": 0,
             "requested_num_workers": 2,
             "cpus_per_worker": 1,
-            "gpus_per_worker": 2,
+            "gpu": {"count": 2, "type": "h100", "cuda_version": "12.4"},
             "steps": [],
         },
         {
@@ -135,7 +136,7 @@ def test_compiled_plan_includes_stage_resource_hints(monkeypatch) -> None:
             "index": 1,
             "requested_num_workers": 1,
             "cpus_per_worker": 1,
-            "gpus_per_worker": 2,
+            "gpu": {"count": 2, "type": "h100", "cuda_version": "12.4"},
             "steps": [],
         },
     ]

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from collections.abc import Callable
-from typing import Any, cast
+from typing import cast
 
 from refiner.pipeline import read_jsonl
 from refiner.pipeline.resources import GPU
@@ -110,8 +110,6 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
         "type": "h100",
         "cuda_version": "12.8",
     }
-    assert "gpus_per_worker" not in request.plan["stages"][0]
-    assert "gpu_type" not in request.plan["stages"][0]
     assert "cuda_version" not in request.plan["stages"][0]
     assert len(request.stage_payloads) == 1
     assert request.stage_payloads[0].stage_index == 0
@@ -152,22 +150,6 @@ def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:
     }
     runtime = request.stage_payloads[0].runtime
     assert runtime.gpu == GPU(count=1, type="h100", cuda_version="12.4")
-
-
-def test_pipeline_launch_cloud_rejects_legacy_gpu_kwargs(monkeypatch) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    launch_cloud = cast(Any, read_jsonl("input.jsonl").launch_cloud)
-    with pytest.raises(TypeError, match="gpus_per_worker"):
-        launch_cloud(
-            name="demo cloud",
-            gpus_per_worker=1,
-        )
-    with pytest.raises(TypeError, match="gpu_type"):
-        launch_cloud(
-            name="demo cloud",
-            gpu_type="h100",
-        )
 
 
 def test_gpu_rejects_unsupported_values() -> None:

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -90,8 +90,7 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
         num_workers=3,
         cpus_per_worker=2,
         mem_mb_per_worker=4096,
-        gpus_per_worker=2,
-        gpu_type="h100",
+        gpu=GPU(count=2, type="h100", cuda_version="12.8"),
     )
 
     assert result.job_id == "job-123"
@@ -106,8 +105,14 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert request.plan["stages"][0]["requested_num_workers"] == 3
     assert request.plan["stages"][0]["cpus_per_worker"] == 2
     assert request.plan["stages"][0]["memory_mb_per_worker"] == 4096
-    assert request.plan["stages"][0]["gpus_per_worker"] == 2
-    assert request.plan["stages"][0]["gpu_type"] == "h100"
+    assert request.plan["stages"][0]["gpu"] == {
+        "count": 2,
+        "type": "h100",
+        "cuda_version": "12.8",
+    }
+    assert "gpus_per_worker" not in request.plan["stages"][0]
+    assert "gpu_type" not in request.plan["stages"][0]
+    assert "cuda_version" not in request.plan["stages"][0]
     assert len(request.stage_payloads) == 1
     assert request.stage_payloads[0].stage_index == 0
     assert request.stage_payloads[0].pipeline_payload.sha256 == "abc123"
@@ -115,8 +120,11 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert request.stage_payloads[0].runtime.num_workers == 3
     assert request.stage_payloads[0].runtime.cpus_per_worker == 2
     assert request.stage_payloads[0].runtime.mem_mb_per_worker == 4096
-    assert request.stage_payloads[0].runtime.gpus_per_worker == 2
-    assert request.stage_payloads[0].runtime.gpu_type == "h100"
+    assert request.stage_payloads[0].runtime.gpu == GPU(
+        count=2,
+        type="h100",
+        cuda_version="12.8",
+    )
     assert request.manifest == {
         "version": 1,
         "environment": {"refiner_version": "0.2.0", "refiner_ref": "abc123def456"},
@@ -137,74 +145,28 @@ def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
-    assert request.plan["stages"][0]["gpus_per_worker"] == 1
-    assert request.plan["stages"][0]["gpu_type"] == "h100"
-    assert request.plan["stages"][0]["cuda_version"] == "12.4"
+    assert request.plan["stages"][0]["gpu"] == {
+        "count": 1,
+        "type": "h100",
+        "cuda_version": "12.4",
+    }
     runtime = request.stage_payloads[0].runtime
-    assert runtime.gpus_per_worker == 1
-    assert runtime.gpu_type == "h100"
-    assert runtime.cuda_version == "12.4"
+    assert runtime.gpu == GPU(count=1, type="h100", cuda_version="12.4")
 
 
-def test_pipeline_launch_cloud_rejects_mixed_gpu_styles(monkeypatch) -> None:
+def test_pipeline_launch_cloud_rejects_legacy_gpu_kwargs(monkeypatch) -> None:
     _stub_cloud_submit(monkeypatch, fail_on_submit=True)
 
-    with pytest.raises(
-        ValueError,
-        match="gpu cannot be combined with gpus_per_worker or gpu_type",
-    ):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            gpu=GPU(count=1, type="h100"),
-            gpus_per_worker=1,
-        )
-
-
-def test_pipeline_launch_cloud_requires_gpu_type_with_gpu_count(monkeypatch) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    with pytest.raises(
-        ValueError,
-        match="gpu_type is required when gpus_per_worker is set",
-    ):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            gpus_per_worker=2,
-        )
-
-
-def test_pipeline_launch_cloud_requires_gpu_count_with_gpu_type(monkeypatch) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    with pytest.raises(
-        ValueError,
-        match="gpus_per_worker is required when gpu_type is set",
-    ):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            gpu_type="h100",
-        )
-
-
-def test_pipeline_launch_cloud_rejects_non_positive_gpu_count(monkeypatch) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    with pytest.raises(ValueError, match="gpus_per_worker must be > 0"):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            gpus_per_worker=0,
-            gpu_type="h100",
-        )
-
-
-def test_pipeline_launch_cloud_rejects_blank_gpu_type(monkeypatch) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    with pytest.raises(ValueError, match="gpu_type must be non-empty"):
-        read_jsonl("input.jsonl").launch_cloud(
+    launch_cloud = cast(Any, read_jsonl("input.jsonl").launch_cloud)
+    with pytest.raises(TypeError, match="gpus_per_worker"):
+        launch_cloud(
             name="demo cloud",
             gpus_per_worker=1,
-            gpu_type=cast(Any, "   "),
+        )
+    with pytest.raises(TypeError, match="gpu_type"):
+        launch_cloud(
+            name="demo cloud",
+            gpu_type="h100",
         )
 
 
@@ -783,28 +745,24 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.plan["stages"][0]["cpus_per_worker"] == 4
     assert request.plan["stages"][0]["memory_mb_per_worker"] == 8192
-    assert request.plan["stages"][0]["gpus_per_worker"] == 1
-    assert request.plan["stages"][0]["gpu_type"] == "h100"
-    assert request.plan["stages"][0]["cuda_version"] == "12.6"
+    assert request.plan["stages"][0]["gpu"] == {
+        "count": 1,
+        "type": "h100",
+        "cuda_version": "12.6",
+    }
     assert "cpus_per_worker" not in request.plan["stages"][1]
     assert "memory_mb_per_worker" not in request.plan["stages"][1]
-    assert "gpus_per_worker" not in request.plan["stages"][1]
-    assert "gpu_type" not in request.plan["stages"][1]
-    assert "cuda_version" not in request.plan["stages"][1]
+    assert "gpu" not in request.plan["stages"][1]
     first_runtime = request.stage_payloads[0].runtime
     second_runtime = request.stage_payloads[1].runtime
     assert first_runtime is not None
     assert second_runtime is not None
     assert first_runtime.cpus_per_worker == 4
     assert first_runtime.mem_mb_per_worker == 8192
-    assert first_runtime.gpus_per_worker == 1
-    assert first_runtime.gpu_type == "h100"
-    assert first_runtime.cuda_version == "12.6"
+    assert first_runtime.gpu == GPU(count=1, type="h100", cuda_version="12.6")
     assert second_runtime.cpus_per_worker is None
     assert second_runtime.mem_mb_per_worker is None
-    assert second_runtime.gpus_per_worker is None
-    assert second_runtime.gpu_type is None
-    assert second_runtime.cuda_version is None
+    assert second_runtime.gpu is None
 
 
 def test_pipeline_launch_cloud_auto_attach_uses_stdout_interactivity(
@@ -922,22 +880,6 @@ def test_pipeline_launch_cloud_continue_uses_current_plan_runtime(monkeypatch) -
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.plan is not None
     assert request.plan["stages"][0]["requested_num_workers"] == 1
-
-
-def test_pipeline_launch_cloud_continue_requires_gpu_type_when_gpus_requested(
-    monkeypatch,
-) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
-
-    with pytest.raises(
-        ValueError,
-        match="gpu_type is required when gpus_per_worker is set",
-    ):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            continue_from_job="00000000-0000-1000-8000-000000000123",
-            gpus_per_worker=1,
-        )
 
 
 def test_pipeline_launch_cloud_continue_preserves_fixed_reducer_stage_runtime(

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 from collections.abc import Callable
-from typing import cast
+from typing import Any, cast
 
 from refiner.pipeline import read_jsonl
+from refiner.pipeline.resources import GPU
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
@@ -123,6 +124,42 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     }
 
 
+def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        gpu=GPU(count=1, type="h100", cuda_version="12.4"),
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.plan["stages"][0]["gpus_per_worker"] == 1
+    assert request.plan["stages"][0]["gpu_type"] == "h100"
+    assert request.plan["stages"][0]["cuda_version"] == "12.4"
+    runtime = request.stage_payloads[0].runtime
+    assert runtime.gpus_per_worker == 1
+    assert runtime.gpu_type == "h100"
+    assert runtime.cuda_version == "12.4"
+
+
+def test_pipeline_launch_cloud_rejects_mixed_gpu_styles(monkeypatch) -> None:
+    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
+
+    with pytest.raises(
+        ValueError,
+        match="gpu cannot be combined with gpus_per_worker or gpu_type",
+    ):
+        read_jsonl("input.jsonl").launch_cloud(
+            name="demo cloud",
+            gpu=GPU(count=1, type="h100"),
+            gpus_per_worker=1,
+        )
+
+
 def test_pipeline_launch_cloud_requires_gpu_type_with_gpu_count(monkeypatch) -> None:
     _stub_cloud_submit(monkeypatch, fail_on_submit=True)
 
@@ -167,8 +204,17 @@ def test_pipeline_launch_cloud_rejects_blank_gpu_type(monkeypatch) -> None:
         read_jsonl("input.jsonl").launch_cloud(
             name="demo cloud",
             gpus_per_worker=1,
-            gpu_type="   ",
+            gpu_type=cast(Any, "   "),
         )
+
+
+def test_gpu_rejects_unsupported_values() -> None:
+    with pytest.raises(ValueError, match="gpu.count must be > 0"):
+        GPU(count=0, type="h100")
+    with pytest.raises(ValueError, match="gpu.type must be one of: h100"):
+        GPU(count=1, type="a100")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gpu.cuda_version must be one of"):
+        GPU(count=1, type="h100", cuda_version="13.0")  # type: ignore[arg-type]
 
 
 def test_pipeline_launch_cloud_can_disable_dependency_install(monkeypatch) -> None:
@@ -731,8 +777,7 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
         name="demo cloud",
         cpus_per_worker=4,
         mem_mb_per_worker=8192,
-        gpus_per_worker=1,
-        gpu_type="h100",
+        gpu=GPU(count=1, type="h100", cuda_version="12.6"),
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
@@ -740,10 +785,12 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
     assert request.plan["stages"][0]["memory_mb_per_worker"] == 8192
     assert request.plan["stages"][0]["gpus_per_worker"] == 1
     assert request.plan["stages"][0]["gpu_type"] == "h100"
+    assert request.plan["stages"][0]["cuda_version"] == "12.6"
     assert "cpus_per_worker" not in request.plan["stages"][1]
     assert "memory_mb_per_worker" not in request.plan["stages"][1]
     assert "gpus_per_worker" not in request.plan["stages"][1]
     assert "gpu_type" not in request.plan["stages"][1]
+    assert "cuda_version" not in request.plan["stages"][1]
     first_runtime = request.stage_payloads[0].runtime
     second_runtime = request.stage_payloads[1].runtime
     assert first_runtime is not None
@@ -752,10 +799,12 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
     assert first_runtime.mem_mb_per_worker == 8192
     assert first_runtime.gpus_per_worker == 1
     assert first_runtime.gpu_type == "h100"
+    assert first_runtime.cuda_version == "12.6"
     assert second_runtime.cpus_per_worker is None
     assert second_runtime.mem_mb_per_worker is None
     assert second_runtime.gpus_per_worker is None
     assert second_runtime.gpu_type is None
+    assert second_runtime.cuda_version is None
 
 
 def test_pipeline_launch_cloud_auto_attach_uses_stdout_interactivity(

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -140,7 +140,7 @@ def test_build_gpu_sets_partitions_gpus(monkeypatch: pytest.MonkeyPatch) -> None
         "refiner.worker.resources.gpu.available_gpu_ids",
         lambda: ["0", "1", "2", "3"],
     )
-    sets = build_gpu_sets(num_workers=2, gpus_per_worker=2)
+    sets = build_gpu_sets(num_workers=2, gpu_count_per_worker=2)
     assert sets == [["0", "1"], ["2", "3"]]
 
 
@@ -152,7 +152,7 @@ def test_build_gpu_sets_raises_when_insufficient(
         lambda: ["0"],
     )
     with pytest.raises(ValueError):
-        build_gpu_sets(num_workers=2, gpus_per_worker=1)
+        build_gpu_sets(num_workers=2, gpu_count_per_worker=1)
 
 
 def test_launch_local_assigns_visible_gpus(
@@ -177,19 +177,6 @@ def test_launch_local_assigns_visible_gpus(
     assert stats.workers == 1
     assert stats.completed == 1
     assert stats.failed == 0
-
-
-def test_launch_local_rejects_legacy_gpu_kwarg(tmp_path) -> None:
-    path = tmp_path / "a.jsonl"
-    path.write_text('{"x": 1}\n')
-    launch_local = cast(Any, read_jsonl(str(path)).launch_local)
-
-    with pytest.raises(TypeError, match="gpus_per_worker"):
-        launch_local(
-            name="local-gpu-launch",
-            gpus_per_worker=1,
-            rundir=str(tmp_path / "run"),
-        )
 
 
 def test_launch_local_multi_worker_subprocess_with_lambda(tmp_path) -> None:
@@ -1612,12 +1599,12 @@ def test_local_launcher_preserves_reducer_stage_resource_opt_out(
             ),
         ),
     ]
-    seen_gpu_hints: list[int | None] = []
+    seen_gpu_hints: list[GPU | None] = []
 
     monkeypatch.setattr(launcher, "_planned_stages", lambda: stages)
 
     def fake_launch_stage(*, stage):  # noqa: ANN001
-        seen_gpu_hints.append(stage.compute.gpus_per_worker)
+        seen_gpu_hints.append(stage.compute.gpu)
         return LaunchStats(
             job_id="job-1",
             workers=1,
@@ -1631,7 +1618,7 @@ def test_local_launcher_preserves_reducer_stage_resource_opt_out(
 
     launcher.launch()
 
-    assert seen_gpu_hints == [1, None]
+    assert seen_gpu_hints == [GPU(count=1, type="h100", cuda_version="12.6"), None]
 
 
 def test_local_launcher_does_not_force_platform_terminal_state(

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -26,6 +26,7 @@ from refiner.cli.ui.console import (
 )
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline import RefinerPipeline, read_csv, read_jsonl
+from refiner.pipeline.resources import GPU
 from refiner.launchers.local import LaunchStats, LocalLauncher
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
 from refiner.pipeline.sources.readers.base import BaseReader
@@ -169,13 +170,26 @@ def test_launch_local_assigns_visible_gpus(
     stats = pipeline.launch_local(
         name="local-gpu-launch",
         num_workers=1,
-        gpus_per_worker=1,
+        gpu=GPU(count=1, type="h100", cuda_version="12.4"),
         rundir=str(tmp_path / "run"),
     )
 
     assert stats.workers == 1
     assert stats.completed == 1
     assert stats.failed == 0
+
+
+def test_launch_local_rejects_legacy_gpu_kwarg(tmp_path) -> None:
+    path = tmp_path / "a.jsonl"
+    path.write_text('{"x": 1}\n')
+    launch_local = cast(Any, read_jsonl(str(path)).launch_local)
+
+    with pytest.raises(TypeError, match="gpus_per_worker"):
+        launch_local(
+            name="local-gpu-launch",
+            gpus_per_worker=1,
+            rundir=str(tmp_path / "run"),
+        )
 
 
 def test_launch_local_multi_worker_subprocess_with_lambda(tmp_path) -> None:
@@ -1578,7 +1592,7 @@ def test_local_launcher_preserves_reducer_stage_resource_opt_out(
         pipeline=pipeline,
         name="local-reducer-resources",
         num_workers=1,
-        gpus_per_worker=1,
+        gpu=GPU(count=1, type="h100", cuda_version="12.6"),
     )
 
     stages = [

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -10,6 +10,7 @@ from refiner.platform.client import (
     StagePayload,
 )
 from refiner.platform.client import MacrodataApiError
+from refiner.pipeline.resources import GPU
 
 
 def _request() -> CloudRunCreateRequest:
@@ -29,9 +30,7 @@ def _request() -> CloudRunCreateRequest:
                     num_workers=2,
                     cpus_per_worker=4,
                     mem_mb_per_worker=8192,
-                    gpus_per_worker=2,
-                    gpu_type="h100",
-                    cuda_version="12.4",
+                    gpu=GPU(count=2, type="h100", cuda_version="12.4"),
                 ),
             )
         ],
@@ -83,9 +82,11 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
                 "num_workers": 2,
                 "cpus_per_worker": 4,
                 "mem_mb_per_worker": 8192,
-                "gpus_per_worker": 2,
-                "gpu_type": "h100",
-                "cuda_version": "12.4",
+                "gpu": {
+                    "count": 2,
+                    "type": "h100",
+                    "cuda_version": "12.4",
+                },
             },
         }
     ]

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -31,6 +31,7 @@ def _request() -> CloudRunCreateRequest:
                     mem_mb_per_worker=8192,
                     gpus_per_worker=2,
                     gpu_type="h100",
+                    cuda_version="12.4",
                 ),
             )
         ],
@@ -84,6 +85,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
                 "mem_mb_per_worker": 8192,
                 "gpus_per_worker": 2,
                 "gpu_type": "h100",
+                "cuda_version": "12.4",
             },
         }
     ]


### PR DESCRIPTION
## Summary

Adds a structured `mdr.GPU(...)` launch option so users specify GPU count, GPU type, and CUDA version together for both local and cloud launches:

```python
pipeline.launch_local(
    name="local-job",
    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.4"),
)

pipeline.launch_cloud(
    name="cloud-job",
    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.4"),
)
```

The legacy GPU worker-count field has been removed from the public launch APIs and from internal stage planning. Local launch uses `gpu.count` for `CUDA_VISIBLE_DEVICES` assignment and ignores `cuda_version`; cloud submit serialization sends a structured `gpu` object in the per-stage plan/runtime payload.

## Details

- Adds `GPU`, `GPUType`, and `CUDAVersion` public exports.
- Supports CUDA literals `"12.4"`, `"12.6"`, and `"12.8"`.
- Keeps GPU type conservative with the currently documented `"h100"` literal.
- Propagates structured `gpu` through stage planning and cloud submit serialization.
- Updates local launch, cloud launch, launcher docs, GPU example, and tests.

## Validation

- `uv run pytest` -> `546 passed`
- Commit hook passed `ruff`, `ruff format`, and `ty`