### PR TITLE
[codex] Embed runtime services in cloud payloads

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -49,12 +49,16 @@ Set `OPENAI_API_KEY` in the worker environment before execution. For cloud jobs,
 ### Refiner managed VLLM runtime
 
 Use `VLLMProvider` when launching on Refiner Cloud and you want the platform to start and manage a VLLM server for you.
+Cloud launches include the VLLM runtime service requirements in the submitted
+stage plan and worker payload so the platform can reserve service capacity
+before workers begin processing shards.
 
 ```python
 import refiner as mdr
 
 provider = mdr.inference.VLLMProvider(
     model="google/gemma-4-E4B-it",
+    config="correctness",
 )
 
 async def summarize(row, generate):
@@ -79,14 +83,8 @@ pipeline = mdr.read_jsonl("input.jsonl").map_async(
 )
 ```
 
-Pass extra VLLM server arguments through `extra_kwargs` on the provider:
-
-```python
-provider = mdr.inference.VLLMProvider(
-    model="Qwen/Qwen3.5-9B",
-    extra_kwargs={"limit-mm-per-prompt": '{"video": 1}'},
-)
-```
+Use `config="throughput"` when you want the managed VLLM service to prioritize
+serving throughput over the default correctness-oriented profile.
 
 #### Supported models
 Only the following models are currently supported. If you are missing one, please create an issue:

--- a/src/refiner/inference/providers.py
+++ b/src/refiner/inference/providers.py
@@ -1,6 +1,5 @@
-from collections.abc import Mapping
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Literal
 
 from refiner.services import VLLMServiceDefinition
 
@@ -31,36 +30,26 @@ class OpenAIEndpointProvider:
 @dataclass(frozen=True, slots=True)
 class VLLMProvider:
     model: str
-    model_max_context: int | None = None
-    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    config: Literal["correctness", "throughput"] = "correctness"
 
     def __post_init__(self) -> None:
         if not self.model.strip():
             raise ValueError("model_name_or_path must be non-empty")
-        if self.model_max_context is not None and self.model_max_context <= 0:
-            raise ValueError("model_max_context must be > 0 when provided")
-        for key, value in dict(self.extra_kwargs).items():
-            if not str(key).strip():
-                raise ValueError("extra_kwargs keys must be non-empty")
-            if value is None:
-                raise ValueError("extra_kwargs values must be non-null")
+        if self.config not in {"correctness", "throughput"}:
+            raise ValueError("config must be 'correctness' or 'throughput'")
 
     def service_definition(self) -> VLLMServiceDefinition:
         return VLLMServiceDefinition(
             model_name_or_path=self.model,
-            model_max_context=self.model_max_context,
-            extra_kwargs=self.extra_kwargs,
+            config=self.config,
         )
 
     def to_builtin_args(self) -> dict[str, object]:
-        payload: dict[str, Any] = {
+        service = self.service_definition()
+        payload: dict[str, object] = {
             "type": "vllm",
-            "model_name_or_path": self.model,
+            **service.to_spec().config,
         }
-        if self.model_max_context is not None:
-            payload["model_max_context"] = self.model_max_context
-        if self.extra_kwargs:
-            payload["extra_kwargs"] = dict(self.extra_kwargs)
         return payload
 
 

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -26,6 +26,7 @@ from refiner.platform.manifest import refiner_ref_exists_on_remote
 from refiner.launchers.secrets import SecretInput, resolve_env_mapping
 from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
 from refiner.pipeline.resources import GPU
+from refiner.services.discovery import collect_pipeline_services
 
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
@@ -198,6 +199,7 @@ class CloudLauncher(BaseLauncher):
                         mem_mb_per_worker=stage.compute.memory_mb_per_worker,
                         gpu=stage.compute.gpu,
                     ),
+                    runtime_services=collect_pipeline_services(stage.pipeline),
                 )
                 for stage in stages
             ],

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -25,6 +25,10 @@ from refiner.pipeline.planning import PlannedStage
 from refiner.pipeline.resources import GPU
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
 from refiner.platform.client.api import MacrodataClient, request_json
+from refiner.services.discovery import (
+    collect_pipeline_services,
+    runtime_service_specs_to_dicts,
+)
 from refiner.worker.context import logger
 from refiner.worker.lifecycle import read_finalized_workers
 from refiner.worker.resources.cpu import available_cpu_ids
@@ -140,6 +144,7 @@ class LocalLauncher(BaseLauncher):
         worker_id: str,
         rundir: str,
         gpu_ids: tuple[str, ...],
