### PR TITLE
Implement cloud stage payload uploads

### DIFF
--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -80,6 +80,8 @@ Returned result includes:
 - `stage_index`
 - `status`
 
+Note: cloud launch setup may fail due to payload uploads before a cloud job is even created.
+
 ### Cloud options
 
 - `num_workers`: requested logical worker count

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -15,13 +15,18 @@ from refiner.cli.run.modes import (
 from refiner.cli.ui import stdin_is_interactive, stdout_is_interactive
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
+    CloudFile,
+    CloudFileCompleteRequestItem,
+    CloudFileUploadInstruction,
+    CloudFileUploadRequestItem,
+    CloudFileUploadStatus,
     CloudRunCreateRequest,
     CloudRuntimeConfig,
     MacrodataApiError,
     MacrodataClient,
     StagePayload,
-    serialize_pipeline_inline,
 )
+from refiner.platform.client.serialize import PreparedPipelinePayload
 from refiner.platform.manifest import refiner_ref_exists_on_remote
 from refiner.launchers.secrets import SecretInput, resolve_env_mapping
 from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
@@ -33,9 +38,11 @@ from refiner.launchers.base import BaseLauncher
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
+    from refiner.pipeline.planning import PlannedStage
 
 
 _FALLBACK_ENV_VAR = "MACRODATA_FALLBACK_TO_LATEST_PYPI"
+_CLOUD_FILE_BATCH_SIZE = 100
 _UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
     re.IGNORECASE,
@@ -173,6 +180,90 @@ class CloudLauncher(BaseLauncher):
             f"Set {_FALLBACK_ENV_VAR}=1 to allow fallback to the latest PyPI version."
         )
 
+    @staticmethod
+    def _upload_instructions_by_file(
+        instructions: list[CloudFileUploadInstruction],
+        *,
+        expected_files: set[tuple[str, int]],
+    ) -> dict[tuple[str, int], CloudFileUploadInstruction]:
+        instructions_by_file: dict[tuple[str, int], CloudFileUploadInstruction] = {}
+        for instruction in instructions:
+            file_key = (instruction.sha256, instruction.size_bytes)
+            if file_key in expected_files:
+                instructions_by_file[file_key] = instruction
+
+        missing_files = sorted(expected_files - instructions_by_file.keys())
+        if missing_files:
+            sha256, size_bytes = missing_files[0]
+            raise ValueError(
+                "Cloud file upload URL response did not return instructions "
+                f"for sha256/size_bytes: {sha256}/{size_bytes}"
+            )
+        return instructions_by_file
+
+    @staticmethod
+    def _upload_stage_payloads(
+        *,
+        client: MacrodataClient,
+        stages: list[PlannedStage],
+    ) -> dict[int, CloudFile]:
+        serialized_payloads = [
+            PreparedPipelinePayload.from_pipeline(stage.pipeline) for stage in stages
+        ]
+        serialized_by_file = {}
+        for serialized in serialized_payloads:
+            file_key = (serialized.sha256, serialized.size_bytes)
+            serialized_by_file.setdefault(file_key, serialized)
+
+        instructions_by_file: dict[tuple[str, int], CloudFileUploadInstruction] = {}
+        serialized_items = list(serialized_by_file.items())
+        for index in range(0, len(serialized_items), _CLOUD_FILE_BATCH_SIZE):
+            batch = serialized_items[index : index + _CLOUD_FILE_BATCH_SIZE]
+            upload_response = client.cloud_create_file_upload_urls(
+                files=[
+                    CloudFileUploadRequestItem(
+                        sha256=serialized.sha256,
+                        size_bytes=serialized.size_bytes,
+                    )
+                    for _, serialized in batch
+                ],
+                object_ttl_secs=None,
+            )
+            instructions_by_file.update(
+                CloudLauncher._upload_instructions_by_file(
+                    upload_response.files,
+                    expected_files={file_key for file_key, _ in batch},
+                )
+            )
+
+        completed_files: list[CloudFileCompleteRequestItem] = []
+        for file_key, instruction in instructions_by_file.items():
+            if instruction.status is CloudFileUploadStatus.EXISTS:
+                continue
+            serialized = serialized_by_file[file_key]
+            client.cloud_upload_file(
+                instruction=instruction,
+                payload_bytes=serialized.payload_bytes,
+            )
+            completed_files.append(
+                CloudFileCompleteRequestItem(file_id=instruction.file_id)
+            )
+
+        for index in range(0, len(completed_files), _CLOUD_FILE_BATCH_SIZE):
+            client.cloud_complete_files(
+                files=completed_files[index : index + _CLOUD_FILE_BATCH_SIZE],
+                object_ttl_secs=None,
+            )
+
+        return {
+            stage.index: CloudFile(
+                file_id=instructions_by_file[
+                    (serialized.sha256, serialized.size_bytes)
+                ].file_id
+            )
+            for stage, serialized in zip(stages, serialized_payloads, strict=True)
+        }
+
     def launch(self) -> CloudLaunchResult:
         try:
             client = MacrodataClient()
@@ -186,37 +277,42 @@ class CloudLauncher(BaseLauncher):
         stages = self._resolved_stages()
         manifest = self._resolve_cloud_manifest(secret_values=secret_values)
         plan = self._compiled_plan(stages, secret_values=secret_values)
-        request = CloudRunCreateRequest(
-            name=self.name,
-            plan=plan,
-            stage_payloads=[
-                StagePayload(
-                    stage_index=stage.index,
-                    pipeline_payload=serialize_pipeline_inline(stage.pipeline),
-                    runtime=CloudRuntimeConfig(
-                        num_workers=stage.compute.num_workers,
-                        cpus_per_worker=stage.compute.cpus_per_worker,
-                        mem_mb_per_worker=stage.compute.memory_mb_per_worker,
-                        gpu=stage.compute.gpu,
-                    ),
-                    runtime_services=collect_pipeline_services(stage.pipeline),
-                )
-                for stage in stages
-            ],
-            manifest=manifest,
-            sync_local_dependencies=self.sync_local_dependencies,
-            secrets=resolved_secret_sources,
-            env=resolved_env,
-            continue_from_job=self.continue_from_job,
-            unsafe_continue=self.unsafe_continue,
-        )
         try:
