### PR TITLE
Add array-backed video source

### DIFF
--- a/src/refiner/pipeline/utils/cache/decoder_cache.py
+++ b/src/refiner/pipeline/utils/cache/decoder_cache.py
@@ -4,13 +4,15 @@ import atexit
 import asyncio
 from dataclasses import dataclass
 from fractions import Fraction
-from functools import partial
-from typing import IO, Any, cast
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from refiner.execution.asyncio.runtime import io_executor
 from refiner.io import DataFile
 from refiner.pipeline.utils.cache.lease_cache import LeaseCache
 from refiner.utils import check_required_dependencies
+
+if TYPE_CHECKING:
+    from refiner.video.types import VideoSource
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,12 +60,12 @@ class OpenedVideoSourceCache(LeaseCache[str, OpenedVideoSource]):
         self,
         key: str,
     ) -> tuple[OpenedVideoSource, int]:
+        from refiner.video.types import VideoFile
+
         source = await asyncio.get_running_loop().run_in_executor(
             io_executor(),
-            partial(
-                _open_video_source,
-                uri=key,
-            ),
+            open_video_source,
+            VideoFile(DataFile.resolve(key)),
         )
         return source, 0
 
@@ -106,13 +108,11 @@ def _probe_video_source(
     )
 
 
-def _open_video_source(
-    *,
-    uri: str,
-) -> OpenedVideoSource:
+def open_video_source(video: "VideoSource") -> OpenedVideoSource:
     import av
 