+        runtime_services_json: str,
     ) -> subprocess.Popen[str]:
         cmd = [
             sys.executable,
@@ -157,6 +162,8 @@ class LocalLauncher(BaseLauncher):
             worker_id,
             "--rundir",
             rundir,
+            "--runtime-services-json",
+            runtime_services_json,
         ]
         if gpu_ids:
             cmd.extend(["--gpu-ids", ",".join(gpu_ids)])
@@ -322,6 +329,10 @@ class LocalLauncher(BaseLauncher):
         stage_run_dir.mkdir(parents=True, exist_ok=True)
         payload_path = stage_run_dir / "pipeline.cloudpickle"
         payload_path.write_bytes(cloudpickle.dumps(stage.pipeline))
+        runtime_services_json = json.dumps(
+            runtime_service_specs_to_dicts(collect_pipeline_services(stage.pipeline)),
+            separators=(",", ":"),
+        )
         shard_assignments = self._assign_shards(
             shards,
             num_workers=stage_workers,
@@ -353,6 +364,7 @@ class LocalLauncher(BaseLauncher):
                         worker_id=worker_id,
                         rundir=self.rundir,
                         gpu_ids=tuple(gpu_sets[rank]),
+                        runtime_services_json=runtime_services_json,
                     ),
                 )
             )

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -26,6 +26,10 @@ from refiner.pipeline.data.datatype import dtype_to_plan
 from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import _redact_captured_text
 from refiner.services import RuntimeServiceSpec
+from refiner.services.discovery import (
+    collect_pipeline_services,
+    runtime_service_specs_to_dicts,
+)
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
@@ -507,19 +511,21 @@ def compile_planned_stages(
     *,
     secret_values: tuple[str, ...] = (),
 ) -> dict[str, Any]:
-    plan = {
-        "stages": [
-            {
-                "name": stage.name,
-                "index": stage.index,
-                **stage.compute.to_stage_plan_dict(),
-                "steps": _compile_stage_steps(
-                    stage.pipeline, secret_values=secret_values
-                ),
-            }
-            for stage in stages
-        ]
-    }
+    def _stage_payload(stage: PlannedStage) -> dict[str, Any]:
+        payload = {
+            "name": stage.name,
+            "index": stage.index,
+            **stage.compute.to_stage_plan_dict(),
+            "steps": _compile_stage_steps(stage.pipeline, secret_values=secret_values),
+        }
+        runtime_services = collect_pipeline_services(stage.pipeline)
+        if runtime_services:
+            payload["runtime_services"] = runtime_service_specs_to_dicts(
+                runtime_services
+            )
+        return payload
+
+    plan = {"stages": [_stage_payload(stage) for stage in stages]}
     return plan
 
 

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -7,6 +7,7 @@ import msgspec
 
 from refiner.pipeline.resources import GPU
 from refiner.pipeline.data.shard import Shard
+from refiner.services.base import RuntimeServiceSpec
 from refiner.worker.lifecycle import FinalizedShardWorker
 
 
@@ -159,6 +160,7 @@ class StagePayload:
     stage_index: int
     pipeline_payload: CloudPipelinePayload
     runtime: CloudRuntimeConfig
+    runtime_services: tuple[RuntimeServiceSpec, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -166,6 +168,10 @@ class StagePayload:
             "pipeline_payload": self.pipeline_payload.to_dict(),
             "runtime": self.runtime.to_dict(),
         }
+        if self.runtime_services:
+            payload["runtime_services"] = [
+                service.to_dict() for service in self.runtime_services
+            ]
         return payload
 
 

