### PR TITLE
Add cloud secret sources

### DIFF
--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -113,7 +113,7 @@ result = pipeline.launch_cloud(
 )
 ```
 
-Workspace secrets can be created in [workspace settings](https://macrodata.co/settings) or with the [`macrodata secrets` CLI](cli.md#workspace-secrets).
+Workspace secrets can be created in [workspace settings](https://macrodata.co/settings) under the Secrets tab, or from the CLI with `macrodata secrets set`; see [Workspace Secrets](cli.md#workspace-secrets).
 
 Pass `keys` to mount only selected names from that environment:
 

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -160,6 +160,18 @@ result = pipeline.launch_cloud(
 
 Explicit dictionary and `.env` values are redacted from captured pipeline code. Workspace secret environment values are resolved by the cloud service, so the submitting process does not see those secret values.
 
+Use `env` for plain runtime values that should not be treated as secrets:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=mdr.Secrets.env(name="default"),
+    env={"MODEL_NAME": "gpt-5"},
+)
+```
+
+If `env` uses the same key as a secret source, the plain `env` value is applied last in the runtime environment. Plain `env` values are not redacted from captured pipeline code.
+
 ### Continuing cloud work
 
 Fresh cloud launch remains the default. Continue only triggers when you pass `continue_from_job`.

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -113,7 +113,7 @@ result = pipeline.launch_cloud(
 )
 ```
 
-Workspace secrets can be created in [workspace settings](https://macrodata.co/settings) under the Secrets tab, or from the CLI with `macrodata secrets set`; see [Workspace Secrets](cli.md#workspace-secrets).
+Workspace secrets can be created in [workspace settings](https://macrodata.co/settings/secrets), or from the CLI with `macrodata secrets set`; see [Workspace Secrets](cli.md#workspace-secrets).
 
 Pass `keys` to mount only selected names from that environment:
 

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -87,7 +87,7 @@ Returned result includes:
 - `mem_mb_per_worker`: scheduler hint for worker memory sizing
 - `gpu`: structured scheduler hint for GPU count, GPU type, and CUDA version
 - `sync_local_dependencies`: whether to install the submitting environment's dependencies into the cloud image
-- `secrets`: env vars sent as secrets
+- `secrets`: secret sources mounted into the cloud runtime
 - `env`: env vars sent as plain runtime environment values
 - `continue_from_job`: continue from one exact prior job id (`UUID`), one exact job-and-stage boundary (`UUID:stage_index`), or `"infer"`. `:stage_index` is optional; when omitted, the control plane uses the last resumable boundary in the selected job.
 - exact `UUID` selection is scoped to the current workspace; jobs from other workspaces are not eligible continue sources
@@ -99,6 +99,66 @@ Current SDK GPU literals are:
 
 - GPU type: `"h100"`
 - CUDA versions: `"12.4"`, `"12.6"`, `"12.8"`
+
+### Cloud secrets
+
+Pass `secrets` when a cloud job needs API keys or credentials. The previous mapping form still works:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets={"HF_TOKEN": None, "OPENAI_API_KEY": "sk-..."},
+)
+```
+
+Mapping values are handled as follows:
+
+- `None` reads the value from the submitting process environment
+- any other value is converted to a string and sent directly
+
+Use `Secrets.env(...)` to mount secrets already saved in a Macrodata workspace secret environment:
+
+```python
+import refiner as mdr
+
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=mdr.Secrets.env(name="default"),
+)
+```
+
+Pass `keys` to mount only selected names from that environment:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN", "AWS_REGION"]),
+)
+```
+
+Use `Secrets.dotenv(...)` to load a local `.env`-style file and send it as explicit dictionary secrets:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=mdr.Secrets.dotenv(".env"),
+)
+```
+
+`secrets` can also be a list. Sources are applied in order, and later sources override earlier ones:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=[
+        mdr.Secrets.env(name="default"),
+        mdr.Secrets.dotenv(".env.local"),
+        {"HF_TOKEN": None},
+    ],
+)
+```
+
+Explicit dictionary and `.env` values are redacted from captured pipeline code. Workspace secret environment values are resolved by the cloud service, so the submitting process does not see those secret values.
 
 ### Continuing cloud work
 

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -102,7 +102,7 @@ Current SDK GPU literals are:
 
 ### Cloud secrets
 
-Pass `secrets` when a cloud job needs API keys or credentials. The previous mapping form still works:
+Pass `secrets` when a cloud job needs API keys or credentials. A dictionary sends explicit secret values:
 
 ```python
 result = pipeline.launch_cloud(

--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -102,21 +102,7 @@ Current SDK GPU literals are:
 
 ### Cloud secrets
 
-Pass `secrets` when a cloud job needs API keys or credentials. A dictionary sends explicit secret values:
-
-```python
-result = pipeline.launch_cloud(
-    name="cloud-job",
-    secrets={"HF_TOKEN": None, "OPENAI_API_KEY": "sk-..."},
-)
-```
-
-Mapping values are handled as follows:
-
-- `None` reads the value from the submitting process environment
-- any other value is converted to a string and sent directly
-
-Use `Secrets.env(...)` to mount secrets already saved in a Macrodata workspace secret environment:
+Pass `secrets` when a cloud job needs API keys or credentials. Use `Secrets.env(...)` to mount secrets saved in a Macrodata workspace secret environment:
 
 ```python
 import refiner as mdr
@@ -127,6 +113,8 @@ result = pipeline.launch_cloud(
 )
 ```
 
+Workspace secrets can be created in [workspace settings](https://macrodata.co/settings) or with the [`macrodata secrets` CLI](cli.md#workspace-secrets).
+
 Pass `keys` to mount only selected names from that environment:
 
 ```python
@@ -136,7 +124,7 @@ result = pipeline.launch_cloud(
 )
 ```
 
-Use `Secrets.dotenv(...)` to load a local `.env`-style file and send it as explicit dictionary secrets:
+Use `Secrets.dotenv(...)` to load a local `.env`-style file as explicit secrets:
 
 ```python
 result = pipeline.launch_cloud(
@@ -144,6 +132,17 @@ result = pipeline.launch_cloud(
     secrets=mdr.Secrets.dotenv(".env"),
 )
 ```
+
+Use `Secrets.dict(...)` to pass explicit values from code:
+
+```python
+result = pipeline.launch_cloud(
+    name="cloud-job",
+    secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
+)
+```
+
+`None` reads the value from the submitting process environment. Any other value is converted to a string and sent directly.
 
 `secrets` can also be a list. Sources are applied in order, and later sources override earlier ones:
 
@@ -153,12 +152,12 @@ result = pipeline.launch_cloud(
     secrets=[
         mdr.Secrets.env(name="default"),
         mdr.Secrets.dotenv(".env.local"),
-        {"HF_TOKEN": None},
+        mdr.Secrets.dict({"HF_TOKEN": None}),
     ],
 )
 ```
 
-Explicit dictionary and `.env` values are redacted from captured pipeline code. Workspace secret environment values are resolved by the cloud service, so the submitting process does not see those secret values.
+Explicit `Secrets.dict(...)` and `Secrets.dotenv(...)` values are redacted from captured pipeline code. Workspace secret environment values are resolved by the cloud service, so the submitting process does not see those secret values.
 
 Use `env` for plain runtime values that should not be treated as secrets:
 

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -24,6 +24,7 @@ from refiner.pipeline import (
     task,
 )
 from refiner.pipeline.expressions import coalesce, col, if_else, lit
+from refiner.launchers.secrets import Secrets
 from refiner.worker.metrics.api import (
     log_gauge,
     log_gauges,
@@ -42,6 +43,7 @@ __all__ = [
     "GPUType",
     "SUPPORTED_CUDA_VERSIONS",
     "SUPPORTED_GPU_TYPES",
+    "Secrets",
     "read_csv",
     "read_files",
     "read_hf_dataset",

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -180,18 +180,9 @@ class CloudLauncher(BaseLauncher):
                 "Launching jobs in the Macrodata cloud requires Macrodata "
                 "authentication. Run `macrodata login` or set MACRODATA_API_KEY."
             ) from err
-        resolved_secret_sources, secret_values, explicit_secret_keys = (
-            resolve_secret_sources(self.secrets)
-        )
+        resolved_secret_sources, secret_values = resolve_secret_sources(self.secrets)
         resolved_env = resolve_env_mapping(self.env) if self.env else None
         secret_sources = list(resolved_secret_sources or [])
-        if resolved_env and (
-            overlapping_env_keys := explicit_secret_keys & resolved_env.keys()
-        ):
-            raise SystemExit(
-                "cloud env keys must not overlap with secrets: "
-                + ", ".join(sorted(overlapping_env_keys))
-            )
         if resolved_env:
             secret_sources.append(resolved_env)
         stages = self._resolved_stages()

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -23,7 +23,7 @@ from refiner.platform.client import (
     serialize_pipeline_inline,
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
-from refiner.launchers.secrets import SecretInput, SecretPayload, resolve_secret_mapping
+from refiner.launchers.secrets import SecretInput, SecretPayload, resolve_env_mapping
 from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
 from refiner.pipeline.resources import GPU
 
@@ -201,7 +201,7 @@ class CloudLauncher(BaseLauncher):
         resolved_secret_sources, secret_values, explicit_secret_keys = (
             resolve_secret_sources(self.secrets)
         )
-        resolved_env = resolve_secret_mapping(self.env) if self.env else None
+        resolved_env = resolve_env_mapping(self.env) if self.env else None
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
         plan = self._compiled_plan(stages, secret_values=secret_values)

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -23,7 +23,7 @@ from refiner.platform.client import (
     serialize_pipeline_inline,
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
-from refiner.launchers.secrets import SecretInput, SecretPayload, resolve_env_mapping
+from refiner.launchers.secrets import SecretInput, resolve_env_mapping
 from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
 from refiner.pipeline.resources import GPU
 
@@ -133,24 +133,6 @@ class CloudLauncher(BaseLauncher):
         self.unsafe_continue = unsafe_continue
 
     @staticmethod
-    def _merged_secret_sources(
-        secret_sources: list[SecretPayload] | None,
-        env: dict[str, str] | None,
-        explicit_secret_keys: set[str],
-    ) -> list[SecretPayload] | None:
-        sources = list(secret_sources or [])
-        if sources and env:
-            overlapping = explicit_secret_keys & env.keys()
-            if overlapping:
-                raise SystemExit(
-                    "cloud env keys must not overlap with secrets: "
-                    + ", ".join(sorted(overlapping))
-                )
-        if env:
-            sources.append(env)
-        return sources or None
-
-    @staticmethod
     def _fallback_to_latest_pypi_enabled() -> bool:
         raw = os.environ.get(_FALLBACK_ENV_VAR, "")
         return raw.strip().lower() in {"1", "true", "yes", "on"}
@@ -202,6 +184,16 @@ class CloudLauncher(BaseLauncher):
             resolve_secret_sources(self.secrets)
         )
         resolved_env = resolve_env_mapping(self.env) if self.env else None
+        secret_sources = list(resolved_secret_sources or [])
+        if resolved_env and (
+            overlapping_env_keys := explicit_secret_keys & resolved_env.keys()
+        ):
+            raise SystemExit(
+                "cloud env keys must not overlap with secrets: "
+                + ", ".join(sorted(overlapping_env_keys))
+            )
+        if resolved_env:
+            secret_sources.append(resolved_env)
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
         plan = self._compiled_plan(stages, secret_values=secret_values)
@@ -223,9 +215,7 @@ class CloudLauncher(BaseLauncher):
             ],
             manifest=manifest,
             sync_local_dependencies=self.sync_local_dependencies,
-            secrets=self._merged_secret_sources(
-                resolved_secret_sources, resolved_env, explicit_secret_keys
-            ),
+            secrets=secret_sources or None,
             continue_from_job=self.continue_from_job,
             unsafe_continue=self.unsafe_continue,
         )

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -23,6 +23,8 @@ from refiner.platform.client import (
     serialize_pipeline_inline,
 )
 from refiner.platform.manifest import refiner_ref_exists_on_remote
+from refiner.launchers.secrets import SecretInput, SecretPayload, resolve_secret_mapping
+from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
 from refiner.pipeline.resources import GPU
 
 from refiner.job_urls import build_job_tracking_url
@@ -91,7 +93,7 @@ class CloudLauncher(BaseLauncher):
         mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
         gpu: Optional GPU runtime request for cloud scheduling.
         sync_local_dependencies: Whether to sync submitting environment dependencies.
-        secrets: Optional secrets mounted into the cloud runtime.
+        secrets: Optional secret sources mounted into the cloud runtime.
         env: Optional plain environment variables mounted into the cloud runtime.
     """
 
@@ -105,7 +107,7 @@ class CloudLauncher(BaseLauncher):
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
-        secrets: dict[str, object | None] | None = None,
+        secrets: SecretInput | None = None,
         env: dict[str, object | None] | None = None,
         continue_from_job: str | None = None,
         unsafe_continue: bool = False,
@@ -125,43 +127,28 @@ class CloudLauncher(BaseLauncher):
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
         self.sync_local_dependencies = sync_local_dependencies
-        self.secrets = secrets
+        self.secrets = normalize_secret_sources(secrets)
         self.env = env
         self.continue_from_job = normalized_continue_from_job
         self.unsafe_continue = unsafe_continue
 
     @staticmethod
-    def _resolve_env_values(
-        values: dict[str, object | None] | None,
-    ) -> dict[str, str] | None:
-        if not values:
-            return None
-        resolved: dict[str, str] = {}
-        for name, value in values.items():
-            if value is None:
-                env_value = os.environ.get(name)
-                if env_value is None:
-                    raise SystemExit(
-                        f"cloud env {name!r} was set to None but is not present in the environment. Make sure it is being exported."
-                    )
-                resolved[name] = env_value
-                continue
-            resolved[name] = str(value)
-        return resolved
-
-    @staticmethod
-    def _merged_env(
-        secrets: dict[str, str] | None,
+    def _merged_secret_sources(
+        secret_sources: list[SecretPayload] | None,
         env: dict[str, str] | None,
-    ) -> dict[str, str] | None:
-        if secrets and env:
-            overlapping = secrets.keys() & env.keys()
+        explicit_secret_keys: set[str],
+    ) -> list[SecretPayload] | None:
+        sources = list(secret_sources or [])
+        if sources and env:
+            overlapping = explicit_secret_keys & env.keys()
             if overlapping:
                 raise SystemExit(
                     "cloud env keys must not overlap with secrets: "
                     + ", ".join(sorted(overlapping))
                 )
-        return {**(secrets or {}), **(env or {})} or None
+        if env:
+            sources.append(env)
+        return sources or None
 
     @staticmethod
     def _fallback_to_latest_pypi_enabled() -> bool:
@@ -211,9 +198,10 @@ class CloudLauncher(BaseLauncher):
                 "Launching jobs in the Macrodata cloud requires Macrodata "
                 "authentication. Run `macrodata login` or set MACRODATA_API_KEY."
             ) from err
-        resolved_secrets = self._resolve_env_values(self.secrets)
-        resolved_env = self._resolve_env_values(self.env)
-        secret_values = tuple(resolved_secrets.values()) if resolved_secrets else ()
+        resolved_secret_sources, secret_values, explicit_secret_keys = (
+            resolve_secret_sources(self.secrets)
+        )
+        resolved_env = resolve_secret_mapping(self.env) if self.env else None
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
         plan = self._compiled_plan(stages, secret_values=secret_values)
@@ -235,7 +223,9 @@ class CloudLauncher(BaseLauncher):
             ],
             manifest=manifest,
             sync_local_dependencies=self.sync_local_dependencies,
-            secrets=self._merged_env(resolved_secrets, resolved_env),
+            secrets=self._merged_secret_sources(
+                resolved_secret_sources, resolved_env, explicit_secret_keys
+            ),
             continue_from_job=self.continue_from_job,
             unsafe_continue=self.unsafe_continue,
         )

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -182,9 +182,6 @@ class CloudLauncher(BaseLauncher):
             ) from err
         resolved_secret_sources, secret_values = resolve_secret_sources(self.secrets)
         resolved_env = resolve_env_mapping(self.env) if self.env else None
-        secret_sources = list(resolved_secret_sources or [])
-        if resolved_env:
-            secret_sources.append(resolved_env)
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
         plan = self._compiled_plan(stages, secret_values=secret_values)
@@ -206,7 +203,8 @@ class CloudLauncher(BaseLauncher):
             ],
             manifest=manifest,
             sync_local_dependencies=self.sync_local_dependencies,
-            secrets=secret_sources or None,
+            secrets=resolved_secret_sources,
+            env=resolved_env,
             continue_from_job=self.continue_from_job,
             unsafe_continue=self.unsafe_continue,
         )

--- a/src/refiner/launchers/secrets.py
+++ b/src/refiner/launchers/secrets.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import ast
+import builtins
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, cast
+
+
+SecretMapping = Mapping[str, object | None]
+SecretPayload = dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class Secrets:
+    """Cloud secret source for Macrodata jobs."""
+
+    _kind: Literal["dict", "env"]
+    _values: builtins.dict[str, object | None] | None = None
+    _env_name: str | None = None
+    _keys: tuple[str, ...] | None = None
+
+    @classmethod
+    def dict(cls, values: SecretMapping) -> "Secrets":
+        return cls(_kind="dict", _values=dict(values))
+
+    @classmethod
+    def dotenv(cls, path: str | os.PathLike[str]) -> "Secrets":
+        return cls.dict(_load_dotenv(Path(path)))
+
+    @classmethod
+    def env(cls, name: str = "default", keys: Sequence[str] | None = None) -> "Secrets":
+        if not name:
+            raise ValueError("secret environment name is required")
+        if isinstance(keys, str):
+            raise TypeError("secret environment keys must be a sequence of strings")
+        return cls(
+            _kind="env", _env_name=name, _keys=tuple(keys) if keys is not None else None
+        )
+
+
+SecretInput = Secrets | SecretMapping | Sequence[Secrets | SecretMapping]
+
+
+def normalize_secret_sources(secrets: SecretInput | None) -> tuple[Secrets, ...]:
+    if secrets is None:
+        return ()
+    if isinstance(secrets, Secrets):
+        return (secrets,)
+    if isinstance(secrets, Mapping):
+        return (Secrets.dict(cast(SecretMapping, secrets)),)
+    normalized: list[Secrets] = []
+    for source in secrets:
+        if isinstance(source, Secrets):
+            normalized.append(source)
+        elif isinstance(source, Mapping):
+            normalized.append(Secrets.dict(source))
+        else:
+            raise TypeError("secrets entries must be Secrets or mappings")
+    return tuple(normalized)
+
+
+def resolve_secret_sources(
+    sources: Sequence[Secrets],
+) -> tuple[list[SecretPayload] | None, tuple[str, ...], set[str]]:
+    payloads: list[SecretPayload] = []
+    redaction_values: list[str] = []
+    explicit_keys: set[str] = set()
+    for source in sources:
+        if source._kind == "dict":
+            resolved = resolve_secret_mapping(source._values or {})
+            if resolved:
+                payloads.append(resolved)
+                redaction_values.extend(resolved.values())
+                explicit_keys.update(resolved)
+            continue
+        payload: SecretPayload = {
+            "__type__": "__envkeys__",
+            "envname": source._env_name or "default",
+        }
+        if source._keys is not None:
+            payload["keys"] = list(source._keys)
+            explicit_keys.update(source._keys)
+        payloads.append(payload)
+    return payloads or None, tuple(redaction_values), explicit_keys
+
+
+def resolve_secret_mapping(values: SecretMapping) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for name, value in values.items():
+        if value is None:
+            env_value = os.environ.get(name)
+            if env_value is None:
+                raise SystemExit(
+                    f"cloud env {name!r} was set to None but is not present in the environment. Make sure it is being exported."
+                )
+            resolved[name] = env_value
+            continue
+        resolved[name] = str(value)
+    return resolved
+
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        values[key] = _parse_dotenv_value(raw_value)
+    return values
+
+
+def _parse_dotenv_value(raw_value: str) -> str:
+    value = _strip_inline_comment(raw_value.strip())
+    if not value:
+        return ""
+    if value[0] in {"'", '"'}:
+        try:
+            parsed = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            return value.strip(value[0])
+        return str(parsed)
+
+    return value
+
+
+def _strip_inline_comment(value: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+    return value
+
+
+__all__ = ["Secrets", "resolve_secret_mapping"]

--- a/src/refiner/launchers/secrets.py
+++ b/src/refiner/launchers/secrets.py
@@ -89,7 +89,7 @@ def resolve_env_mapping(values: SecretMapping) -> dict[str, str]:
     for name, value in values.items():
         resolved_value = os.environ.get(name) if value is None else str(value)
         if resolved_value is None:
-            raise SystemExit(
+            raise ValueError(
                 f"cloud env {name!r} was set to None but is not present in the environment. Make sure it is being exported."
             )
         resolved[name] = resolved_value

--- a/src/refiner/launchers/secrets.py
+++ b/src/refiner/launchers/secrets.py
@@ -70,7 +70,7 @@ def resolve_secret_sources(
     explicit_keys: set[str] = set()
     for source in sources:
         if source._kind == "dict":
-            resolved = resolve_secret_mapping(source._values or {})
+            resolved = resolve_env_mapping(source._values or {})
             if resolved:
                 payloads.append(resolved)
                 redaction_values.extend(resolved.values())
@@ -87,7 +87,7 @@ def resolve_secret_sources(
     return payloads or None, tuple(redaction_values), explicit_keys
 
 
-def resolve_secret_mapping(values: SecretMapping) -> dict[str, str]:
+def resolve_env_mapping(values: SecretMapping) -> dict[str, str]:
     resolved: dict[str, str] = {}
     for name, value in values.items():
         resolved_value = os.environ.get(name) if value is None else str(value)
@@ -153,4 +153,4 @@ def _strip_inline_comment(value: str) -> str:
     return value
 
 
-__all__ = ["Secrets", "resolve_secret_mapping"]
+__all__ = ["Secrets"]

--- a/src/refiner/launchers/secrets.py
+++ b/src/refiner/launchers/secrets.py
@@ -90,15 +90,12 @@ def resolve_secret_sources(
 def resolve_secret_mapping(values: SecretMapping) -> dict[str, str]:
     resolved: dict[str, str] = {}
     for name, value in values.items():
-        if value is None:
-            env_value = os.environ.get(name)
-            if env_value is None:
-                raise SystemExit(
-                    f"cloud env {name!r} was set to None but is not present in the environment. Make sure it is being exported."
-                )
-            resolved[name] = env_value
-            continue
-        resolved[name] = str(value)
+        resolved_value = os.environ.get(name) if value is None else str(value)
+        if resolved_value is None:
+            raise SystemExit(
+                f"cloud env {name!r} was set to None but is not present in the environment. Make sure it is being exported."
+            )
+        resolved[name] = resolved_value
     return resolved
 
 

--- a/src/refiner/launchers/secrets.py
+++ b/src/refiner/launchers/secrets.py
@@ -64,17 +64,15 @@ def normalize_secret_sources(secrets: SecretInput | None) -> tuple[Secrets, ...]
 
 def resolve_secret_sources(
     sources: Sequence[Secrets],
-) -> tuple[list[SecretPayload] | None, tuple[str, ...], set[str]]:
+) -> tuple[list[SecretPayload] | None, tuple[str, ...]]:
     payloads: list[SecretPayload] = []
     redaction_values: list[str] = []
-    explicit_keys: set[str] = set()
     for source in sources:
         if source._kind == "dict":
             resolved = resolve_env_mapping(source._values or {})
             if resolved:
                 payloads.append(resolved)
                 redaction_values.extend(resolved.values())
-                explicit_keys.update(resolved)
             continue
         payload: SecretPayload = {
             "__type__": "__envkeys__",
@@ -82,9 +80,8 @@ def resolve_secret_sources(
         }
         if source._keys is not None:
             payload["keys"] = list(source._keys)
-            explicit_keys.update(source._keys)
         payloads.append(payload)
-    return payloads or None, tuple(redaction_values), explicit_keys
+    return payloads or None, tuple(redaction_values)
 
 
 def resolve_env_mapping(values: SecretMapping) -> dict[str, str]:

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -62,6 +64,7 @@ import pyarrow as pa
 if TYPE_CHECKING:
     from refiner.launchers.cloud import CloudLaunchResult
     from refiner.launchers.local import LaunchStats
+    from refiner.launchers.secrets import SecretInput
 
 
 class RefinerPipeline:
@@ -413,7 +416,7 @@ class RefinerPipeline:
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
-        secrets: Mapping[str, object | None] | None = None,
+        secrets: SecretInput | None = None,
         env: Mapping[str, object | None] | None = None,
         continue_from_job: str | None = None,
         unsafe_continue: bool = False,
@@ -427,8 +430,9 @@ class RefinerPipeline:
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
             gpu: Optional structured GPU request.
             sync_local_dependencies: Sync submitting environment dependencies in cloud image.
-            secrets: Extra environment variables to mount inside the cloud image.
-                `None` values are loaded from the submitting environment.
+            secrets: Secret sources to mount inside the cloud image. A mapping keeps
+                the legacy behavior; `None` values are loaded from the submitting
+                environment. `Secrets.env(...)` references stored workspace secrets.
             env: Extra environment variables to mount inside the cloud image without
                 treating their values as redaction targets. `None` values are loaded
                 from the submitting environment.
@@ -447,7 +451,7 @@ class RefinerPipeline:
             mem_mb_per_worker=mem_mb_per_worker,
             gpu=gpu,
             sync_local_dependencies=sync_local_dependencies,
-            secrets=dict(secrets) if secrets is not None else None,
+            secrets=secrets,
             env=dict(env) if env is not None else None,
             continue_from_job=continue_from_job,
             unsafe_continue=unsafe_continue,

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -177,6 +177,7 @@ class CloudRunCreateRequest:
     manifest: dict[str, Any] | None = None
     sync_local_dependencies: bool = True
     secrets: list[dict[str, Any]] | None = None
+    env: dict[str, str] | None = None
     continue_from_job: str | None = None
     unsafe_continue: bool = False
 
@@ -193,6 +194,8 @@ class CloudRunCreateRequest:
             payload["manifest"] = self.manifest
         if self.secrets:
             payload["secrets"] = self.secrets
+        if self.env:
+            payload["env"] = self.env
         if self.continue_from_job is not None:
             payload["continue_from_job"] = self.continue_from_job
         if self.unsafe_continue:

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -176,7 +176,7 @@ class CloudRunCreateRequest:
     stage_payloads: list[StagePayload]
     manifest: dict[str, Any] | None = None
     sync_local_dependencies: bool = True
-    secrets: dict[str, str] | None = None
+    secrets: list[dict[str, Any]] | None = None
     continue_from_job: str | None = None
     unsafe_continue: bool = False
 

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -14,6 +14,7 @@ from refiner.platform.client import (
     MacrodataApiError,
 )
 from refiner.platform.manifest import _redact_captured_text
+from refiner.launchers.secrets import Secrets
 
 
 def _stub_cloud_submit(
@@ -190,10 +191,87 @@ def test_pipeline_launch_cloud_resolves_secrets(monkeypatch) -> None:
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
-    assert request.secrets == {
-        "OPENAI_API_KEY": "env-secret",
-        "MODEL_NAME": "gpt-5",
-    }
+    assert request.secrets == [
+        {
+            "OPENAI_API_KEY": "env-secret",
+            "MODEL_NAME": "gpt-5",
+        }
+    ]
+
+
+def test_pipeline_launch_cloud_accepts_env_secret_source(monkeypatch) -> None:
+    captured = _stub_cloud_submit(
+        monkeypatch,
+        manifest={"version": 1, "script": {"text": "HF_TOKEN should not be redacted"}},
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        secrets=Secrets.env(name="production", keys=["HF_TOKEN"]),
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.secrets == [
+        {"__type__": "__envkeys__", "envname": "production", "keys": ["HF_TOKEN"]}
+    ]
+    assert request.manifest is not None
+    assert request.manifest["script"]["text"] == "HF_TOKEN should not be redacted"
+
+
+def test_pipeline_launch_cloud_rejects_string_env_secret_keys() -> None:
+    with pytest.raises(TypeError, match="sequence of strings"):
+        Secrets.env(keys="HF_TOKEN")
+
+
+def test_pipeline_launch_cloud_accepts_multiple_secret_sources(monkeypatch) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        secrets=[
+            Secrets.env(name="default"),
+            Secrets.dict({"MODEL_NAME": "gpt-5"}),
+        ],
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.secrets == [
+        {"__type__": "__envkeys__", "envname": "default"},
+        {"MODEL_NAME": "gpt-5"},
+    ]
+
+
+def test_pipeline_launch_cloud_loads_dotenv_as_dict_secret_source(
+    monkeypatch, tmp_path
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text(
+        "HF_TOKEN=hf_secret\nexport MODEL_NAME='gpt-5' # inline comment\nEMPTY=\n",
+        encoding="utf-8",
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        secrets=Secrets.dotenv(dotenv_path),
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.secrets == [
+        {"HF_TOKEN": "hf_secret", "MODEL_NAME": "gpt-5", "EMPTY": ""}
+    ]
 
 
 def test_pipeline_launch_cloud_sends_env_without_redacting_it(monkeypatch) -> None:
@@ -218,10 +296,12 @@ def test_pipeline_launch_cloud_sends_env_without_redacting_it(monkeypatch) -> No
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
-    assert request.secrets == {
-        "OPENAI_API_KEY": "super-secret-value",
-        "MODEL_NAME": "plain-env-value",
-    }
+    assert request.secrets == [
+        {
+            "OPENAI_API_KEY": "super-secret-value",
+        },
+        {"MODEL_NAME": "plain-env-value"},
+    ]
     assert "REDACTED_SECRET" in request.plan["stages"][0]["steps"][1]["args"]["fn"]
 
 
@@ -234,6 +314,19 @@ def test_pipeline_launch_cloud_rejects_overlapping_secret_and_env_keys(
         read_jsonl("input.jsonl").launch_cloud(
             name="demo cloud",
             secrets={"API_KEY": "secret"},
+            env={"API_KEY": "env"},
+        )
+
+
+def test_pipeline_launch_cloud_rejects_overlapping_env_secret_key_and_env(
+    monkeypatch,
+) -> None:
+    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
+
+    with pytest.raises(SystemExit, match="API_KEY"):
+        read_jsonl("input.jsonl").launch_cloud(
+            name="demo cloud",
+            secrets=Secrets.env(keys=["API_KEY"]),
             env={"API_KEY": "env"},
         )
 

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -408,10 +408,10 @@ def test_pipeline_launch_cloud_requires_missing_env_secret(monkeypatch) -> None:
 
     try:
         pipeline.launch_cloud(name="demo cloud", secrets={"OPENAI_API_KEY": None})
-    except SystemExit as err:
+    except ValueError as err:
         assert "OPENAI_API_KEY" in str(err)
     else:  # pragma: no cover
-        raise AssertionError("expected SystemExit")
+        raise AssertionError("expected ValueError")
 
 
 def test_pipeline_launch_cloud_requires_platform_auth_before_secret_resolution(

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -299,9 +299,9 @@ def test_pipeline_launch_cloud_sends_env_without_redacting_it(monkeypatch) -> No
     assert request.secrets == [
         {
             "OPENAI_API_KEY": "super-secret-value",
-        },
-        {"MODEL_NAME": "plain-env-value"},
+        }
     ]
+    assert request.env == {"MODEL_NAME": "plain-env-value"}
     assert "REDACTED_SECRET" in request.plan["stages"][0]["steps"][1]["args"]["fn"]
 
 
@@ -321,7 +321,8 @@ def test_pipeline_launch_cloud_allows_env_to_override_secret_keys(
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
-    assert request.secrets == [{"API_KEY": "secret"}, {"API_KEY": "env"}]
+    assert request.secrets == [{"API_KEY": "secret"}]
+    assert request.env == {"API_KEY": "env"}
 
 
 def test_pipeline_launch_cloud_allows_env_to_override_env_secret_keys(
@@ -341,9 +342,9 @@ def test_pipeline_launch_cloud_allows_env_to_override_env_secret_keys(
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.secrets == [
-        {"__type__": "__envkeys__", "envname": "default", "keys": ["API_KEY"]},
-        {"API_KEY": "env"},
+        {"__type__": "__envkeys__", "envname": "default", "keys": ["API_KEY"]}
     ]
+    assert request.env == {"API_KEY": "env"}
 
 
 def test_pipeline_launch_cloud_redacts_captured_strings_in_outgoing_request(

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -305,30 +305,45 @@ def test_pipeline_launch_cloud_sends_env_without_redacting_it(monkeypatch) -> No
     assert "REDACTED_SECRET" in request.plan["stages"][0]["steps"][1]["args"]["fn"]
 
 
-def test_pipeline_launch_cloud_rejects_overlapping_secret_and_env_keys(
+def test_pipeline_launch_cloud_allows_env_to_override_secret_keys(
     monkeypatch,
 ) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
 
-    with pytest.raises(SystemExit, match="API_KEY"):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            secrets={"API_KEY": "secret"},
-            env={"API_KEY": "env"},
-        )
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        secrets={"API_KEY": "secret"},
+        env={"API_KEY": "env"},
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.secrets == [{"API_KEY": "secret"}, {"API_KEY": "env"}]
 
 
-def test_pipeline_launch_cloud_rejects_overlapping_env_secret_key_and_env(
+def test_pipeline_launch_cloud_allows_env_to_override_env_secret_keys(
     monkeypatch,
 ) -> None:
-    _stub_cloud_submit(monkeypatch, fail_on_submit=True)
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
 
-    with pytest.raises(SystemExit, match="API_KEY"):
-        read_jsonl("input.jsonl").launch_cloud(
-            name="demo cloud",
-            secrets=Secrets.env(keys=["API_KEY"]),
-            env={"API_KEY": "env"},
-        )
+    read_jsonl("input.jsonl").launch_cloud(
+        name="demo cloud",
+        secrets=Secrets.env(keys=["API_KEY"]),
+        env={"API_KEY": "env"},
+    )
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.secrets == [
+        {"__type__": "__envkeys__", "envname": "default", "keys": ["API_KEY"]},
+        {"API_KEY": "env"},
+    ]
 
 
 def test_pipeline_launch_cloud_redacts_captured_strings_in_outgoing_request(

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -35,6 +35,7 @@ def _request() -> CloudRunCreateRequest:
             )
         ],
         secrets=[{"OPENAI_API_KEY": "test-secret"}],
+        env={"MODEL_NAME": "gpt-5"},
     )
 
 
@@ -91,6 +92,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
         }
     ]
     assert json_payload["secrets"] == [{"OPENAI_API_KEY": "test-secret"}]
+    assert json_payload["env"] == {"MODEL_NAME": "gpt-5"}
 
 
 def test_cloud_client_cloud_submit_job_requires_job_and_stage_ids(monkeypatch) -> None:

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -34,7 +34,7 @@ def _request() -> CloudRunCreateRequest:
                 ),
             )
         ],
-        secrets={"OPENAI_API_KEY": "test-secret"},
+        secrets=[{"OPENAI_API_KEY": "test-secret"}],
     )
 
 
@@ -90,7 +90,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
             },
         }
     ]
-    assert json_payload["secrets"] == {"OPENAI_API_KEY": "test-secret"}
+    assert json_payload["secrets"] == [{"OPENAI_API_KEY": "test-secret"}]
 
 
 def test_cloud_client_cloud_submit_job_requires_job_and_stage_ids(monkeypatch) -> None:


### PR DESCRIPTION
Adds the `Secrets` API for cloud launches.

### Changes
- Adds `Secrets.dict(...)`, `Secrets.dotenv(path)`, and `Secrets.env(name="default", keys=None)`
- Allows `launch_cloud(secrets=...)` to accept one source or a list of sources
- Preserves direct secret value redaction while keeping environment-backed key names out of redaction
- Keeps the implementation under `refiner.launchers` and exports `Secrets` from `refiner`

### Validation
- `uv run ruff format src/refiner/launchers/secrets.py src/refiner/__init__.py src/refiner/pipeline/__init__.py src/refiner/pipeline/pipeline.py src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run ruff check src/refiner/launchers/secrets.py src/refiner/__init__.py src/refiner/pipeline/__init__.py src/refiner/pipeline/pipeline.py src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run ty check src/refiner/launchers/__init__.py src/refiner/launchers/secrets.py src/refiner/launchers/cloud.py src/refiner/pipeline/pipeline.py src/refiner/platform/client/models.py tests/launchers/test_cloud_launcher.py tests/platform/test_cloud_client.py`
- `uv run pytest tests/launchers/test_cloud_launcher.py tests/platform/test_cloud_client.py`