### PR TITLE
[codex] Track row lineage for LeRobot vectorized ops

### DIFF
--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -13,6 +13,7 @@ from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.steps import (
     CastStep,
     DropStep,
+    FilterExprStep,
     FnAsyncRowStep,
     FnBatchStep,
     FnFlatMapStep,
@@ -300,11 +301,26 @@ def _execute_vector_segment(
     pending_rows = RowBuffer()
     current_chunk_rows = max(1, int(vectorized_chunk_rows))
     estimated_row_bytes: float | None = None
+    segment_changes_rows = any(
+        isinstance(op, (FilterExprStep, FnTableStep)) for op in ops
+    )
 
     def _run_block(block: Tabular) -> Tabular:
-        return block.with_table(
-            apply_vectorized_ops(block.table, ops, on_shard_delta=on_shard_delta)
+        return_row_indices = block.needs_row_indices and segment_changes_rows
+        if not return_row_indices:
+            table = apply_vectorized_ops(
+                block.table,
+                ops,
+                on_shard_delta=on_shard_delta,
+            )
+            return block.with_table(table)
+        table, row_indices = apply_vectorized_ops(
+            block.table,
+            ops,
+            on_shard_delta=on_shard_delta,
+            return_row_indices=True,
         )
+        return block.with_table(table, row_indices=row_indices)
 
     def _chunk_rows_for_budget() -> int:
         if (
@@ -392,7 +408,14 @@ def _execute_vector_segment(
                 )
                 split_rows = min(chunk_rows - 1, max(1, scaled_rows))
                 for start in range(0, chunk_rows, split_rows):
-                    queue.append(chunk.with_table(chunk.table.slice(start, split_rows)))
+                    queue.append(
+                        chunk.with_table(
+                            chunk.table.slice(start, split_rows),
+                            row_indices=range(
+                                start, min(start + split_rows, chunk_rows)
+                            ),
+                        )
+                    )
                 current_chunk_rows = min(current_chunk_rows, split_rows)
                 continue
 
@@ -404,10 +427,16 @@ def _execute_vector_segment(
                 split_rows = max(1, chunk_rows // 2)
                 queue.appendleft(
                     chunk.with_table(
-                        chunk.table.slice(split_rows, chunk_rows - split_rows)
+                        chunk.table.slice(split_rows, chunk_rows - split_rows),
+                        row_indices=range(split_rows, chunk_rows),
                     )
                 )
-                queue.appendleft(chunk.with_table(chunk.table.slice(0, split_rows)))
+                queue.appendleft(
+                    chunk.with_table(
+                        chunk.table.slice(0, split_rows),
+                        row_indices=range(0, split_rows),
+                    )
+                )
                 current_chunk_rows = min(current_chunk_rows, split_rows)
                 continue
 

--- a/src/refiner/execution/operators/vectorized.py
+++ b/src/refiner/execution/operators/vectorized.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal, overload
 
+import numpy as np
 import pyarrow as pa
 
 from refiner.execution.tracking.shards import (
@@ -10,10 +12,7 @@ from refiner.execution.tracking.shards import (
     counts_delta,
 )
 from refiner.pipeline.data.datatype import apply_dtypes_to_table
-from refiner.pipeline.data.tabular import (
-    filter_table,
-    repeat_scalar,
-)
+from refiner.pipeline.data.tabular import repeat_scalar
 from refiner.pipeline.expressions import eval_expr_arrow
 from refiner.pipeline.steps import (
     CastStep,
@@ -28,32 +27,45 @@ from refiner.pipeline.steps import (
 from refiner.worker.context import set_active_step_index
 from refiner.worker.metrics.api import log_throughput
 
+_ROW_INDEX_COLUMN = "__refiner_row_index"
+RowIndices = tuple[int, ...] | None
+
+
+def _identity_row_indices(row_indices: RowIndices, num_rows: int) -> RowIndices:
+    return None if row_indices == tuple(range(num_rows)) else row_indices
+
 
 def apply_vectorized_op(
     table: pa.Table,
     op: VectorizedOp,
     *,
     shard_counts: dict[str, int] | None = None,
-) -> tuple[pa.Table, dict[str, int] | None]:
+    row_indices: RowIndices = None,
+    return_row_indices: bool = False,
+) -> tuple[pa.Table, dict[str, int] | None, RowIndices]:
     if shard_counts is None:
         shard_counts = count_table_by_shard(table)
 
     if isinstance(op, SelectStep):
-        return table.select(list(op.columns)), None
+        return table.select(list(op.columns)), None, row_indices
 
     if isinstance(op, DropStep):
-        return table.drop_columns(list(op.columns)), None
+        return table.drop_columns(list(op.columns)), None, row_indices
 
     if isinstance(op, RenameStep):
         names = [op.mapping.get(name, name) for name in table.schema.names]
-        return table.rename_columns(names), None
+        return table.rename_columns(names), None, row_indices
 
     if isinstance(op, CastStep):
-        return apply_dtypes_to_table(
-            table,
-            op.dtypes,
-            preserve_metadata=False,
-        ), None
+        return (
+            apply_dtypes_to_table(
+                table,
+                op.dtypes,
+                preserve_metadata=False,
+            ),
+            None,
+            row_indices,
+        )
 
     if isinstance(op, WithColumnsStep):
         out = table
@@ -66,10 +78,34 @@ def apply_vectorized_op(
                 out = out.append_column(col_name, values)
             else:
                 out = out.set_column(idx, pa.field(col_name, values.type), values)
-        return out, None
+        return out, None, row_indices
 
     if isinstance(op, FilterExprStep):
-        next_table = filter_table(table, op.predicate)
+        mask = eval_expr_arrow(op.predicate, table)
+        if isinstance(mask, pa.Scalar):
+            keep_all = bool(mask.as_py())
+            next_table = table if keep_all else table.slice(0, 0)
+            next_row_indices = row_indices if keep_all else ()
+        else:
+            if isinstance(mask, pa.ChunkedArray):
+                mask = mask.combine_chunks()
+            next_table = table.filter(mask)
+            if return_row_indices:
+                kept = tuple(
+                    int(idx)
+                    for idx in np.flatnonzero(
+                        mask.fill_null(False).to_numpy(zero_copy_only=False)
+                    )
+                )
+                next_row_indices = (
+                    _identity_row_indices(kept, table.num_rows)
+                    if row_indices is None
+                    else tuple(row_indices[idx] for idx in kept)
+                )
+            else:
+                next_row_indices = None
+        if not return_row_indices:
+            next_row_indices = None
         next_shard_counts = count_table_by_shard(next_table)
         for shard_id in set(shard_counts) | set(next_shard_counts):
             previous = int(shard_counts.get(shard_id, 0))
@@ -91,19 +127,63 @@ def apply_vectorized_op(
                     unit="rows",
                     step_index=op.index,
                 )
-        return next_table, next_shard_counts
+        return next_table, next_shard_counts, next_row_indices
 
     if isinstance(op, FnTableStep):
+        if return_row_indices:
+            if _ROW_INDEX_COLUMN in table.column_names:
+                raise ValueError(f"{_ROW_INDEX_COLUMN} is an internal column")
+            lineage = range(table.num_rows) if row_indices is None else row_indices
+            table = table.append_column(
+                _ROW_INDEX_COLUMN,
+                pa.array(lineage, type=pa.int64()),
+            )
         with set_active_step_index(op.index):
             next_table = op.fn(table)
         if not isinstance(next_table, pa.Table):
             raise TypeError(
                 f"map_table() must return pa.Table, got {type(next_table)!r}"
             )
+        next_row_indices = None
+        if return_row_indices:
+            if _ROW_INDEX_COLUMN not in next_table.column_names:
+                raise ValueError(
+                    f"map_table() must preserve {_ROW_INDEX_COLUMN} for this input"
+                )
+            lineage_column = next_table.column(_ROW_INDEX_COLUMN).combine_chunks()
+            lineage = tuple(
+                int(value) for value in lineage_column.to_numpy(zero_copy_only=False)
+            )
+            next_row_indices = (
+                _identity_row_indices(lineage, table.num_rows)
+                if row_indices is None
+                else lineage
+            )
+            next_table = next_table.drop_columns([_ROW_INDEX_COLUMN])
         next_shard_counts = count_table_by_shard(next_table)
-        return next_table, next_shard_counts
+        return next_table, next_shard_counts, next_row_indices
 
     raise TypeError(f"Unsupported vectorized op: {type(op)!r}")
+
+
+@overload
+def apply_vectorized_ops(
+    table: pa.Table,
+    ops: Sequence[VectorizedOp],
+    *,
+    on_shard_delta: ShardDeltaFn | None = None,
+    return_row_indices: Literal[False] = False,
+) -> pa.Table: ...
+
+
+@overload
+def apply_vectorized_ops(
+    table: pa.Table,
+    ops: Sequence[VectorizedOp],
+    *,
+    on_shard_delta: ShardDeltaFn | None = None,
+    return_row_indices: Literal[True],
+) -> tuple[pa.Table, tuple[int, ...] | None]: ...
 
 
 def apply_vectorized_ops(
@@ -111,9 +191,14 @@ def apply_vectorized_ops(
     ops: Sequence[VectorizedOp],
     *,
     on_shard_delta: ShardDeltaFn | None = None,
-) -> pa.Table:
+    return_row_indices: bool = False,
+) -> pa.Table | tuple[pa.Table, tuple[int, ...] | None]:
     initial_shard_counts = count_table_by_shard(table)
     shard_counts = initial_shard_counts
+    # Some Tabular subclasses keep per-row side data outside the Arrow table.
+    # Row indices let them realign that side data after vectorized filters/reorders.
+    row_indices: RowIndices = None
+    initial_rows = table.num_rows
     for op in ops:
         for shard_id, count in shard_counts.items():
             log_throughput(
@@ -123,10 +208,12 @@ def apply_vectorized_ops(
                 unit="rows",
                 step_index=op.index,
             )
-        table, next_shard_counts = apply_vectorized_op(
+        table, next_shard_counts, row_indices = apply_vectorized_op(
             table,
             op,
             shard_counts=shard_counts,
+            row_indices=row_indices,
+            return_row_indices=return_row_indices,
         )
         if next_shard_counts is not None:
             shard_counts = next_shard_counts
@@ -134,7 +221,11 @@ def apply_vectorized_ops(
         delta = counts_delta(produced=shard_counts, consumed=initial_shard_counts)
         if delta:
             on_shard_delta(delta)
-    return table
+    if not return_row_indices:
+        return table
+    if table.num_rows == initial_rows:
+        row_indices = _identity_row_indices(row_indices, initial_rows)
+    return table, row_indices
 
 
 __all__ = [

--- a/src/refiner/pipeline/data/block.py
+++ b/src/refiner/pipeline/data/block.py
@@ -84,7 +84,8 @@ def _split_tabular_by_shard_scanned(
             tables_by_shard[shard_id] = block.with_table(data_table)
         else:
             tables_by_shard[shard_id] = block.with_table(
-                data_table.take(pa.array(indices, type=pa.int64()))
+                data_table.take(pa.array(indices, type=pa.int64())),
+                row_indices=indices.tolist(),
             )
     return dict(tables_by_shard), counts
 
@@ -116,11 +117,16 @@ def _split_tabular_by_shard_sorted(
             tables_by_shard[shard_id] = block.with_table(data_table)
         elif np.all(shard_indices[1:] == shard_indices[:-1] + 1):
             tables_by_shard[shard_id] = block.with_table(
-                data_table.slice(int(shard_indices[0]), int(shard_indices.size))
+                data_table.slice(int(shard_indices[0]), int(shard_indices.size)),
+                row_indices=range(
+                    int(shard_indices[0]),
+                    int(shard_indices[0] + shard_indices.size),
+                ),
             )
         else:
             tables_by_shard[shard_id] = block.with_table(
-                data_table.take(pa.array(shard_indices, type=pa.int64()))
+                data_table.take(pa.array(shard_indices, type=pa.int64())),
+                row_indices=shard_indices.tolist(),
             )
         start = end
     return dict(tables_by_shard), counts

--- a/src/refiner/pipeline/data/tabular.py
+++ b/src/refiner/pipeline/data/tabular.py
@@ -68,6 +68,10 @@ class Tabular:
     def schema(self) -> pa.Schema:
         return self.unit.schema
 
+    @property
+    def needs_row_indices(self) -> bool:
+        return False
+
     def column(self, name: str) -> pa.Array | pa.ChunkedArray:
         return self.unit.column(name)
 
@@ -86,7 +90,12 @@ class Tabular:
     def to_rows(self) -> list[Row]:
         return list(self)
 
-    def with_table(self, table: pa.Table) -> "Tabular":
+    def with_table(
+        self,
+        table: pa.Table,
+        *,
+        row_indices: Sequence[int] | None = None,
+    ) -> "Tabular":
         return Tabular(table)
 
 

--- a/src/refiner/robotics/lerobot_format/tabular.py
+++ b/src/refiner/robotics/lerobot_format/tabular.py
@@ -102,16 +102,39 @@ class LeRobotTabular(Tabular):
     def shard_idx(self) -> int | None:
         return self._tabular.shard_idx
 
-    def with_table(self, table: pa.Table) -> "LeRobotTabular":
-        if table.num_rows != len(self.metadata_by_row):
+    @property
+    def needs_row_indices(self) -> bool:
+        return True
+
+    def with_table(
+        self,
+        table: pa.Table,
+        *,
+        row_indices: Sequence[int] | None = None,
+    ) -> "LeRobotTabular":
+        if row_indices is None:
+            if table.num_rows != len(self.metadata_by_row):
+                raise ValueError(
+                    "LeRobotTabular side data length must match table row count"
+                )
+            metadata_by_row = self.metadata_by_row
+            frames_by_row = self.frames_by_row
+            roots_by_row = self.roots_by_row
+        elif len(row_indices) != table.num_rows:
             raise ValueError(
-                "LeRobotTabular side data length must match table row count"
+                "LeRobotTabular row index length must match table row count"
             )
+        else:
+            metadata_by_row = tuple(
+                self.metadata_by_row[int(idx)] for idx in row_indices
+            )
+            frames_by_row = tuple(self.frames_by_row[int(idx)] for idx in row_indices)
+            roots_by_row = tuple(self.roots_by_row[int(idx)] for idx in row_indices)
         return LeRobotTabular(
             self._tabular.with_table(table),
-            metadata_by_row=self.metadata_by_row,
-            frames_by_row=self.frames_by_row,
-            roots_by_row=self.roots_by_row,
+            metadata_by_row=metadata_by_row,
+            frames_by_row=frames_by_row,
+            roots_by_row=roots_by_row,
         )
 
     def __iter__(self) -> Iterator[Row]:

--- a/tests/pipeline/test_pipeline_vectorized_ops.py
+++ b/tests/pipeline/test_pipeline_vectorized_ops.py
@@ -151,18 +151,58 @@ def test_apply_vectorized_op_filter_without_explicit_shard_counts() -> None:
     table = pa.table(
         {SHARD_ID_COLUMN: pa.array(["s1", "s1", "s2"]), "x": pa.array([1, 2, 3])}
     )
-    out, counts = apply_vectorized_op(
+    out, counts, row_indices = apply_vectorized_op(
         table,
         FilterExprStep(predicate=col("x") >= 2, index=1),
     )
 
     assert out.to_pydict()["x"] == [2, 3]
     assert counts == {"s1": 1, "s2": 1}
+    assert row_indices is None
+
+
+def test_apply_vectorized_ops_can_return_filtered_row_indices() -> None:
+    table = pa.table({"x": pa.array([1, 2, 3, 4])})
+
+    out, row_indices = apply_vectorized_ops(
+        table,
+        [FilterExprStep(predicate=col("x").is_in([2, 4]), index=1)],
+        return_row_indices=True,
+    )
+
+    assert out.to_pydict()["x"] == [2, 4]
+    assert row_indices == (1, 3)
+
+
+def test_apply_vectorized_ops_omits_identity_row_indices() -> None:
+    table = pa.table({"x": pa.array([1, 2])})
+
+    out, row_indices = apply_vectorized_ops(
+        table,
+        [FilterExprStep(predicate=col("x") >= 1, index=1)],
+        return_row_indices=True,
+    )
+
+    assert out.to_pydict()["x"] == [1, 2]
+    assert row_indices is None
+
+
+def test_apply_vectorized_ops_keeps_empty_filtered_row_indices() -> None:
+    table = pa.table({"x": pa.array([1, 2])})
+
+    out, row_indices = apply_vectorized_ops(
+        table,
+        [FilterExprStep(predicate=col("x") > 10, index=1)],
+        return_row_indices=True,
+    )
+
+    assert out.to_pydict()["x"] == []
+    assert row_indices == ()
 
 
 def test_apply_vectorized_op_map_table_without_explicit_shard_counts() -> None:
     table = pa.table({SHARD_ID_COLUMN: pa.array(["s1", "s2"]), "x": pa.array([1, 2])})
-    out, counts = apply_vectorized_op(
+    out, counts, row_indices = apply_vectorized_op(
         table,
         FnTableStep(
             fn=lambda current: current.append_column("y", pa.array([10, 20])), index=1
@@ -171,6 +211,40 @@ def test_apply_vectorized_op_map_table_without_explicit_shard_counts() -> None:
 
     assert out.to_pydict()["y"] == [10, 20]
     assert counts == {"s1": 1, "s2": 1}
+    assert row_indices is None
+
+
+def test_apply_vectorized_ops_tracks_map_table_lineage() -> None:
+    table = pa.table({"x": pa.array([1, 2, 3])})
+
+    out, row_indices = apply_vectorized_ops(
+        table,
+        [
+            FnTableStep(
+                fn=lambda current: current.sort_by([("x", "descending")]), index=1
+            )
+        ],
+        return_row_indices=True,
+    )
+
+    assert out.to_pydict()["x"] == [3, 2, 1]
+    assert row_indices == (2, 1, 0)
+
+
+def test_apply_vectorized_ops_requires_map_table_lineage_when_tracking() -> None:
+    table = pa.table({"x": pa.array([1, 2])})
+
+    with pytest.raises(ValueError, match="must preserve __refiner_row_index"):
+        apply_vectorized_ops(
+            table,
+            [
+                FnTableStep(
+                    fn=lambda current: current.drop_columns(["__refiner_row_index"]),
+                    index=1,
+                )
+            ],
+            return_row_indices=True,
+        )
 
 
 def test_map_table_does_not_fall_back_to_row_execution(monkeypatch) -> None:

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -9,6 +9,7 @@ import pyarrow.parquet as pq
 import pytest
 from typing import cast
 
+import refiner as mdr
 from refiner.video import VideoFile
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
@@ -188,6 +189,50 @@ def test_lerobot_reader_exposes_episode_shard_planning_knobs(tmp_path: Path) -> 
     shards = reader.list_shards()
 
     assert len(shards) == 2
+
+
+def test_lerobot_vectorized_filter_realigns_side_data(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = (
+        mdr.read_lerobot(str(root)).filter(mdr.col("episode_index") == 1).materialize()
+    )
+
+    assert len(rows) == 1
+    row = cast(LeRobotRow, rows[0])
+    assert int(row["episode_index"]) == 1
+    frame_rows = row["frames"].to_rows()
+    assert [int(frame["episode_index"]) for frame in frame_rows] == [1, 1]
+    assert [int(frame["index"]) for frame in frame_rows] == [2, 3]
+
+
+def test_lerobot_row_preserving_vectorized_ops_keep_side_data(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = mdr.read_lerobot(str(root)).select("episode_index").materialize()
+
+    assert [int(row["episode_index"]) for row in rows] == [0, 1]
+    frame_rows = [cast(LeRobotRow, row)["frames"].to_rows() for row in rows]
+    assert int(frame_rows[0][0]["episode_index"]) == 0
+    assert int(frame_rows[1][0]["episode_index"]) == 1
+
+
+def test_lerobot_map_table_can_reorder_rows_with_lineage(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = (
+        mdr.read_lerobot(str(root))
+        .map_table(lambda table: table.sort_by([("episode_index", "descending")]))
+        .materialize()
+    )
+
+    assert [int(row["episode_index"]) for row in rows] == [1, 0]
+    frame_rows = [cast(LeRobotRow, row)["frames"].to_rows() for row in rows]
+    assert int(frame_rows[0][0]["episode_index"]) == 1
+    assert int(frame_rows[1][0]["episode_index"]) == 0
 
 
 def test_lerobot_reader_describe_uses_dataset_roots(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add optional row-index tracking to vectorized table execution
- use row indices to realign LeRobot side data after filters/reorders without filtering episode frames
- keep tracking off for normal Tabular blocks and row-preserving LeRobot segments

Fixes #137.

## Validation

- uv run pytest tests/pipeline/test_pipeline_vectorized_ops.py tests/readers/test_lerobot_reader.py
- uv run pytest tests/pipeline tests/readers/test_lerobot_reader.py tests/worker/test_runner.py
- uv run ruff check .
- uv run ty check
- git diff --check

## Review

Local PR review pass found no blocking findings. Residual risk is arbitrary map_table on LeRobotTabular; it must preserve __refiner_row_index when row lineage tracking is active, and this is covered by tests.