--- a/src/refiner/services/base.py
+++ b/src/refiner/services/base.py
@@ -11,6 +11,19 @@ class RuntimeServiceSpec:
     kind: str
     config: Mapping[str, Any]
 
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> RuntimeServiceSpec:
+        name = payload.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("runtime service name must be non-empty")
+        kind = payload.get("kind")
+        if not isinstance(kind, str) or not kind.strip():
+            raise ValueError(f"runtime service {name!r} kind must be non-empty")
+        config = payload.get("config")
+        if not isinstance(config, Mapping):
+            raise ValueError(f"runtime service {name!r} config must be an object")
+        return cls(name=name.strip(), kind=kind.strip(), config=dict(config))
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -67,7 +67,23 @@ def collect_pipeline_services(
     return tuple(services_by_key.values())
 
 
-__all__ = ["collect_pipeline_services"]
+def runtime_service_specs_to_dicts(
+    services: Sequence[RuntimeServiceSpec],
+) -> list[dict[str, Any]]:
+    return [service.to_dict() for service in services]
+
+
+def parse_runtime_service_specs(
+    services: Sequence[Mapping[str, Any]],
+) -> tuple[RuntimeServiceSpec, ...]:
+    return tuple(RuntimeServiceSpec.from_dict(service) for service in services)
+
+
+__all__ = [
+    "collect_pipeline_services",
+    "parse_runtime_service_specs",
+    "runtime_service_specs_to_dicts",
+]
 
 
 def _service_config_key(config: Mapping[str, Any]) -> str:

--- a/src/refiner/services/vllm.py
+++ b/src/refiner/services/vllm.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from refiner.services.base import RuntimeServiceBinding, RuntimeServiceSpec
 
@@ -12,40 +12,34 @@ from refiner.services.base import RuntimeServiceBinding, RuntimeServiceSpec
 @dataclass(frozen=True, slots=True)
 class VLLMServiceDefinition:
     model_name_or_path: str
-    model_max_context: int | None = None
-    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    config: Literal["correctness", "throughput"] = "correctness"
     kind: str = "llm"
 
     def __post_init__(self) -> None:
         if not self.model_name_or_path.strip():
             raise ValueError("model_name_or_path must be non-empty")
-        if self.model_max_context is not None and self.model_max_context <= 0:
-            raise ValueError("model_max_context must be > 0 when provided")
-        for key, value in dict(self.extra_kwargs).items():
-            if not str(key).strip():
-                raise ValueError("extra_kwargs keys must be non-empty")
-            if value is None:
-                raise ValueError("extra_kwargs values must be non-null")
+        if self.config not in {"correctness", "throughput"}:
+            raise ValueError("config must be 'correctness' or 'throughput'")
 
     @property
     def name(self) -> str:
         name_source = json.dumps(
-            {
-                "model_name_or_path": self.model_name_or_path,
-                "model_max_context": self.model_max_context,
-                "extra_kwargs": self.extra_kwargs,
-            },
+            self._service_config(),
+            sort_keys=True,
             separators=(",", ":"),
         )
-        return f"vllm-{hashlib.sha1(name_source.encode('utf-8')).hexdigest()[:12]}"
+        return f"vllm-{hashlib.sha256(name_source.encode('utf-8')).hexdigest()[:12]}"
 
     def to_spec(self) -> RuntimeServiceSpec:
-        config: dict[str, Any] = {"model_name_or_path": self.model_name_or_path}
-        if self.model_max_context is not None:
-            config["model_max_context"] = self.model_max_context
-        if self.extra_kwargs:
-            config["extra_kwargs"] = dict(self.extra_kwargs)
-        return RuntimeServiceSpec(name=self.name, kind=self.kind, config=config)
+        return RuntimeServiceSpec(
+            name=self.name, kind=self.kind, config=self._service_config()
+        )
+
+    def _service_config(self) -> dict[str, Any]:
+        return {
+            "model_name_or_path": self.model_name_or_path,
+            "config": self.config,
+        }
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/refiner/worker/entrypoint.py
+++ b/src/refiner/worker/entrypoint.py
@@ -6,6 +6,7 @@ import json
 import cloudpickle
 
 from refiner.pipeline.data.shard import Shard
+from refiner.services.discovery import parse_runtime_service_specs
 from refiner.worker.context import logger
 from refiner.worker.lifecycle import LocalRuntimeLifecycle
 from refiner.worker.metrics.emitter import LocalLogEmitter
@@ -22,6 +23,7 @@ def main() -> int:
     parser.add_argument("--worker-id", type=str, required=True)
     parser.add_argument("--rundir", type=str, required=True)
     parser.add_argument("--gpu-ids", type=str, default="")
+    parser.add_argument("--runtime-services-json", type=str, default="[]")
     args = parser.parse_args()
 
     payload = {
@@ -44,6 +46,10 @@ def main() -> int:
             set_visible_gpu_ids(gpu_ids)
         with open(args.pipeline_payload, "rb") as f:
             pipeline = cloudpickle.load(f)
+        raw_runtime_services = json.loads(args.runtime_services_json)
+        if not isinstance(raw_runtime_services, list):
+            raise ValueError("runtime services payload must be a list")
+        runtime_services = parse_runtime_service_specs(raw_runtime_services)
 
         with open(
             f"{args.rundir}/stage-{args.stage_index}/assignments/worker-{args.worker_id}.json",
@@ -66,6 +72,7 @@ def main() -> int:
             worker_id=args.worker_id,
             worker_name=args.worker_name,
             runtime_lifecycle=runtime_lifecycle,
+            runtime_services=runtime_services,
             user_metrics_emitter=log_emitter,
         ).run()
         payload.update(

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from refiner.execution.engine import block_num_rows
 from refiner.pipeline.data.shard import Shard
 from refiner.pipeline.pipeline import RefinerPipeline
 from refiner.pipeline.sinks import NullSink
-from refiner.services import ServiceManager
-from refiner.services.discovery import collect_pipeline_services
+from refiner.services import RuntimeServiceSpec, ServiceManager
 from refiner.worker.context import logger, set_active_run_context, set_active_step_index
 from refiner.worker.lifecycle import RuntimeLifecycle
 from refiner.worker.metrics.emitter import (
@@ -37,6 +37,7 @@ class Worker:
         worker_name: str | None = None,
         heartbeat_interval_seconds: int = 0,
         runtime_lifecycle: RuntimeLifecycle,
+        runtime_services: Sequence[RuntimeServiceSpec] = (),
         user_metrics_emitter: UserMetricsEmitter | None = None,
     ):
         self.pipeline = pipeline
@@ -46,6 +47,7 @@ class Worker:
         self.worker_name = worker_name
         self.heartbeat_interval_seconds = heartbeat_interval_seconds
         self.runtime_lifecycle = runtime_lifecycle
+        self.runtime_services = tuple(runtime_services)
         self.user_metrics_emitter = (
             NOOP_USER_METRICS_EMITTER
             if user_metrics_emitter is None
@@ -86,7 +88,7 @@ class Worker:
             worker_id=self.worker_id,
             worker_name=self.worker_name,
         )
-        runtime_services = collect_pipeline_services(self.pipeline)
+        runtime_services = self.runtime_services
         sink = self.pipeline.sink or NullSink()
         sink_schema = self.pipeline.output_schema()
         sink.set_input_schema(sink_schema)

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -4,6 +4,7 @@ import pytest
 from collections.abc import Callable
 from typing import cast
 
+import refiner as mdr
 from refiner.pipeline import read_jsonl
 from refiner.pipeline.resources import GPU
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
@@ -15,6 +16,11 @@ from refiner.platform.client import (
 )
 from refiner.platform.manifest import _redact_captured_text
 from refiner.launchers.secrets import Secrets
+
+
+async def _noop_inference(row, generate):
+    del generate
+    return row
 
 
 def _stub_cloud_submit(
@@ -129,6 +135,34 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
         "environment": {"refiner_version": "0.2.0", "refiner_ref": "abc123def456"},
         "script": {"text": "print('hi')"},
     }
+
+
+def test_pipeline_launch_cloud_embeds_runtime_services(monkeypatch) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    pipeline = read_jsonl("input.jsonl").map_async(
+        mdr.inference.generate(
+            fn=_noop_inference,
+            provider=mdr.inference.VLLMProvider(model="Qwen/Qwen3.5-9B"),
+        )
+    )
+    pipeline.launch_cloud(name="demo cloud")
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    expected_service = {
+        "name": request.plan["stages"][0]["runtime_services"][0]["name"],
+        "kind": "llm",
+        "config": {
+            "model_name_or_path": "Qwen/Qwen3.5-9B",
+            "config": "correctness",
+        },
+    }
+    assert request.plan["stages"][0]["runtime_services"] == [expected_service]
+    assert request.stage_payloads[0].runtime_services[0].to_dict() == expected_service
 
 
 def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -43,6 +43,35 @@ def _disable_local_init_api_ping(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
     monkeypatch.setenv("REFINER_WORKDIR", str(tmp_path))
 
 
+def test_spawn_local_worker_passes_runtime_services_json(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        pass
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    process = LocalLauncher._spawn_local_worker(
+        pipeline_payload="/tmp/pipeline.cloudpickle",
+        job_id="job-1",
+        stage_index=2,
+        worker_name="worker-a",
+        worker_id="worker-1",
+        rundir="/tmp/run",
+        gpu_ids=("0",),
+        runtime_services_json='[{"name":"vllm-demo"}]',
+    )
+
+    assert isinstance(process, _FakeProcess)
+    cmd = cast(list[str], captured["cmd"])
+    assert cmd[cmd.index("--runtime-services-json") + 1] == '[{"name":"vllm-demo"}]'
+
+
 class _FakeReader(BaseReader):
     def __init__(
         self,

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -169,6 +169,34 @@ def test_compile_pipeline_plan_uses_builtin_calls_for_builtin_steps() -> None:
     }
 
 
+async def _noop_inference(row, generate):
+    del generate
+    return row
+
+
+def test_compile_pipeline_plan_includes_runtime_services_for_builtin_steps() -> None:
+    pipeline = RefinerPipeline(FakeReader()).map_async(
+        rf.inference.generate(
+            fn=_noop_inference,
+            provider=rf.inference.VLLMProvider(model="Qwen/Qwen3.5-9B"),
+        )
+    )
+
+    stage = compile_pipeline_plan(pipeline)["stages"][0]
+
+    assert stage["runtime_services"] == [
+        {
+            "name": stage["runtime_services"][0]["name"],
+            "kind": "llm",
+            "config": {
+                "model_name_or_path": "Qwen/Qwen3.5-9B",
+                "config": "correctness",
+            },
+        }
+    ]
+    assert stage["runtime_services"][0]["name"].startswith("vllm-")
+
+
 def test_compile_pipeline_plan_includes_lerobot_writer_steps() -> None:
     pipeline = (
         RefinerPipeline(FakeReader())

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -11,6 +11,7 @@ from refiner.platform.client import (
 )
 from refiner.platform.client import MacrodataApiError
 from refiner.pipeline.resources import GPU
+from refiner.services import RuntimeServiceSpec
 
 
 def _request() -> CloudRunCreateRequest:
@@ -31,6 +32,16 @@ def _request() -> CloudRunCreateRequest:
                     cpus_per_worker=4,
                     mem_mb_per_worker=8192,
                     gpu=GPU(count=2, type="h100", cuda_version="12.4"),
+                ),
+                runtime_services=(
+                    RuntimeServiceSpec(
+                        name="vllm-demo",
+                        kind="llm",
+                        config={
+                            "model_name_or_path": "Qwen/Qwen3.5-9B",
+                            "config": "correctness",
+                        },
+                    ),
                 ),
             )
         ],
@@ -89,6 +100,16 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
                     "cuda_version": "12.4",
                 },
             },
+            "runtime_services": [
+                {
+                    "name": "vllm-demo",
+                    "kind": "llm",
+                    "config": {
+                        "model_name_or_path": "Qwen/Qwen3.5-9B",
+                        "config": "correctness",
+                    },
+                }
+            ],
         }
     ]
     assert json_payload["secrets"] == [{"OPENAI_API_KEY": "test-secret"}]

