### PR TITLE
[codex] add uv dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ dev = [
 testpaths = ["tests"]
 addopts = "-ra"
 
+[tool.uv]
+exclude-newer = "14 days"
+
 [tool.ty]
 [tool.ty.terminal]
 error-on-warning = false

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aiobotocore"
 version = "3.3.0"


### PR DESCRIPTION
## Summary

Adds a global uv dependency cooldown so package resolution ignores distributions uploaded within the last 14 days. This follows uv's current dependency cooldown documentation for `[tool.uv] exclude-newer`.

The lockfile was refreshed with uv 0.11.13 so it records the relative cooldown metadata without changing resolved package versions.

## Validation

- `uv --version`: `uv 0.11.13 (Homebrew 2026-05-11 aarch64-apple-darwin)`
- `uv lock --check`: resolved 80 packages successfully
- `uv run pytest`: 549 passed in 78.87s
- `uv run pytest tests/test_optional_dependencies.py`: 1 passed in 1.11s

## Notes

Older uv versions, including 0.9.14, warn on friendly duration syntax in `[tool.uv]`. uv 0.11.13 accepts `exclude-newer = "14 days"` and writes the expected lock metadata.