+            pipeline_payloads = self._upload_stage_payloads(
+                client=client, stages=stages
+            )
+            request = CloudRunCreateRequest(
+                name=self.name,
+                plan=plan,
+                stage_payloads=[
+                    StagePayload(
+                        stage_index=stage.index,
+                        pipeline_payload=pipeline_payloads[stage.index],
+                        runtime=CloudRuntimeConfig(
+                            num_workers=stage.compute.num_workers,
+                            cpus_per_worker=stage.compute.cpus_per_worker,
+                            mem_mb_per_worker=stage.compute.memory_mb_per_worker,
+                            gpu=stage.compute.gpu,
+                        ),
+                        runtime_services=collect_pipeline_services(stage.pipeline),
+                    )
+                    for stage in stages
+                ],
+                manifest=manifest,
+                sync_local_dependencies=self.sync_local_dependencies,
+                secrets=resolved_secret_sources,
+                env=resolved_env,
+                continue_from_job=self.continue_from_job,
+                unsafe_continue=self.unsafe_continue,
+            )
             resp = client.cloud_submit_job(request=request)
         except MacrodataCredentialsError as err:
             raise SystemExit(
                 "Your Macrodata API key is invalid. Run `macrodata login` "
                 "or set MACRODATA_API_KEY with a valid key."
             ) from err