--- a/tests/services/test_discovery.py
+++ b/tests/services/test_discovery.py
@@ -15,7 +15,6 @@ def test_collect_pipeline_services_supports_nested_service_config() -> None:
             fn=_noop_inference,
             provider=mdr.inference.VLLMProvider(
                 model="Qwen/Qwen2.5-VL-7B-Instruct",
-                extra_kwargs={"limit-mm-per-prompt": "video=1"},
             ),
         )
     )
@@ -25,5 +24,5 @@ def test_collect_pipeline_services_supports_nested_service_config() -> None:
     assert len(services) == 1
     assert services[0].config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
+        "config": "correctness",
     }

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -236,41 +238,31 @@ def test_service_manager_times_out_when_service_never_becomes_ready(
         asyncio.run(manager.get("llm-a"))
 
 
-def test_vllm_service_definition_includes_extra_kwargs_in_name_and_config() -> None:
+def test_vllm_service_definition_uses_supported_service_config() -> None:
     service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        model_max_context=32768,
-        extra_kwargs={"limit-mm-per-prompt": "video=1"},
     )
 
     spec = service.to_spec()
 
     assert spec.config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
+        "config": "correctness",
     }
-    assert service.name.startswith("vllm-")
+    expected_suffix = hashlib.sha256(
+        json.dumps(spec.config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:12]
+    assert service.name == f"vllm-{expected_suffix}"
 
 
-def test_vllm_service_definition_name_preserves_extra_kwargs_value_types() -> None:
-    int_service = VLLMServiceDefinition(
+def test_vllm_service_definition_name_tracks_service_config_profile() -> None:
+    correctness_service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs={"max-num-seqs": 2048},
+        config="correctness",
     )
-    str_service = VLLMServiceDefinition(
+    throughput_service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs={"max-num-seqs": "2048"},
-    )
-
-    assert int_service.name != str_service.name
-
-
-def test_vllm_service_definition_name_accepts_mixed_extra_kwargs_key_types() -> None:
-    extra_kwargs = cast(Mapping[str, Any], {1: "one", "2": "two"})
-    service = VLLMServiceDefinition(
-        model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        extra_kwargs=extra_kwargs,
+        config="throughput",
     )
 
-    assert service.name.startswith("vllm-")
+    assert correctness_service.name != throughput_service.name

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -421,23 +421,19 @@ def test_vllm_provider_includes_model_in_requests(monkeypatch) -> None:
     }
 
 