-    input_file = DataFile.resolve(uri).open("rb")
+    source_name = getattr(video, "uri", type(video).__name__)
+    input_file = video.open()
     try:
         container = av.open(input_file, mode="r")
         stream = cast(
@@ -122,12 +122,12 @@ def _open_video_source(
         if stream is None:
             container.close()
             input_file.close()
-            raise ValueError(f"Video source has no video stream for {uri!r}")
+            raise ValueError(f"Video source has no video stream for {source_name!r}")
         probe = _probe_video_source(
             container=container,
         )
         return OpenedVideoSource(
-            uri=uri,
+            uri=str(source_name),
             probe=probe,
             input_file=input_file,
             container=container,
@@ -190,5 +190,6 @@ __all__ = [
     "OpenedVideoSourceCache",
     "VideoSourceProbe",
     "get_opened_video_source_cache",
+    "open_video_source",
     "reset_opened_video_source_cache",
 ]

--- a/src/refiner/video/__init__.py
+++ b/src/refiner/video/__init__.py
@@ -22,7 +22,7 @@ from refiner.video.transcode import (
     TranscodeWriter,
     VideoTranscodeConfig,
 )
-from refiner.video.types import VideoFile
+from refiner.video.types import VideoFrameArray, VideoFile, VideoSource
 from refiner.video.writer import (
     VideoStreamWriter,
     WrittenVideo,
@@ -33,10 +33,12 @@ __all__ = [
     "DecodedFrameWindow",
     "DecodedVideoFrame",
     "FrameObserver",
+    "VideoFrameArray",
     "PreparedVideoSource",
     "RemuxWriter",
     "TranscodeWriter",
     "VideoFile",
+    "VideoSource",
     "VideoPtsAlignment",
     "VideoStreamWriter",
     "VideoTranscodeConfig",

--- a/src/refiner/video/arrays.py
+++ b/src/refiner/video/arrays.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def coerce_frame_array(frames: Any) -> np.ndarray:
+    array = np.asarray(frames)
+    if array.ndim == 4 and array.dtype != object:
+        return validate_frame_array(array)
+
+    try:
+        array = np.stack([np.asarray(frame) for frame in frames])
+    except TypeError as exc:
+        raise TypeError("frames must be a [T, H, W, C] array or iterable") from exc
+    except ValueError as exc:
+        raise ValueError("frames must have a stable [H, W, C] shape") from exc
+    return validate_frame_array(array)
+
+
+def validate_frame_array(array: np.ndarray) -> np.ndarray:
+    if array.ndim != 4:
+        raise ValueError("frames must have shape [T, H, W, C]")
+    if array.shape[0] <= 0:
+        raise ValueError("frames must contain at least one frame")
+    if array.shape[1] <= 0 or array.shape[2] <= 0:
+        raise ValueError("frames must have non-empty height and width")
+    if array.shape[3] not in {1, 3, 4}:
+        raise ValueError("frames must have 1, 3, or 4 channels")
+    return np.ascontiguousarray(array)
+
+
+def rgb24_frame_array(frame: np.ndarray) -> np.ndarray:
+    if frame.ndim != 3:
+        raise ValueError("video frames must have shape [H, W, C]")
+    if frame.shape[2] == 1:
+        frame = np.repeat(frame, 3, axis=2)
+    elif frame.shape[2] == 4:
+        frame = frame[:, :, :3]
+    elif frame.shape[2] != 3:
+        raise ValueError("video frames must have 1, 3, or 4 channels")
+
+    if frame.dtype == np.uint8:
+        return np.ascontiguousarray(frame)
+
+    if np.issubdtype(frame.dtype, np.floating):
+        finite = frame[np.isfinite(frame)]
+        if finite.size and float(finite.min()) >= 0.0 and float(finite.max()) <= 1.0:
+            frame = frame * 255.0
+    return np.ascontiguousarray(np.clip(frame, 0, 255).astype(np.uint8))
+
+
+__all__ = [
+    "coerce_frame_array",
+    "rgb24_frame_array",
+    "validate_frame_array",
+]

--- a/src/refiner/video/decode.py
+++ b/src/refiner/video/decode.py
@@ -17,7 +17,7 @@ from refiner.video.remux import (
 if TYPE_CHECKING:
     import av
 
-    from refiner.video.types import VideoFile
+    from refiner.video.types import VideoSource
     from refiner.video.transcode import VideoTranscodeConfig
 
 _FRAME_TIMESTAMP_EPSILON_S = 1e-6
@@ -46,7 +46,7 @@ class _NonClosingBytesIO(io.BytesIO):
 
 
 async def export_clip(
-    video: VideoFile,
+    video: VideoSource,
     *,
     force_transcode: bool = False,
     transcode_config: VideoTranscodeConfig | None = None,
@@ -91,7 +91,7 @@ async def export_clip(
 
 
 async def iter_frames(
-    video: VideoFile,
+    video: VideoSource,
 ) -> AsyncIterator[DecodedVideoFrame]:
     prepared = await prepare_video_source(video=video)
     try:
@@ -116,7 +116,7 @@ async def iter_frames(
 
 
 async def iter_frame_windows(
-    video: VideoFile,
+    video: VideoSource,
     *,
     offsets: Sequence[int],
     stride: int = 1,

--- a/src/refiner/video/encode.py
+++ b/src/refiner/video/encode.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import io
+
+import numpy as np
+
+from typing import IO
+
+from refiner.utils import check_required_dependencies
+from refiner.video.arrays import rgb24_frame_array
+
+
+class NonClosingBytesIO(io.BytesIO):
+    def close(self) -> None:
+        pass
+
+
+def encode_frame_array_to_mp4(frames: np.ndarray, *, fps: int) -> bytes:
+    check_required_dependencies("video frame array encoding", ["av"], dist="video")
+    import av
+
+    output = NonClosingBytesIO()
+    container = av.open(output, mode="w", format="mp4")
+    try:
+        stream = container.add_stream("mpeg4", rate=int(fps))
+        stream.width = int(frames.shape[2])
+        stream.height = int(frames.shape[1])
+        stream.pix_fmt = "yuv420p"
+
+        for frame_array in frames:
+            frame = av.VideoFrame.from_ndarray(
+                rgb24_frame_array(frame_array),
+                format="rgb24",
+            )
+            for packet in stream.encode(frame):
+                container.mux(packet)
+
+        for packet in stream.encode(None):
+            container.mux(packet)
+    finally:
+        container.close()
+    return output.getvalue()
+
+
+def open_frame_array_as_mp4(frames: np.ndarray, *, fps: int) -> IO[bytes]:
+    return io.BytesIO(encode_frame_array_to_mp4(frames, fps=fps))
+
+
+def open_video_bytes(data: bytes) -> IO[bytes]:
+    return io.BytesIO(data)
+
+
+__all__ = [
+    "NonClosingBytesIO",
+    "encode_frame_array_to_mp4",
+    "open_frame_array_as_mp4",
+    "open_video_bytes",
+]

--- a/src/refiner/video/remux.py
+++ b/src/refiner/video/remux.py
@@ -1,31 +1,34 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import IO, Any
 from typing import TYPE_CHECKING
 
+from refiner.execution.asyncio.runtime import io_executor
 from refiner.io import DataFolder
 from refiner.pipeline.utils.cache.decoder_cache import (
     OpenedVideoSource,
     VideoSourceProbe,
     get_opened_video_source_cache,
+    open_video_source,
     reset_opened_video_source_cache,
 )
 from refiner.pipeline.utils.cache.lease_cache import CacheLease
 from refiner.utils import check_required_dependencies
 
 if TYPE_CHECKING:
-    from refiner.video.types import VideoFile
+    from refiner.video.types import VideoSource
 
 _SEGMENTED_MP4_MOVFLAGS = "frag_keyframe+default_base_moof"
 
 
-def video_from_timestamp_s(video: VideoFile) -> float:
-    return float(video.from_timestamp_s or 0.0)
+def video_from_timestamp_s(video: "VideoSource") -> float:
+    return float(getattr(video, "from_timestamp_s", None) or 0.0)
 
 
-def video_to_timestamp_s(video: VideoFile) -> float | None:
-    return video.to_timestamp_s
+def video_to_timestamp_s(video: "VideoSource") -> float | None:
+    return getattr(video, "to_timestamp_s", None)
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,8 +40,9 @@ class VideoPtsAlignment:
 
 @dataclass(slots=True)
 class PreparedVideoSource:
-    lease: CacheLease[str, OpenedVideoSource]
-    video: VideoFile
+    lease: CacheLease[str, OpenedVideoSource] | None
+    source: OpenedVideoSource | None
+    video: VideoSource
     uri: str
     probe: VideoSourceProbe | None
     alignment: VideoPtsAlignment | None
@@ -46,7 +50,11 @@ class PreparedVideoSource:
     stream: Any
 
     def close(self) -> None:
-        self.lease.release()
+        if self.lease is not None:
+            self.lease.release()
+            return
+        if self.source is not None:
+            self.source.close()
 
 
 class RemuxWriter:
@@ -188,7 +196,7 @@ def prepared_source_is_remuxable(prepared: PreparedVideoSource) -> bool:
 def probe_for_remux(
     *,
     probe: VideoSourceProbe | None,
-    video: VideoFile,
+    video: "VideoSource",
 ) -> tuple[VideoSourceProbe | None, VideoPtsAlignment | None]:
     if probe is None:
         return None, None
@@ -209,11 +217,23 @@ def probe_for_remux(
 
 async def prepare_video_source(
     *,
-    video: VideoFile,
+    video: "VideoSource",
 ) -> PreparedVideoSource:
+    from refiner.video.types import VideoFile
+
     check_required_dependencies("video decoding", ["av"], dist="video")
-    lease = await get_opened_video_source_cache().acquire(video.uri)
-    source = lease.resource
+    if isinstance(video, VideoFile):
+        lease = await get_opened_video_source_cache().acquire(video.uri)
+        source = lease.resource
+        source_owner: OpenedVideoSource | None = None
+    else:
+        lease = None
+        source = await asyncio.get_running_loop().run_in_executor(
+            io_executor(),
+            open_video_source,
+            video,
+        )
+        source_owner = source
     try:
         start_pts = 0
         if source.stream.time_base is not None:
@@ -242,6 +262,7 @@ async def prepare_video_source(
         probe, alignment = probe_for_remux(probe=source.probe, video=video)
         return PreparedVideoSource(
             lease=lease,
+            source=source_owner,
             video=video,
             uri=source.uri,
             probe=probe,
@@ -250,7 +271,10 @@ async def prepare_video_source(
             stream=source.stream,
         )
     except Exception:
-        lease.release()
+        if lease is not None:
+            lease.release()
+        elif source_owner is not None:
+            source_owner.close()
         raise
 
 

--- a/src/refiner/video/transcode.py
+++ b/src/refiner/video/transcode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from fractions import Fraction
 import os
@@ -9,6 +9,7 @@ import numpy as np
 
 from refiner.io import DataFolder
 from refiner.utils import check_required_dependencies
+from refiner.video.arrays import rgb24_frame_array
 from refiner.video.decode import _iter_selected_frames
 from refiner.video.remux import (
     PreparedVideoSource,
@@ -178,6 +179,29 @@ class TranscodeWriter:
 
         if self.frames_written <= 0 or self.duration_s <= from_timestamp:
             raise ValueError("Video segment contains no decodable frames")
+
+        return from_timestamp, self.duration_s
+
+    def append_frame_arrays(
+        self,
+        frames: Iterable[np.ndarray],
+        *,
+        frame_observer: FrameObserver | None = None,
+    ) -> tuple[float, float]:
+        import av
+
+        from_timestamp = self.duration_s
+        segment_frames = 0
+        for frame_index, frame_array in enumerate(frames):
+            rgb = rgb24_frame_array(frame_array)
+            self.ensure_stream(width=rgb.shape[1], height=rgb.shape[0])
+            if frame_observer is not None:
+                frame_observer(frame_index, rgb)
+            self.write_frame(av.VideoFrame.from_ndarray(rgb, format="rgb24"))
+            segment_frames += 1
+
+        if segment_frames <= 0 or self.duration_s <= from_timestamp:
+            raise ValueError("Video segment contains no frames")
 
         return from_timestamp, self.duration_s
 

--- a/src/refiner/video/types.py
+++ b/src/refiner/video/types.py
@@ -1,18 +1,39 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
-from dataclasses import dataclass
-from typing import IO
+from collections.abc import AsyncIterator, Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import IO, TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import numpy as np
 
 from refiner.io import DataFile
-from refiner.video.decode import (
-    DecodedFrameWindow,
-    DecodedVideoFrame,
-    export_clip,
-    iter_frame_windows,
-    iter_frames,
-)
-from refiner.video.transcode import VideoTranscodeConfig
+from refiner.video.arrays import coerce_frame_array
+
+if TYPE_CHECKING:
+    from refiner.video.decode import DecodedFrameWindow, DecodedVideoFrame
+    from refiner.video.transcode import VideoTranscodeConfig
+
+
+@runtime_checkable
+class VideoSource(Protocol):
+    def open(self) -> IO[bytes]: ...
+
+    async def export_clip(
+        self,
+        *,
+        force_transcode: bool = False,
+        transcode_config: VideoTranscodeConfig | None = None,
+    ) -> bytes: ...
+
+    def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]: ...
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,8 +46,8 @@ class VideoFile:
     def uri(self) -> str:
         return str(self.data_file)
 
-    def open(self, mode: str = "rb") -> IO[bytes]:
-        return self.data_file.open(mode=mode)
+    def open(self) -> IO[bytes]:
+        return self.data_file.open(mode="rb")
 
     async def export_clip(
         self,
@@ -34,6 +55,8 @@ class VideoFile:
         force_transcode: bool = False,
         transcode_config: VideoTranscodeConfig | None = None,
     ) -> bytes:
+        from refiner.video.decode import export_clip
+
         return await export_clip(
             self,
             force_transcode=force_transcode,
@@ -41,6 +64,8 @@ class VideoFile:
         )
 
     def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
+        from refiner.video.decode import iter_frames
+
         return iter_frames(self)
 
     def iter_frame_windows(
@@ -50,6 +75,8 @@ class VideoFile:
         stride: int = 1,
         drop_incomplete: bool = True,
     ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
         return iter_frame_windows(
             self,
             offsets=offsets,
@@ -58,4 +85,95 @@ class VideoFile:
         )
 
 
-__all__ = ["VideoFile"]
+@dataclass(frozen=True, slots=True, eq=False)
+class VideoFrameArray:
+    frames: Any = field(repr=False, compare=False)
+    fps: int = 30
+    _array: np.ndarray = field(init=False, repr=False)
+    _encoded_bytes: bytes | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        array = coerce_frame_array(self.frames)
+        if self.fps <= 0:
+            raise ValueError("fps must be > 0")
+        object.__setattr__(self, "_array", array)
+
+    @property
+    def frame_count(self) -> int:
+        return int(self._array.shape[0])
+
+    @property
+    def height(self) -> int:
+        return int(self._array.shape[1])
+
+    @property
+    def width(self) -> int:
+        return int(self._array.shape[2])
+
+    @property
+    def channels(self) -> int:
+        return int(self._array.shape[3])
+
+    @property
+    def shape(self) -> tuple[int, int, int, int]:
+        t, h, w, c = self._array.shape
+        return int(t), int(h), int(w), int(c)
+
+    def __iter__(self) -> Iterator[np.ndarray]:
+        return self.iter_frame_arrays()
+
+    def iter_frame_arrays(self) -> Iterator[np.ndarray]:
+        for index in range(self.frame_count):
+            yield self._array[index]
+
+    def open(self) -> IO[bytes]:
+        from refiner.video.encode import open_video_bytes
+
+        return open_video_bytes(self.to_bytes())
+
+    def to_bytes(self) -> bytes:
+        from refiner.video.encode import encode_frame_array_to_mp4
+
+        encoded = self._encoded_bytes
+        if encoded is None:
+            encoded = encode_frame_array_to_mp4(self._array, fps=self.fps)
+            object.__setattr__(self, "_encoded_bytes", encoded)
+        return encoded
+
+    async def export_clip(
+        self,
+        *,
+        force_transcode: bool = False,
+        transcode_config: VideoTranscodeConfig | None = None,
+    ) -> bytes:
+        from refiner.video.decode import export_clip
+
+        return await export_clip(
+            self,
+            force_transcode=force_transcode,
+            transcode_config=transcode_config,
+        )
+
+    def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
+        from refiner.video.decode import iter_frames
+
+        return iter_frames(self)
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
+        return iter_frame_windows(
+            self,
+            offsets=offsets,
+            stride=stride,
+            drop_incomplete=drop_incomplete,
+        )
+
+
+__all__ = ["VideoFrameArray", "VideoFile", "VideoSource"]

--- a/src/refiner/video/writer.py
+++ b/src/refiner/video/writer.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from typing import Literal
 from dataclasses import dataclass, field
 from functools import partial
+from typing import Literal
 
 from refiner.execution.asyncio.runtime import io_executor
 from refiner.io import DataFolder
@@ -21,7 +21,7 @@ from refiner.video.transcode import (
     TranscodeWriter,
     VideoTranscodeConfig,
 )
-from refiner.video.types import VideoFile
+from refiner.video.types import VideoFrameArray, VideoSource
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,11 +59,18 @@ class VideoStreamWriter:
 
     async def write_video(
         self,
-        video: VideoFile,
+        video: VideoSource,
         *,
         frame_observer: FrameObserver | None = None,
         force_transcode: bool = False,
     ) -> WrittenVideo:
+        if isinstance(video, VideoFrameArray):
+            _ = force_transcode
+            return await self._commit_video_frame_array(
+                video,
+                frame_observer=frame_observer,
+            )
+
         prepared = await prepare_video_source(video=video)
         try:
             return await self._commit(
@@ -103,6 +110,53 @@ class VideoStreamWriter:
                     force_transcode=force_transcode,
                 ),
             )
+
+    async def _commit_video_frame_array(
+        self,
+        video: VideoFrameArray,
+        *,
+        frame_observer: FrameObserver | None,
+    ) -> WrittenVideo:
+        async with self._commit_lock:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                io_executor(),
+                partial(
+                    self._commit_video_frame_array_sync,
+                    video,
+                    frame_observer=frame_observer,
+                ),
+            )
+
+    def _commit_video_frame_array_sync(
+        self,
+        video: VideoFrameArray,
+        *,
+        frame_observer: FrameObserver | None,
+    ) -> WrittenVideo:
+        writer = self._ensure_transcode_writer(video.fps)
+        file_index = self._next_file_index
+        from_timestamp, to_timestamp = writer.append_frame_arrays(
+            video.iter_frame_arrays(),
+            frame_observer=frame_observer,
+        )
+        if writer.stream is None:
+            raise RuntimeError("Transcode writer did not initialize an output stream")
+        segment = WrittenVideoSegment(
+            stream_key=self.stream_key,
+            file_index=file_index,
+            output_rel=self._current_output_rel,
+            from_timestamp=from_timestamp,
+            to_timestamp=to_timestamp,
+            fps=int(writer.fps),
+            width=int(writer.stream.width),
+            height=int(writer.stream.height),
+            codec=self.transcode_config.codec,
+            pix_fmt=self.transcode_config.pix_fmt,
+        )
+        if writer.size_bytes >= self.video_bytes_limit:
+            self._rotate_writer()
+        return WrittenVideo(segment=segment, mode="transcode")
 
     def _commit_sync(
         self,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 import os
 from refiner.io import DataFile
-from refiner.video import VideoFile
 from refiner.pipeline.utils.cache.file_cache import get_media_cache
 from refiner.pipeline.utils.cache.lease_cache import LeaseCache
 
 
 def test_media_cache_async_context_reuses_download() -> None:
     uri = "memory://context-manager.bin"
-    with VideoFile(DataFile.resolve(uri)).open("wb") as f:
+    with DataFile.resolve(uri).open(mode="wb") as f:
         f.write(b"context-manager")
 
     cache = get_media_cache("context-manager")
@@ -29,7 +28,7 @@ def test_media_cache_async_context_reuses_download() -> None:
 
 def test_media_cache_file_lease_can_be_acquired_and_released_twice() -> None:
     uri = "memory://lease-same-file.bin"
-    with VideoFile(DataFile.resolve(uri)).open("wb") as f:
+    with DataFile.resolve(uri).open(mode="wb") as f:
         f.write(b"lease-reuse")
 
     cache = get_media_cache("lease-same-file")

--- a/tests/test_video_frame_array.py
+++ b/tests/test_video_frame_array.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from refiner.io import DataFolder
+from refiner.video import VideoFrameArray, VideoStreamWriter, VideoTranscodeConfig
+
+
+async def _collect_frame_shapes(video: VideoFrameArray) -> list[tuple[int, int]]:
+    return [(frame.height, frame.width) async for frame in video.iter_frames()]
+
+
+def test_video_frame_array_normalizes_frame_sequence() -> None:
+    frames = [
+        np.zeros((8, 10, 3), dtype=np.uint8),
+        np.ones((8, 10, 3), dtype=np.uint8),
+    ]
+
+    video = VideoFrameArray(frames, fps=12)
+
+    assert video.shape == (2, 8, 10, 3)
+    assert video.frame_count == 2
+    assert video.fps == 12
+    assert len(list(video.iter_frame_arrays())) == 2
+
+
+def test_video_frame_array_equality_is_identity() -> None:
+    frames = np.zeros((2, 8, 10, 3), dtype=np.uint8)
+
+    first = VideoFrameArray(frames, fps=12)
+    second = VideoFrameArray(frames.copy(), fps=12)
+
+    assert first == first
+    assert first != second
+
+
+def test_video_frame_array_open_returns_encoded_video_bytes() -> None:
+    pytest.importorskip("av")
+    frames = np.zeros((3, 8, 10, 3), dtype=np.uint8)
+    frames[:, :, :, 0] = 200
+    video = VideoFrameArray(frames, fps=10)
+
+    with video.open() as stream:
+        assert stream.read(8)
+
+    assert asyncio.run(_collect_frame_shapes(video)) == [(8, 10), (8, 10), (8, 10)]
+
+
+def test_video_stream_writer_accepts_video_frame_array(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("av")
+    frames = np.zeros((4, 16, 16, 3), dtype=np.uint8)
+    frames[:, :, :, 1] = 180
+    video = VideoFrameArray(frames, fps=10)
+    monkeypatch.setattr(
+        VideoFrameArray,
+        "open",
+        lambda *_args, **_kwargs: pytest.fail("writer should not encode/decode arrays"),
+    )
+    output = DataFolder.resolve(str(tmp_path / "out"))
+    writer = VideoStreamWriter(
+        folder=output,
+        stream_key="front",
+        transcode_config=VideoTranscodeConfig(codec="mpeg4", pix_fmt="yuv420p"),
+        video_bytes_limit=1024 * 1024,
+        output_rel_template="videos/{stream_key}/file-{file_index:03d}.mp4",
+    )
+
+    written = asyncio.run(writer.write_video(video, force_transcode=True))
+    writer.close()
+
+    assert written.mode == "transcode"
+    assert written.segment.stream_key == "front"
+    assert written.segment.fps == 10
+    assert written.segment.width == 16
+    assert written.segment.height == 16
+    assert (tmp_path / "out" / "videos" / "front" / "file-000.mp4").exists()
+
+
+def test_video_stream_writer_writes_all_video_frame_array_frames(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("av")
+    frames = np.zeros((4, 16, 16, 3), dtype=np.uint8)
+    video = VideoFrameArray(frames, fps=10)
+    output = DataFolder.resolve(str(tmp_path / "out"))
+    writer = VideoStreamWriter(
+        folder=output,
+        stream_key="front",
+        transcode_config=VideoTranscodeConfig(codec="mpeg4", pix_fmt="yuv420p"),
+        video_bytes_limit=1024 * 1024,
+        output_rel_template="videos/{stream_key}/file-{file_index:03d}.mp4",
+    )
+
+    written = asyncio.run(writer.write_video(video))
+    writer.close()
+
+    assert written.segment.from_timestamp == pytest.approx(0.0)
+    assert written.segment.to_timestamp == pytest.approx(0.4)


### PR DESCRIPTION
## Summary
- add ArrayVideo as an in-memory [T, H, W, C] / iterable-frame video source
- let existing decode/export/writer paths consume structural VideoSource objects while preserving VideoFile caching
- add focused tests for ArrayVideo normalization, encoded open()/decode, and VideoStreamWriter integration

## Validation
- uv run ruff check .
- uv run ty check
- uv run python -m pytest tests/test_array_video.py

## Scope
- no robotics-row adapter API changes
- no to_robot_row/to_robot_rows changes
- no LeRobot row API changes