### PR TITLE
[codex] handle cloud runtime service specs

### DIFF
--- a/src/refiner/inference/client.py
+++ b/src/refiner/inference/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import random
 from collections.abc import Mapping, Sequence
@@ -13,6 +14,7 @@ _OPENAI_ENDPOINT_TIMEOUT_SECONDS = 600.0
 _OPENAI_ENDPOINT_MAX_RETRIES = 6
 _OPENAI_ENDPOINT_RETRY_BASE_DELAY_SECONDS = 5.0
 _OPENAI_ENDPOINT_RETRY_JITTER_FRACTION = 0.1
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,6 +23,10 @@ class InferenceResponse:
     finish_reason: str | None
     usage: Mapping[str, Any]
     response: Mapping[str, Any]
+
+    @property
+    def raw(self) -> Mapping[str, Any]:
+        return self.response
 
 
 @dataclass(slots=True)
@@ -111,6 +117,15 @@ def _parse_inference_response(
         content = message.get("content")
         if isinstance(content, str):
             text = content
+        elif content is None:
+            logger.warning(
+                "chat completion response had null message.content; returning empty text",
+                extra={
+                    "finish_reason": choice.get("finish_reason"),
+                    "has_reasoning": isinstance(message.get("reasoning"), str),
+                },
+            )
+            text = ""
         elif isinstance(content, Sequence):
             parts: list[str] = []
             for item in content:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -318,6 +318,37 @@ def test_openai_endpoint_retries_on_connect_error(monkeypatch) -> None:
     assert seen == {"calls": 2, "sleeps": 1}
 
 
+def test_openai_endpoint_warns_on_null_chat_content(caplog) -> None:
+    raw_response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning": "Thinking Process: still reasoning",
+                },
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {"completion_tokens": 64},
+    }
+    response = openai_module._parse_inference_response(
+        raw_response,
+        use_chat=True,
+    )
+
+    assert response.text == ""
+    assert response.finish_reason == "length"
+    assert response.usage == {"completion_tokens": 64}
+    assert response.raw == raw_response
+    message = response.raw["choices"][0]["message"]
+    assert message["reasoning"] == "Thinking Process: still reasoning"
+    assert (
+        "chat completion response had null message.content; returning empty text"
+        in caplog.text
+    )
+
+
 def test_openai_endpoint_does_not_retry_on_http_503(monkeypatch) -> None:
     seen: dict[str, int] = {"calls": 0, "sleeps": 0}
 


### PR DESCRIPTION
## Summary

- embed stage runtime service specs in cloud launch payloads and let workers consume those specs directly
- align the vLLM provider/service definition with the supported `model_name_or_path` + `config` contract
- expose raw OpenAI-compatible response accessors and treat null chat content as a warning with empty text

## Why

Cloud scheduling needs service requirements before worker runtime so the controller can reserve GPU/container capacity correctly. Refiner now sends the service specs in each stage payload rather than relying on worker-side discovery.

Qwen/vLLM reasoning responses can return `message.content = null` with provider-specific reasoning fields. Refiner should not fail the worker in that case; callers can inspect `response.raw`, `response.choice`, or `response.message` for the provider-native payload.

## Validation

- `uv run pre-commit run --files src/refiner/inference/client.py src/refiner/inference/providers.py src/refiner/launchers/cloud.py src/refiner/platform/client/models.py src/refiner/services/discovery.py src/refiner/services/vllm.py src/refiner/worker/runner.py tests/test_inference.py tests/services/test_discovery.py tests/services/test_manager.py`
- `uv run pytest tests/test_inference.py tests/services/test_discovery.py tests/services/test_manager.py -q`
- Cloud smoke against local stack completed successfully: job `019e3157-d7d1-76ce-af97-24bd53b2812d`