+        except ValueError as err:
+            raise SystemExit(str(err)) from err
         except MacrodataApiError as err:
             raise SystemExit(err.message) from err
         tracking_url = build_job_tracking_url(

--- a/src/refiner/platform/client/__init__.py
+++ b/src/refiner/platform/client/__init__.py
@@ -7,7 +7,14 @@ from refiner.platform.client.api import (
     verify_api_key,
 )
 from refiner.platform.client.models import (
-    CloudPipelinePayload,
+    CloudFileCompleteRequestItem,
+    CloudFileCompleteResponse,
+    CloudFileCompleteResult,
+    CloudFileUploadInstruction,
+    CloudFileUploadRequestItem,
+    CloudFileUploadStatus,
+    CloudFileUploadUrlsResponse,
+    CloudFile,
     CloudRunCreateRequest,
     CloudRunCreateResponse,
     CloudRuntimeConfig,
@@ -23,20 +30,22 @@ from refiner.platform.client.models import (
     WorkspaceIdentity,
     WorkerStartedResponse,
 )
-from refiner.platform.client.serialize import (
-    INLINE_PIPELINE_PAYLOAD_MAX_BYTES,
-    serialize_pipeline_inline,
-)
 
 __all__ = [
-    "CloudPipelinePayload",
+    "CloudFile",
+    "CloudFileCompleteRequestItem",
+    "CloudFileCompleteResponse",
+    "CloudFileCompleteResult",
+    "CloudFileUploadInstruction",
+    "CloudFileUploadRequestItem",
+    "CloudFileUploadStatus",
+    "CloudFileUploadUrlsResponse",
     "CloudRunCreateRequest",
     "CloudRunCreateResponse",
     "CloudRuntimeConfig",
     "CreateJobResponse",
     "FinalizedShardWorker",
     "FinalizedShardWorkersResponse",
-    "INLINE_PIPELINE_PAYLOAD_MAX_BYTES",
     "MacrodataClient",
     "MacrodataApiError",
     "OkResponse",
@@ -50,6 +59,5 @@ __all__ = [
     "request_json",
     "resolve_platform_base_url",
     "sanitize_terminal_text",
-    "serialize_pipeline_inline",
     "verify_api_key",
 ]

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -11,6 +11,11 @@ import msgspec
 
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
 from refiner.platform.client.models import (
+    CloudFileCompleteRequestItem,
+    CloudFileCompleteResponse,
+    CloudFileUploadInstruction,
+    CloudFileUploadRequestItem,
+    CloudFileUploadUrlsResponse,
     CloudRunCreateRequest,
     CloudRunCreateResponse,
     CreateJobEnvelope,
@@ -302,6 +307,70 @@ class MacrodataClient:
             path="/api/cloud/runs",
             response_type=CloudRunCreateResponse,
             json_payload=request.to_dict(),
+            timeout_s=30.0,
+        )
+
+    def cloud_create_file_upload_urls(
+        self,
+        *,
+        files: list[CloudFileUploadRequestItem],
+        object_ttl_secs: int | None = None,
+    ) -> CloudFileUploadUrlsResponse:
+        return self._request(
+            method="POST",
+            path="/api/cloud/files/upload-urls",
+            response_type=CloudFileUploadUrlsResponse,
+            json_payload={
+                "files": [file.to_dict() for file in files],
+                "object_ttl_secs": object_ttl_secs,
+            },
+            timeout_s=30.0,
+        )
+
+    def cloud_upload_file(
+        self,
+        *,
+        instruction: CloudFileUploadInstruction,
+        payload_bytes: bytes,
+        timeout_s: float = 300.0,
+    ) -> None:
+        try:
+            upload_target = instruction.upload_target()
+        except ValueError as err:
+            raise MacrodataApiError(status=0, message=str(err)) from err
+        if upload_target is None:
+            return
+        url, required_headers = upload_target
+        try:
+            response = httpx.request(
+                method="PUT",
+                url=url,
+                headers=required_headers,
+                content=payload_bytes,
+                timeout=timeout_s,
+            )
+        except httpx.RequestError as err:
+            raise MacrodataApiError(status=0, message=str(err)) from err
+        if response.status_code < 200 or response.status_code >= 300:
+            raise MacrodataApiError(
+                status=response.status_code,
+                message=f"Failed to upload cloud file: {_http_error_message(response)}",
+            )
+
+    def cloud_complete_files(
+        self,
+        *,
+        files: list[CloudFileCompleteRequestItem],
+        object_ttl_secs: int | None = None,
+    ) -> CloudFileCompleteResponse:
+        return self._request(
+            method="POST",
+            path="/api/cloud/files/complete",
+            response_type=CloudFileCompleteResponse,
+            json_payload={
+                "files": [file.to_dict() for file in files],
+                "object_ttl_secs": object_ttl_secs,
+            },
             timeout_s=30.0,
         )
 

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 from typing import Any
 
 import msgspec
@@ -140,25 +142,128 @@ class CloudRuntimeConfig:
 
 
 @dataclass(frozen=True, slots=True)
-class CloudPipelinePayload:
-    format: str
-    bytes_b64: str
+class CloudFile:
+    """Reference to a workspace cloud file used in a cloud run payload."""
+
+    file_id: str
+    """Workspace-scoped cloud file UUID."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"file_id": self.file_id}
+
+
+@dataclass(frozen=True, slots=True)
+class CloudFileUploadRequestItem:
+    """Declared metadata for one file that needs an upload URL."""
+
     sha256: str
+    """Lowercase hex SHA-256 digest of the file bytes."""
+
     size_bytes: int
+    """Exact file size in bytes."""
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "format": self.format,
-            "bytes_b64": self.bytes_b64,
             "sha256": self.sha256,
             "size_bytes": self.size_bytes,
         }
 
 
+class CloudFileUploadStatus(str, Enum):
+    """Cloud file upload URL status returned by the public cloud API."""
+
+    NEW = "new"
+    """The file is not available yet and must be uploaded to the signed URL."""
+
+    EXISTS = "exists"
+    """The workspace already has the file; upload and completion can be skipped."""
+
+
+class CloudFileUploadInstruction(msgspec.Struct, frozen=True):
+    """Upload URL response item for one declared cloud file."""
+
+    file_id: str
+    """Workspace-scoped cloud file UUID assigned by the API."""
+
+    sha256: str
+    """Lowercase hex SHA-256 digest of the expected file bytes."""
+
+    size_bytes: int
+    """Exact expected file size in bytes."""
+
+    status: CloudFileUploadStatus
+    """Whether the file is new or already available in the workspace."""
+
+    url: str | None = None
+    """Opaque signed upload URL for new files."""
+
+    required_headers: dict[str, str] | None = None
+    """HTTP headers that must be sent exactly with the signed upload request."""
+
+    upload_url_expires_at: datetime | None = None
+    """Signed upload URL expiry time, when an upload URL exists."""
+
+    expires_at: datetime | None = None
+    """Cloud file expiry time, or None for non-expiring files."""
+
+    def upload_target(self) -> tuple[str, dict[str, str]] | None:
+        if self.status is CloudFileUploadStatus.EXISTS:
+            return None
+        if not self.url or self.required_headers is None:
+            raise ValueError(
+                "new cloud file upload instruction is missing upload target"
+            )
+        return self.url, self.required_headers
+
+
+class CloudFileUploadUrlsResponse(msgspec.Struct, frozen=True):
+    """Response from the cloud file upload URL endpoint."""
+
+    files: list[CloudFileUploadInstruction]
+    """Upload instructions corresponding to requested files."""
+
+
+@dataclass(frozen=True, slots=True)
+class CloudFileCompleteRequestItem:
+    """Request item for marking one uploaded cloud file complete."""
+
+    file_id: str
+    """Workspace-scoped cloud file UUID to complete."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"file_id": self.file_id}
+
+
+class CloudFileCompleteResult(msgspec.Struct, frozen=True):
+    """Completion result for one cloud file."""
+
+    file_id: str
+    """Workspace-scoped cloud file UUID."""
+
+    sha256: str
+    """Lowercase hex SHA-256 digest verified by the backend."""
+
+    size_bytes: int
+    """Verified file size in bytes."""
+
+    uploaded_at: datetime
+    """Time when the file was marked uploaded."""
+
+    expires_at: datetime | None = None
+    """Cloud file expiry time, or None for non-expiring files."""
+
+
+class CloudFileCompleteResponse(msgspec.Struct, frozen=True):
+    """Response from the cloud file completion endpoint."""
+
+    files: list[CloudFileCompleteResult]
+    """Completion results corresponding to requested files."""
+
+
 @dataclass(frozen=True, slots=True)
 class StagePayload:
     stage_index: int
-    pipeline_payload: CloudPipelinePayload
+    pipeline_payload: CloudFile
     runtime: CloudRuntimeConfig
     runtime_services: tuple[RuntimeServiceSpec, ...] = ()
 

--- a/src/refiner/platform/client/serialize.py
+++ b/src/refiner/platform/client/serialize.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 import cloudpickle
 
+CLOUD_PIPELINE_PAYLOAD_MAX_BYTES = 1024 * 1024 * 1024  # 1 GiB
+
 
 @dataclass(frozen=True, slots=True)
 class PreparedPipelinePayload:
@@ -24,8 +26,14 @@ class PreparedPipelinePayload:
         # This payload is executable-by-design and must only be deserialized
         # in a trusted tenant boundary for the submitting account.
         payload_bytes = cloudpickle.dumps(pipeline)
+        size_bytes = len(payload_bytes)
+        if size_bytes > CLOUD_PIPELINE_PAYLOAD_MAX_BYTES:
+            raise ValueError(
+                "Pipeline payload exceeds cloud upload limit "
+                f"({size_bytes} bytes > {CLOUD_PIPELINE_PAYLOAD_MAX_BYTES} bytes)."
+            )
         return cls(
             payload_bytes=payload_bytes,
             sha256=hashlib.sha256(payload_bytes).hexdigest(),
-            size_bytes=len(payload_bytes),
+            size_bytes=size_bytes,
         )

--- a/src/refiner/platform/client/serialize.py
+++ b/src/refiner/platform/client/serialize.py
@@ -1,34 +1,31 @@
 from __future__ import annotations
 
-import base64
 import hashlib
+from dataclasses import dataclass
 
 import cloudpickle
 
-from refiner.platform.client.models import CloudPipelinePayload
 
-INLINE_PIPELINE_PAYLOAD_MAX_BYTES = 1_000_000
+@dataclass(frozen=True, slots=True)
+class PreparedPipelinePayload:
+    """Serialized pipeline payload prepared for cloud file staging."""
 
+    payload_bytes: bytes
+    """Raw cloudpickle payload bytes."""
 
-def serialize_pipeline_inline(
-    pipeline: object,
-    *,
-    max_bytes: int = INLINE_PIPELINE_PAYLOAD_MAX_BYTES,
-) -> CloudPipelinePayload:
-    # This payload is executable-by-design and must only be deserialized
-    # in a trusted tenant boundary for the submitting account.
-    payload_bytes = cloudpickle.dumps(pipeline)
-    size_bytes = len(payload_bytes)
-    if size_bytes > max_bytes:
-        raise ValueError(
-            "Pipeline payload exceeds inline cloud submission limit "
-            f"({size_bytes} bytes > {max_bytes} bytes). "
-            "Artifact uploads are not implemented yet."
+    sha256: str
+    """Lowercase hex SHA-256 digest of payload_bytes."""
+
+    size_bytes: int
+    """Exact payload size in bytes."""
+
+    @classmethod
+    def from_pipeline(cls, pipeline: object) -> PreparedPipelinePayload:
+        # This payload is executable-by-design and must only be deserialized
+        # in a trusted tenant boundary for the submitting account.
+        payload_bytes = cloudpickle.dumps(pipeline)
+        return cls(
+            payload_bytes=payload_bytes,
+            sha256=hashlib.sha256(payload_bytes).hexdigest(),
+            size_bytes=len(payload_bytes),
         )
-
-    return CloudPipelinePayload(
-        format="cloudpickle",
-        bytes_b64=base64.b64encode(payload_bytes).decode("ascii"),
-        sha256=hashlib.sha256(payload_bytes).hexdigest(),
-        size_bytes=size_bytes,
-    )

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -1,21 +1,31 @@
 from __future__ import annotations
 
+import hashlib
 import pytest
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import cast
 
 import refiner as mdr
 from refiner.pipeline import read_jsonl
 from refiner.pipeline.resources import GPU
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
+from refiner.launchers.cloud import CloudLauncher
 from refiner.platform.auth import MacrodataCredentialsError
 from refiner.platform.client import (
-    CloudPipelinePayload,
+    CloudFileCompleteRequestItem,
+    CloudFileUploadInstruction,
+    CloudFileUploadRequestItem,
+    CloudFileUploadStatus,
     CloudRunCreateRequest,
     MacrodataApiError,
+    MacrodataClient,
 )
+from refiner.platform.client.serialize import PreparedPipelinePayload
 from refiner.platform.manifest import _redact_captured_text
 from refiner.launchers.secrets import Secrets
+
+_TEST_TIMESTAMP = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
 
 
 async def _noop_inference(row, generate):
@@ -23,21 +33,122 @@ async def _noop_inference(row, generate):
     return row
 
 
+def _prepared_payload(payload_bytes: bytes) -> PreparedPipelinePayload:
+    return PreparedPipelinePayload(
+        payload_bytes=payload_bytes,
+        sha256=hashlib.sha256(payload_bytes).hexdigest(),
+        size_bytes=len(payload_bytes),
+    )
+
+
+def _cloud_file_upload_instruction(
+    file: CloudFileUploadRequestItem,
+    *,
+    file_id: str = "00000000-0000-7000-8000-000000000001",
+    status: CloudFileUploadStatus = CloudFileUploadStatus.NEW,
+) -> CloudFileUploadInstruction:
+    if status is CloudFileUploadStatus.EXISTS:
+        return CloudFileUploadInstruction(
+            file_id=file_id,
+            sha256=file.sha256,
+            size_bytes=file.size_bytes,
+            status=status,
+            expires_at=None,
+        )
+    return CloudFileUploadInstruction(
+        file_id=file_id,
+        sha256=file.sha256,
+        size_bytes=file.size_bytes,
+        status=status,
+        url=f"https://payloads.example/{file_id}",
+        required_headers={
+            "content-length": str(file.size_bytes),
+            "x-amz-checksum-sha256": "checksum",
+        },
+        upload_url_expires_at=_TEST_TIMESTAMP,
+        expires_at=None,
+    )
+
+
 def _stub_cloud_submit(
     monkeypatch,
     *,
     manifest: dict[str, object] | Callable[..., dict[str, object]] | None = None,
     fail_on_submit: bool = False,
+    fail_on_upload_urls: bool = False,
+    fail_on_upload: bool = False,
+    fail_on_complete: bool = False,
 ) -> dict[str, object]:
-    captured: dict[str, object] = {}
+    captured: dict[str, object] = {
+        "events": [],
+        "uploads": [],
+        "upload_url_batches": [],
+        "complete_batches": [],
+    }
 
     class FakeMacrodataClient:
         def __init__(self):
             self.base_url = "https://example.com"
 
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            if fail_on_upload_urls:
+                raise MacrodataApiError(
+                    status=400, message="failed to create upload URLs"
+                )
+            assert object_ttl_secs is None
+            cast(list[str], captured["events"]).append("upload-urls")
+            captured["upload_url_files"] = files
+            cast(
+                list[list[CloudFileUploadRequestItem]], captured["upload_url_batches"]
+            ).append(files)
+            offset = sum(
+                len(batch)
+                for batch in cast(
+                    list[list[CloudFileUploadRequestItem]],
+                    captured["upload_url_batches"],
+                )[:-1]
+            )
+            instructions = []
+            for index, file in enumerate(files, start=1):
+                instructions.append(
+                    _cloud_file_upload_instruction(
+                        file,
+                        file_id=f"00000000-0000-7000-8000-{offset + index:012d}",
+                    )
+                )
+
+            class _Resp:
+                files = instructions
+
+            return _Resp()
+
+        def cloud_upload_file(self, *, instruction, payload_bytes):
+            if fail_on_upload:
+                raise MacrodataApiError(status=502, message="failed to upload payload")
+            cast(list[str], captured["events"]).append("upload")
+            cast(list[object], captured["uploads"]).append((instruction, payload_bytes))
+
+        def cloud_complete_files(self, *, files, object_ttl_secs=None):
+            if fail_on_complete:
+                raise MacrodataApiError(
+                    status=502, message="failed to complete payload"
+                )
+            assert object_ttl_secs is None
+            cast(list[str], captured["events"]).append("complete")
+            captured["complete_files"] = files
+            cast(
+                list[list[CloudFileCompleteRequestItem]], captured["complete_batches"]
+            ).append(files)
+
+            class _Resp:
+                files = []
+
+            return _Resp()
+
         def cloud_submit_job(self, *, request):
             if fail_on_submit:
                 raise AssertionError("should not submit")
+            cast(list[str], captured["events"]).append("submit")
             captured["submit_request"] = request
 
             class _Resp:
@@ -51,13 +162,8 @@ def _stub_cloud_submit(
 
     monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
     monkeypatch.setattr(
-        "refiner.launchers.cloud.serialize_pipeline_inline",
-        lambda pipeline: CloudPipelinePayload(
-            format="cloudpickle",
-            bytes_b64="AQID",
-            sha256="abc123",
-            size_bytes=3,
-        ),
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(b"AQID"),
     )
     monkeypatch.setattr(
         "refiner.launchers.base.plan_pipeline_stages",
@@ -120,7 +226,9 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert "cuda_version" not in request.plan["stages"][0]
     assert len(request.stage_payloads) == 1
     assert request.stage_payloads[0].stage_index == 0
-    assert request.stage_payloads[0].pipeline_payload.sha256 == "abc123"
+    assert request.stage_payloads[0].pipeline_payload.file_id == (
+        "00000000-0000-7000-8000-000000000001"
+    )
     assert request.stage_payloads[0].runtime is not None
     assert request.stage_payloads[0].runtime.num_workers == 3
     assert request.stage_payloads[0].runtime.cpus_per_worker == 2
@@ -135,6 +243,20 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
         "environment": {"refiner_version": "0.2.0", "refiner_ref": "abc123def456"},
         "script": {"text": "print('hi')"},
     }
+    upload_url_files = cast(
+        list[CloudFileUploadRequestItem], captured["upload_url_files"]
+    )
+    assert len(upload_url_files) == 1
+    assert upload_url_files[0].sha256 == _prepared_payload(b"AQID").sha256
+    uploaded_payloads = cast(
+        list[tuple[CloudFileUploadInstruction, bytes]], captured["uploads"]
+    )
+    assert uploaded_payloads[0][1] == b"AQID"
+    complete_files = cast(
+        list[CloudFileCompleteRequestItem], captured["complete_files"]
+    )
+    assert complete_files[0].file_id == "00000000-0000-7000-8000-000000000001"
+    assert captured["events"] == ["upload-urls", "upload", "complete", "submit"]
 
 
 def test_pipeline_launch_cloud_embeds_runtime_services(monkeypatch) -> None:
@@ -473,9 +595,13 @@ def test_pipeline_launch_cloud_requires_valid_api_key(monkeypatch) -> None:
         def __init__(self):
             self.base_url = "https://example.com"
 
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):  # noqa: ANN001
+            del files, object_ttl_secs
+            raise MacrodataCredentialsError("Invalid API key", missing=False)
+
         def cloud_submit_job(self, *, request):  # noqa: ANN001
             del request
-            raise MacrodataCredentialsError("Invalid API key", missing=False)
+            raise AssertionError("cloud_submit_job should not be called")
 
     monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
     monkeypatch.setattr(
@@ -490,14 +616,289 @@ def test_pipeline_launch_cloud_requires_valid_api_key(monkeypatch) -> None:
         read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
 
 
+def test_pipeline_launch_cloud_upload_url_failure_prevents_submit(
+    monkeypatch,
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch, fail_on_upload_urls=True)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    with pytest.raises(SystemExit, match="failed to create upload URLs"):
+        read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    assert captured["uploads"] == []
+    assert "submit_request" not in captured
+
+
+def test_pipeline_launch_cloud_payload_upload_failure_prevents_submit(
+    monkeypatch,
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch, fail_on_upload=True)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    with pytest.raises(SystemExit, match="failed to upload payload"):
+        read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    assert "upload_url_files" in captured
+    assert "complete_files" not in captured
+    assert "submit_request" not in captured
+
+
+def test_pipeline_launch_cloud_complete_failure_prevents_submit(
+    monkeypatch,
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch, fail_on_complete=True)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    with pytest.raises(SystemExit, match="failed to complete payload"):
+        read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    assert captured["uploads"]
+    assert "submit_request" not in captured
+
+
+def test_pipeline_launch_cloud_missing_upload_url_response_prevents_submit(
+    monkeypatch,
+) -> None:
+    class FakeMacrodataClient:
+        def __init__(self):
+            self.base_url = "https://example.com"
+
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            del files, object_ttl_secs
+
+            class _Resp:
+                files = []
+
+            return _Resp()
+
+    monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(b"payload"),
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    with pytest.raises(SystemExit, match="did not return instructions"):
+        read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+
+def test_pipeline_launch_cloud_existing_cloud_file_skips_upload_and_complete(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {"uploads": []}
+
+    class FakeMacrodataClient:
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            assert object_ttl_secs is None
+            captured["upload_url_files"] = files
+            instructions = [
+                _cloud_file_upload_instruction(
+                    files[0],
+                    file_id="00000000-0000-7000-8000-000000000123",
+                    status=CloudFileUploadStatus.EXISTS,
+                )
+            ]
+
+            class _Resp:
+                files = instructions
+
+            return _Resp()
+
+        def cloud_upload_file(self, *, instruction, payload_bytes):
+            del instruction, payload_bytes
+            raise AssertionError("existing cloud files should not be uploaded")
+
+        def cloud_complete_files(self, *, files, object_ttl_secs=None):
+            del files, object_ttl_secs
+            raise AssertionError("existing cloud files should not be completed")
+
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(b"payload"),
+    )
+
+    payloads = CloudLauncher._upload_stage_payloads(
+        client=cast(MacrodataClient, FakeMacrodataClient()),
+        stages=[
+            PlannedStage(
+                index=0,
+                name="stage_0",
+                pipeline=read_jsonl("input.jsonl"),
+                compute=StageComputeRequirements(num_workers=1),
+            )
+        ],
+    )
+
+    assert (
+        len(cast(list[CloudFileUploadRequestItem], captured["upload_url_files"])) == 1
+    )
+    assert captured["uploads"] == []
+    assert payloads[0].file_id == "00000000-0000-7000-8000-000000000123"
+
+
+def test_pipeline_launch_cloud_deduplicates_identical_stage_payloads(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {"uploads": []}
+
+    class FakeMacrodataClient:
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            assert object_ttl_secs is None
+            captured["upload_url_files"] = files
+            instructions = [
+                _cloud_file_upload_instruction(
+                    files[0],
+                    file_id="00000000-0000-7000-8000-000000000123",
+                )
+            ]
+
+            class _Resp:
+                files = instructions
+
+            return _Resp()
+
+        def cloud_upload_file(self, *, instruction, payload_bytes):
+            cast(list[object], captured["uploads"]).append((instruction, payload_bytes))
+
+        def cloud_complete_files(self, *, files, object_ttl_secs=None):
+            assert object_ttl_secs is None
+            captured["complete_files"] = files
+
+            class _Resp:
+                files = []
+
+            return _Resp()
+
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(b"same-payload"),
+    )
+
+    payloads = CloudLauncher._upload_stage_payloads(
+        client=cast(MacrodataClient, FakeMacrodataClient()),
+        stages=[
+            PlannedStage(
+                index=0,
+                name="stage_0",
+                pipeline=read_jsonl("input-a.jsonl"),
+                compute=StageComputeRequirements(num_workers=1),
+            ),
+            PlannedStage(
+                index=1,
+                name="stage_1",
+                pipeline=read_jsonl("input-b.jsonl"),
+                compute=StageComputeRequirements(num_workers=1),
+            ),
+        ],
+    )
+
+    assert (
+        len(cast(list[CloudFileUploadRequestItem], captured["upload_url_files"])) == 1
+    )
+    assert len(cast(list[object], captured["uploads"])) == 1
+    assert (
+        len(cast(list[CloudFileCompleteRequestItem], captured["complete_files"])) == 1
+    )
+    assert payloads[0].file_id == "00000000-0000-7000-8000-000000000123"
+    assert payloads[1].file_id == "00000000-0000-7000-8000-000000000123"
+
+
+def test_pipeline_launch_cloud_batches_more_than_100_unique_payload_files(
+    monkeypatch,
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(f"payload-{id(pipeline)}".encode()),
+    )
+    stage_pipelines = [read_jsonl(f"input-{index}.jsonl") for index in range(101)]
+    monkeypatch.setattr(
+        "refiner.launchers.base.plan_pipeline_stages",
+        lambda pipeline, default_num_workers: [
+            PlannedStage(
+                index=index,
+                name=f"stage_{index}",
+                pipeline=stage_pipeline,
+                compute=StageComputeRequirements(num_workers=default_num_workers),
+            )
+            for index, stage_pipeline in enumerate(stage_pipelines)
+        ],
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+
+    upload_url_batches = cast(
+        list[list[CloudFileUploadRequestItem]], captured["upload_url_batches"]
+    )
+    complete_batches = cast(
+        list[list[CloudFileCompleteRequestItem]], captured["complete_batches"]
+    )
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert [len(batch) for batch in upload_url_batches] == [100, 1]
+    assert [len(batch) for batch in complete_batches] == [100, 1]
+    assert len(cast(list[object], captured["uploads"])) == 101
+    assert len(request.stage_payloads) == 101
+    assert request.stage_payloads[0].pipeline_payload.file_id == (
+        "00000000-0000-7000-8000-000000000001"
+    )
+    assert request.stage_payloads[-1].pipeline_payload.file_id == (
+        "00000000-0000-7000-8000-000000000101"
+    )
+
+
 def test_pipeline_launch_cloud_submits_one_stage_payload_per_planned_stage(
     monkeypatch,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: dict[str, object] = {"uploads": []}
 
     class FakeMacrodataClient:
         def __init__(self):
             self.base_url = "https://example.com"
+
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            assert object_ttl_secs is None
+            captured["upload_url_files"] = files
+            instructions = []
+            for index, file in enumerate(files, start=1):
+                instructions.append(
+                    _cloud_file_upload_instruction(
+                        file,
+                        file_id=f"00000000-0000-7000-8000-{index:012d}",
+                    )
+                )
+
+            class _Resp:
+                files = instructions
+
+            return _Resp()
+
+        def cloud_upload_file(self, *, instruction, payload_bytes):
+            cast(list[object], captured["uploads"]).append((instruction, payload_bytes))
+
+        def cloud_complete_files(self, *, files, object_ttl_secs=None):
+            assert object_ttl_secs is None
+            captured["complete_files"] = files
+
+            class _Resp:
+                files = []
+
+            return _Resp()
 
         def cloud_submit_job(self, *, request):
             captured["request"] = request
@@ -512,13 +913,8 @@ def test_pipeline_launch_cloud_submits_one_stage_payload_per_planned_stage(
 
     monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
     monkeypatch.setattr(
-        "refiner.launchers.cloud.serialize_pipeline_inline",
-        lambda pipeline: CloudPipelinePayload(
-            format="cloudpickle",
-            bytes_b64=f"payload-{id(pipeline)}",
-            sha256=f"sha-{id(pipeline)}",
-            size_bytes=3,
-        ),
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda pipeline: _prepared_payload(f"payload-{id(pipeline)}".encode()),
     )
     first_stage_pipeline = read_jsonl("input-a.jsonl")
     second_stage_pipeline = read_jsonl("input-b.jsonl")
@@ -560,8 +956,8 @@ def test_pipeline_launch_cloud_submits_one_stage_payload_per_planned_stage(
         5,
     ]
     assert (
-        request.stage_payloads[0].pipeline_payload.sha256
-        != request.stage_payloads[1].pipeline_payload.sha256
+        request.stage_payloads[0].pipeline_payload.file_id
+        != request.stage_payloads[1].pipeline_payload.file_id
     )
 
 
@@ -944,7 +1340,9 @@ def test_pipeline_launch_cloud_continue_from_job_posts_submit_request(
     assert request.plan["stages"][0]["cpus_per_worker"] == 2
     assert request.stage_payloads is not None
     assert request.stage_payloads[0].stage_index == 0
-    assert request.stage_payloads[0].pipeline_payload.sha256 == "abc123"
+    assert request.stage_payloads[0].pipeline_payload.file_id == (
+        "00000000-0000-7000-8000-000000000001"
+    )
     assert request.stage_payloads[0].runtime.num_workers == 3
     assert request.stage_payloads[0].runtime.cpus_per_worker == 2
     assert request.sync_local_dependencies is True
@@ -1132,6 +1530,33 @@ def test_pipeline_launch_cloud_surfaces_submit_warnings(monkeypatch) -> None:
     class WarningClient:
         def __init__(self):
             self.base_url = "https://example.com"
+
+        def cloud_create_file_upload_urls(self, *, files, object_ttl_secs=None):
+            del object_ttl_secs
+            instructions = []
+            for index, file in enumerate(files, start=1):
+                instructions.append(
+                    _cloud_file_upload_instruction(
+                        file,
+                        file_id=f"00000000-0000-7000-8000-{index:012d}",
+                    )
+                )
+
+            class _Resp:
+                files = instructions
+
+            return _Resp()
+
+        def cloud_upload_file(self, *, instruction, payload_bytes):
+            del instruction, payload_bytes
+
+        def cloud_complete_files(self, *, files, object_ttl_secs=None):
+            del files, object_ttl_secs
+
+            class _Resp:
+                files = []
+
+            return _Resp()
 
         def cloud_submit_job(self, *, request):
             captured["submit_request"] = request

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import cast
 
-from refiner.platform.client import MacrodataClient
+import httpx
+import msgspec
+
+from refiner.pipeline.resources import GPU
 from refiner.platform.client import (
-    CloudPipelinePayload,
+    CloudFile,
+    CloudFileCompleteRequestItem,
+    CloudFileUploadInstruction,
+    CloudFileUploadRequestItem,
+    CloudFileUploadStatus,
     CloudRunCreateRequest,
     CloudRuntimeConfig,
+    MacrodataApiError,
+    MacrodataClient,
     StagePayload,
 )
-from refiner.platform.client import MacrodataApiError
-from refiner.pipeline.resources import GPU
 from refiner.services import RuntimeServiceSpec
+
+_TEST_TIMESTAMP = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
 
 
 def _request() -> CloudRunCreateRequest:
@@ -21,11 +31,8 @@ def _request() -> CloudRunCreateRequest:
         stage_payloads=[
             StagePayload(
                 stage_index=0,
-                pipeline_payload=CloudPipelinePayload(
-                    format="cloudpickle",
-                    bytes_b64="AQID",
-                    sha256="abc123",
-                    size_bytes=3,
+                pipeline_payload=CloudFile(
+                    file_id="00000000-0000-7000-8000-000000000123",
                 ),
                 runtime=CloudRuntimeConfig(
                     num_workers=2,
@@ -85,10 +92,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
         {
             "stage_index": 0,
             "pipeline_payload": {
-                "format": "cloudpickle",
-                "bytes_b64": "AQID",
-                "sha256": "abc123",
-                "size_bytes": 3,
+                "file_id": "00000000-0000-7000-8000-000000000123",
             },
             "runtime": {
                 "num_workers": 2,
@@ -155,11 +159,8 @@ def test_cloud_client_cloud_submit_job_posts_continue_metadata(monkeypatch) -> N
             stage_payloads=[
                 StagePayload(
                     stage_index=0,
-                    pipeline_payload=CloudPipelinePayload(
-                        format="cloudpickle",
-                        bytes_b64="AQID",
-                        sha256="abc123",
-                        size_bytes=3,
+                    pipeline_payload=CloudFile(
+                        file_id="00000000-0000-7000-8000-000000000123",
                     ),
                     runtime=CloudRuntimeConfig(num_workers=1),
                 )
@@ -191,11 +192,195 @@ def test_cloud_client_cloud_submit_job_posts_continue_metadata(monkeypatch) -> N
         {
             "stage_index": 0,
             "pipeline_payload": {
-                "format": "cloudpickle",
-                "bytes_b64": "AQID",
-                "sha256": "abc123",
-                "size_bytes": 3,
+                "file_id": "00000000-0000-7000-8000-000000000123",
             },
             "runtime": {"num_workers": 1},
         }
     ]
+
+
+def test_cloud_client_creates_file_upload_urls(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request_json(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "files": [
+                {
+                    "file_id": "00000000-0000-7000-8000-000000000123",
+                    "sha256": "a" * 64,
+                    "size_bytes": 3,
+                    "status": "new",
+                    "url": "https://payloads.example/upload",
+                    "required_headers": {
+                        "content-length": "3",
+                        "x-amz-checksum-sha256": "checksum",
+                    },
+                    "upload_url_expires_at": "2026-05-20T12:00:00Z",
+                    "expires_at": None,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("refiner.platform.client.api.request_json", fake_request_json)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    response = client.cloud_create_file_upload_urls(
+        files=[
+            CloudFileUploadRequestItem(
+                sha256="a" * 64,
+                size_bytes=3,
+            )
+        ],
+        object_ttl_secs=None,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/cloud/files/upload-urls"
+    assert captured["base_url"] == "https://example.com"
+    assert captured["timeout_s"] == 30.0
+    assert captured["json_payload"] == {
+        "files": [{"sha256": "a" * 64, "size_bytes": 3}],
+        "object_ttl_secs": None,
+    }
+    assert response.files[0].file_id == "00000000-0000-7000-8000-000000000123"
+    assert response.files[0].status is CloudFileUploadStatus.NEW
+    assert response.files[0].upload_url_expires_at == _TEST_TIMESTAMP
+    assert response.files[0].expires_at is None
+    assert response.files[0].required_headers is not None
+    assert response.files[0].required_headers["x-amz-checksum-sha256"] == "checksum"
+
+
+def test_cloud_file_upload_status_serializes_as_wire_literal() -> None:
+    assert msgspec.json.encode(CloudFileUploadStatus.NEW) == b'"new"'
+    assert msgspec.json.encode(CloudFileUploadStatus.EXISTS) == b'"exists"'
+
+
+def test_cloud_client_uploads_cloud_file_without_macrodata_auth(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 204
+
+    def fake_httpx_request(**kwargs: object) -> FakeResponse:
+        captured.update(kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr("refiner.platform.client.api.httpx.request", fake_httpx_request)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    client.cloud_upload_file(
+        instruction=CloudFileUploadInstruction(
+            file_id="00000000-0000-7000-8000-000000000123",
+            sha256="a" * 64,
+            size_bytes=7,
+            status=CloudFileUploadStatus.NEW,
+            url="https://payloads.example/upload",
+            required_headers={
+                "content-length": "7",
+                "x-amz-checksum-sha256": "checksum",
+            },
+            upload_url_expires_at=_TEST_TIMESTAMP,
+            expires_at=None,
+        ),
+        payload_bytes=b"payload",
+    )
+
+    assert captured["method"] == "PUT"
+    assert captured["url"] == "https://payloads.example/upload"
+    assert captured["content"] == b"payload"
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["content-length"] == "7"
+    assert headers["x-amz-checksum-sha256"] == "checksum"
+    assert "Authorization" not in headers
+    assert "User-Agent" not in headers
+
+
+def test_cloud_client_cloud_upload_file_noops_when_file_exists(monkeypatch) -> None:
+    def fake_httpx_request(**kwargs: object) -> None:
+        del kwargs
+        raise AssertionError("existing cloud files should not be uploaded")
+
+    monkeypatch.setattr("refiner.platform.client.api.httpx.request", fake_httpx_request)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    client.cloud_upload_file(
+        instruction=CloudFileUploadInstruction(
+            file_id="00000000-0000-7000-8000-000000000123",
+            sha256="a" * 64,
+            size_bytes=7,
+            status=CloudFileUploadStatus.EXISTS,
+            expires_at=None,
+        ),
+        payload_bytes=b"payload",
+    )
+
+
+def test_cloud_client_cloud_file_upload_failure_includes_provider_message(
+    monkeypatch,
+) -> None:
+    def fake_httpx_request(**kwargs: object) -> httpx.Response:
+        del kwargs
+        return httpx.Response(
+            403,
+            json={"message": "SignatureDoesNotMatch"},
+        )
+
+    monkeypatch.setattr("refiner.platform.client.api.httpx.request", fake_httpx_request)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    try:
+        client.cloud_upload_file(
+            instruction=CloudFileUploadInstruction(
+                file_id="00000000-0000-7000-8000-000000000123",
+                sha256="a" * 64,
+                size_bytes=7,
+                status=CloudFileUploadStatus.NEW,
+                url="https://payloads.example/upload",
+                required_headers={"content-length": "7"},
+            ),
+            payload_bytes=b"payload",
+        )
+    except MacrodataApiError as err:
+        assert err.status == 403
+        assert err.message == "Failed to upload cloud file: SignatureDoesNotMatch"
+    else:  # pragma: no cover
+        raise AssertionError("expected upload failure")
+
+
+def test_cloud_client_completes_cloud_files(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request_json(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "files": [
+                {
+                    "file_id": "00000000-0000-7000-8000-000000000123",
+                    "sha256": "a" * 64,
+                    "size_bytes": 3,
+                    "uploaded_at": "2026-05-20T12:00:00Z",
+                    "expires_at": None,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("refiner.platform.client.api.request_json", fake_request_json)
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    response = client.cloud_complete_files(
+        files=[
+            CloudFileCompleteRequestItem(file_id="00000000-0000-7000-8000-000000000123")
+        ],
+        object_ttl_secs=None,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/cloud/files/complete"
+    assert captured["json_payload"] == {
+        "files": [{"file_id": "00000000-0000-7000-8000-000000000123"}],
+        "object_ttl_secs": None,
+    }
+    assert response.files[0].file_id == "00000000-0000-7000-8000-000000000123"
+    assert response.files[0].uploaded_at == _TEST_TIMESTAMP
+    assert response.files[0].expires_at is None

--- a/tests/platform/test_cloud_serialize.py
+++ b/tests/platform/test_cloud_serialize.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 
 import cloudpickle
+import pytest
 
 from refiner.platform.client.serialize import PreparedPipelinePayload
 
@@ -13,3 +14,18 @@ def test_prepared_pipeline_payload_from_pipeline_returns_raw_bytes_and_sha() -> 
     assert cloudpickle.loads(payload.payload_bytes) == {"hello": "world"}
     assert payload.size_bytes == len(payload.payload_bytes)
     assert payload.sha256 == hashlib.sha256(payload.payload_bytes).hexdigest()
+
+
+def test_prepared_pipeline_payload_from_pipeline_enforces_size_limit(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "refiner.platform.client.serialize.CLOUD_PIPELINE_PAYLOAD_MAX_BYTES", 8
+    )
+    monkeypatch.setattr(
+        "refiner.platform.client.serialize.cloudpickle.dumps",
+        lambda pipeline: b"x" * 9,
+    )
+
+    with pytest.raises(ValueError, match="cloud upload limit"):
+        PreparedPipelinePayload.from_pipeline({"hello": "world"})

--- a/tests/platform/test_cloud_serialize.py
+++ b/tests/platform/test_cloud_serialize.py
@@ -1,24 +1,15 @@
 from __future__ import annotations
 
-import base64
 import hashlib
 
-from refiner.platform.client import serialize_pipeline_inline
+import cloudpickle
+
+from refiner.platform.client.serialize import PreparedPipelinePayload
 
 
-def test_serialize_pipeline_inline_returns_base64_and_sha() -> None:
-    payload = serialize_pipeline_inline({"hello": "world"})
+def test_prepared_pipeline_payload_from_pipeline_returns_raw_bytes_and_sha() -> None:
+    payload = PreparedPipelinePayload.from_pipeline({"hello": "world"})
 
-    raw = base64.b64decode(payload.bytes_b64.encode("ascii"))
-    assert payload.format == "cloudpickle"
-    assert payload.size_bytes == len(raw)
-    assert payload.sha256 == hashlib.sha256(raw).hexdigest()
-
-
-def test_serialize_pipeline_inline_enforces_size_limit() -> None:
-    try:
-        serialize_pipeline_inline("x" * 1024, max_bytes=8)
-    except ValueError as err:
-        assert "inline cloud submission limit" in str(err)
-    else:  # pragma: no cover
-        raise AssertionError("expected size limit error")
+    assert cloudpickle.loads(payload.payload_bytes) == {"hello": "world"}
+    assert payload.size_bytes == len(payload.payload_bytes)
+    assert payload.sha256 == hashlib.sha256(payload.payload_bytes).hexdigest()


### PR DESCRIPTION
## Purpose

Update Refiner cloud launches to upload serialized stage payloads before job submission. The final cloud run request now sends durable payload references instead of inline base64 payloads.

## Changes

- Add client support for requesting signed stage payload upload URLs.
- Upload each serialized stage payload through the returned HTTP PUT URL.
- Submit cloud jobs with S3-backed payload references.
- Update launcher docs and cloud client/launcher tests.

## Notes

This is a draft until the matching cloud API changes are available.