-def test_vllm_provider_includes_extra_kwargs_in_service_definition() -> None:
+def test_vllm_provider_includes_supported_service_config() -> None:
     provider = VLLMProvider(
         model="Qwen/Qwen2.5-VL-7B-Instruct",
-        model_max_context=32768,
-        extra_kwargs={"limit-mm-per-prompt": "video=1"},
     )
 
     assert provider.to_builtin_args() == {
         "type": "vllm",
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
+        "config": "correctness",
     }
     assert provider.service_definition().to_spec().config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "model_max_context": 32768,
-        "extra_kwargs": {"limit-mm-per-prompt": "video=1"},
+        "config": "correctness",
     }
 
 

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -14,6 +14,7 @@ from refiner.pipeline.expressions import col
 from refiner.execution.engine import iter_rows
 from refiner.pipeline.sinks import BaseSink
 from refiner.pipeline.data.shard import FilePart
+from refiner.services import RuntimeServiceSpec
 from refiner.worker.runner import Worker
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
@@ -249,6 +250,39 @@ def test_worker_runs_fused_pipeline_and_updates_runtime_lifecycle() -> None:
     assert runtime_lifecycle.claim_previous[0] is None
     assert runtime_lifecycle.claim_previous[1] == shard1
     assert emitted == [(shard1.id, 3), (shard1.id, 2), (shard2.id, 11)]
+
+
+def test_worker_uses_explicit_runtime_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    shard = _shard("p", 0, 1)
+    runtime_lifecycle = _FakeRuntimeLifecycle([shard])
+    service = RuntimeServiceSpec(
+        name="vllm-demo",
+        kind="llm",
+        config={"model_name_or_path": "Qwen/Qwen3.5-9B", "config": "correctness"},
+    )
+    started_services: list[tuple[RuntimeServiceSpec, ...]] = []
+
+    class _FakeServiceManager:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        async def start_services(self, services) -> None:
+            started_services.append(tuple(services))
+
+    monkeypatch.setattr("refiner.worker.runner.ServiceManager", _FakeServiceManager)
+    worker = Worker(
+        pipeline=RefinerPipeline(source=_FakeReader({shard.id: [DictRow({"x": 1})]})),
+        job_id="job",
+        stage_index=0,
+        worker_id=runtime_lifecycle.worker_id,
+        runtime_lifecycle=runtime_lifecycle,
+        runtime_services=[service],
+    )
+
+    stats = worker.run()
+
+    assert stats.completed == 1
+    assert started_services == [(service,)]
 
 
 def test_worker_sends_heartbeat_for_inflight_shards() -> None:


### PR DESCRIPTION
## Summary
- embed discovered runtime services in compiled cloud stages and stage payloads
- pass serialized runtime services through local worker subprocesses and cloud runtime subprocesses instead of rediscovering inside Worker
- align managed VLLM service specs with the cloud controller's supported service schema
- remove unsupported VLLM provider knobs so only model and service profile are emitted

## Validation
- uv run pytest tests/worker/test_entrypoint.py tests/launchers/test_local_launcher.py tests/worker/test_runner.py tests/services/test_discovery.py tests/services/test_manager.py tests/pipeline/test_planning.py tests/platform/test_cloud_client.py tests/launchers/test_cloud_launcher.py tests/test_inference.py
- uv run ruff check src/refiner/launchers/local.py src/refiner/worker/entrypoint.py src/refiner/worker/runner.py src/refiner/services/base.py src/refiner/services/discovery.py src/refiner/platform/client/models.py src/refiner/pipeline/planning.py src/refiner/launchers/cloud.py src/refiner/inference/providers.py src/refiner/services/vllm.py tests/worker/test_entrypoint.py tests/launchers/test_local_launcher.py tests/worker/test_runner.py tests/services/test_discovery.py tests/services/test_manager.py tests/pipeline/test_planning.py tests/platform/test_cloud_client.py tests/launchers/test_cloud_launcher.py tests/test_inference.py