### PR TITLE
Add generic robotics row and video source support

### DIFF
--- a/docs/robotics.md
+++ b/docs/robotics.md
@@ -140,21 +140,19 @@ def keep_first_ten_frames(row):
 
 ### Videos
 
-`row.videos` is a mapping from video feature key to `LeRobotVideoRef`.
+`row.videos` is a mapping from video feature key to `VideoSource`.
 
-For each video ref, you can access:
+For LeRobot rows, each source is a clipped `VideoFile`, so you can access:
 
 - `video.uri`
 - `video.from_timestamp_s`
 - `video.to_timestamp_s`
-- `video.video`
-  - the underlying `VideoFile`
 
-You can also decode a `VideoFile` lazily through methods on the handle itself:
+All video sources expose:
 
 - `video.iter_frames()`
 - `video.iter_frame_windows(offsets=[...], stride=...)`
-- `await video.export_clip()`
+- `video.clipped(from_timestamp_s=..., to_timestamp_s=...)`
 
 Example:
 
@@ -163,8 +161,7 @@ def shift_videos_by_half_second(row):
     for key, video in row.videos.items():
         row = row.with_video(
             key,
-            from_timestamp_s=(video.from_timestamp_s or 0.0) + 0.5,
-            to_timestamp_s=(video.to_timestamp_s or 0.0) + 0.5,
+            video.clipped(from_timestamp_s=0.5),
         )
     return row
 ```
@@ -260,6 +257,45 @@ pipeline = (
 For list-valued columns like `tasks`, `col("tasks").is_in(["pick"])` means
 "does this episode contain any task in that set?"
 
+### Adapting Generic Robotics Rows
+
+Use `to_robot_rows(...)` when your data is already organized as generic
+robotics episodes or frame rows and you want the common `RoboticsRow` view:
+
+```python
+pipeline = pipeline.to_robot_rows(
+    episode_id_key="episode_id",
+    fps=30.0,
+    robot_type="aloha",
+    nested_frames_key="frames",
+    timestamp_key="time_s",
+    action_key="actions",
+    state_key="qpos",
+    extra_observation_keys={"images.main": "camera"},
+    video_keys={"images.front": "front_video"},
+)
+```
+
+By default `episode_id_key`, `fps`, and `robot_type` are unset. Pass
+`episode_id_key=` when source rows carry a stable episode id. Pass literal
+`fps=` and `robot_type=` values when they are dataset constants, or pass
+`fps_key=` and `robot_type_key=` when each source row carries those values in
+columns.
+
+For `layout="episode_rows"`, `nested_frames_key=` names the source column that
+contains nested per-frame rows. For `layout="frame_rows"`, it names the grouped
+per-episode frame table written by the adapter. When omitted in `frame_rows`
+mode, Refiner uses an internal hidden key, so unclaimed source columns stay in
+the nested frame table and do not appear as episode metadata unless listed in
+`episode_metadata_keys=`.
+
+Video fields are detected from schema asset metadata, such as
+`dtypes={"front_video": mdr.datatype.video_path()}` on readers that accept
+`dtypes`. For raw rows without asset metadata, pass `video_keys=` to declare
+which source keys are video streams. `extra_observation_keys=` and `video_keys=`
+both accept either a mapping for renames or an iterable of source keys when no
+rename is needed.
+
 ## Writing Datasets
 
 Use `write_lerobot(...)` to write a LeRobot-compatible output dataset:
@@ -267,6 +303,10 @@ Use `write_lerobot(...)` to write a LeRobot-compatible output dataset:
 ```python
 pipeline = pipeline.write_lerobot("hf://buckets/macrodata/my_robotics_output")
 ```
+
+Inputs must be `LeRobotRow` values, such as rows from `read_lerobot(...)`, or
+generic `RoboticsRow` values. For raw robotics rows, call `to_robot_rows(...)`
+before `write_lerobot(...)`.
 
 This is more than a generic file writer. The LeRobot writer handles:
 

--- a/docs/robotics_conversion.md
+++ b/docs/robotics_conversion.md
@@ -1,0 +1,79 @@
+# Robotics Conversion Examples
+
+## ALOHA / ACT HDF5
+
+ALOHA-style HDF5 datasets are usually one HDF5 file per episode, with
+frame-aligned arrays under fixed paths:
+
+- `/action`
+- `/observations/qpos`
+- `/observations/qvel`
+- `/observations/images/<camera>`
+
+```python
+import refiner as mdr
+
+pipeline = (
+    mdr.read_hdf5(
+        "/data/aloha/*.hdf5",
+        groups="/",
+        datasets={
+            "action": "action",
+            "qpos": "observations/qpos",
+            "qvel": "observations/qvel",
+            "cam_high": "observations/images/cam_high",
+            "cam_left_wrist": "observations/images/cam_left_wrist",
+        },
+        file_path_column="episode_file",
+    )
+    .to_robot_rows(
+        episode_id_key="episode_file",
+        action_key="action",
+        state_key="qpos",
+        extra_observation_keys=("qvel",),
+        video_keys=("cam_high", "cam_left_wrist"),
+    )
+)
+```
+
+## robomimic HDF5
+
+robomimic-style HDF5 datasets usually store many demonstrations in one file.
+Each demo group is one episode:
+
+- `/data/demo_*/actions`
+- `/data/demo_*/obs/<field>`
+- `/data/demo_*/rewards`
+- `/data/demo_*/dones`
+
+`read_hdf5(groups="/data/demo_*")` emits one row per matched demo group, and
+`datasets=` paths are relative to that demo group.
+
+```python
+import refiner as mdr
+
+pipeline = (
+    mdr.read_hdf5(
+        "/data/robomimic.hdf5",
+        groups="/data/demo_*",
+        datasets={
+            "actions": "actions",
+            "joint_pos": "obs/robot0_joint_pos",
+            "joint_vel": "obs/robot0_joint_vel",
+            "eef_pos": "obs/robot0_eef_pos",
+            "gripper_qpos": "obs/robot0_gripper_qpos",
+            "agentview": "obs/agentview_image",
+            "wrist": "obs/robot0_eye_in_hand_image",
+        },
+        attrs={"task": "task"},
+        group_path_column="episode_id",
+    )
+    .to_robot_rows(
+        episode_id_key="episode_id",
+        task_key="task",
+        action_key="actions",
+        state_key=("joint_pos", "joint_vel", "eef_pos", "gripper_qpos"),
+        video_keys=("agentview", "wrist"),
+    )
+)
+```

--- a/src/refiner/pipeline/data/datatype.py
+++ b/src/refiner/pipeline/data/datatype.py
@@ -14,6 +14,13 @@ _BYTES_WITH_PATH_TYPE = pa.struct(
         pa.field("path", pa.string()),
     ]
 )
+_VIDEO_FRAME_ARRAY_TYPE = pa.large_list(
+    pa.large_list(
+        pa.large_list(
+            pa.list_(pa.uint8(), list_size=3),
+        ),
+    ),
+)
 
 DTypeLike: TypeAlias = str | pa.DataType | pa.Field
 DTypeMapping: TypeAlias = Mapping[str, DTypeLike]
@@ -137,6 +144,10 @@ def video_bytes_with_path() -> pa.Field:
     return asset_bytes_with_path("video")
 
 
+def video_frame_array() -> pa.Field:
+    return _asset_field("video", _VIDEO_FRAME_ARRAY_TYPE)
+
+
 def pdf_path() -> pa.Field:
     return asset_path("pdf")
 
@@ -225,6 +236,8 @@ def asset_storage(field: pa.Field) -> str | None:
         return "bytes"
     if _is_bytes_with_path_type(field_type):
         return "bytes_with_path"
+    if _is_video_frame_array_type(field_type):
+        return "frame_array"
     return None
 
 
@@ -271,6 +284,10 @@ def _is_bytes_with_path_type(field_type: pa.DataType) -> builtins.bool:
     return (
         pa.types.is_binary(bytes_type) or pa.types.is_large_binary(bytes_type)
     ) and (pa.types.is_string(path_type) or pa.types.is_large_string(path_type))
+
+
+def _is_video_frame_array_type(field_type: pa.DataType) -> builtins.bool:
+    return field_type.equals(_VIDEO_FRAME_ARRAY_TYPE)
 
 
 def _replace_field_dtype(
@@ -387,5 +404,6 @@ __all__ = [
     "uint64",
     "video_bytes",
     "video_bytes_with_path",
+    "video_frame_array",
     "video_path",
 ]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from fsspec import AbstractFileSystem
 
@@ -158,6 +158,49 @@ class RefinerPipeline:
                 dtypes=dtypes,
             )
         )
+
+    def to_robot_rows(
+        self,
+        *,
+        episode_id_key: str | None = None,
+        task_key: str | None = None,
+        fps: float | None = None,
+        fps_key: str | None = None,
+        robot_type: str | None = None,
+        robot_type_key: str | None = None,
+        nested_frames_key: str | None = None,
+        timestamp_key: str | None = "timestamp",
+        action_key: str | None = "action",
+        state_key: str | Sequence[str] | None = "observation.state",
+        extra_observation_keys: Mapping[str, str] | Iterable[str] | None = None,
+        video_keys: Mapping[str, str] | Iterable[str] | None = None,
+        stats_key: str | None = "stats",
+        stats_prefix: str = "stats/",
+        episode_ends_key: str | None = None,
+    ) -> "RefinerPipeline":
+        from refiner.robotics.row import _robot_row_converter
+
+        converter = _robot_row_converter(
+            episode_id_key=episode_id_key,
+            task_key=task_key,
+            fps=fps,
+            fps_key=fps_key,
+            robot_type=robot_type,
+            robot_type_key=robot_type_key,
+            nested_frames_key=nested_frames_key,
+            timestamp_key=timestamp_key,
+            action_key=action_key,
+            state_key=state_key,
+            extra_observation_keys=extra_observation_keys,
+            video_keys=video_keys,
+            schema=self.output_schema(),
+            stats_key=stats_key,
+            stats_prefix=stats_prefix,
+            episode_ends_key=episode_ends_key,
+        )
+        if episode_ends_key is None:
+            return self.map(cast(MapFn, converter))
+        return self.flat_map(cast(FlatMapFn, converter))
 
     def map_async(
         self,

--- a/src/refiner/pipeline/sinks/lerobot.py
+++ b/src/refiner/pipeline/sinks/lerobot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -12,7 +13,7 @@ import pyarrow.parquet as pq
 from refiner.execution.asyncio.runtime import submit
 from refiner.execution.asyncio.window import AsyncWindow
 from refiner.io.datafolder import DataFolder, DataFolderLike
-from refiner.video import VideoFile
+from refiner.video import VideoSource
 from refiner.video.writer import VideoStreamWriter, VideoTranscodeConfig
 from refiner.pipeline.data.block import Block
 from refiner.pipeline.data.row import DictRow, Row
@@ -25,12 +26,15 @@ from refiner.robotics.lerobot_format import (
     LeRobotInfo,
     LeRobotMetadata,
     LeRobotRow,
+    LeRobotStatsFile,
+    LeRobotTasks,
     LeRobotVideoInfo,
     LeRobotVideoStatsAccumulator,
     compute_table_stats,
     default_feature_info_by_key,
     infer_feature_info,
 )
+from refiner.robotics.row import RoboticsRow
 from refiner.utils import check_required_dependencies
 from refiner.worker.context import get_active_worker_token
 from refiner.worker.metrics.api import register_gauge
@@ -55,6 +59,7 @@ class _LeRobotShardState:
     video_writers: dict[str, VideoStreamWriter] = field(
         default_factory=dict, init=False
     )
+    generic_task_to_index: dict[str, int] = field(default_factory=dict, init=False)
 
 
 @dataclass(slots=True)
@@ -243,22 +248,72 @@ class LeRobotWriterSink(BaseSink):
 
     async def _write_row(self, state: _LeRobotShardState, row: Row) -> None:
         """Write one LeRobot episode into staged shard-local outputs."""
-        metadata = row.metadata if isinstance(row, LeRobotRow) else row.get("metadata")
-        if not isinstance(metadata, LeRobotMetadata):
-            raise ValueError("LeRobot writer requires LeRobot metadata on each row")
-
+        is_lerobot_row = isinstance(row, LeRobotRow)
+        is_generic_robotics_row = not is_lerobot_row and isinstance(row, RoboticsRow)
         if isinstance(row, LeRobotRow):
+            metadata = row.metadata
             frames = (
                 row.frames
                 if isinstance(row.frames, Tabular)
                 else Tabular.from_rows(cast(Sequence[Row], row.frames))
             )
+        elif is_generic_robotics_row:
+            robotics_row = cast(RoboticsRow, row)
+            task_index = None
+            if robotics_row.task is not None:
+                task_index = state.generic_task_to_index.get(robotics_row.task)
+                if task_index is None:
+                    digest = hashlib.blake2b(
+                        robotics_row.task.encode("utf-8"),
+                        digest_size=8,
+                    ).digest()
+                    task_index = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+                    existing_task = next(
+                        (
+                            task
+                            for task, index in state.generic_task_to_index.items()
+                            if index == task_index
+                        ),
+                        None,
+                    )
+                    if existing_task is not None:
+                        raise ValueError(
+                            "LeRobot writer encountered colliding task_index values "
+                            f"for {existing_task!r} and {robotics_row.task!r}"
+                        )
+                    state.generic_task_to_index[robotics_row.task] = task_index
+            frames = robotics_row.to_frame_table()
+            if task_index is not None:
+                frames = frames.with_table(
+                    set_or_append_column(
+                        frames.table,
+                        "task_index",
+                        pa.array([task_index] * frames.num_rows, type=pa.int64()),
+                    )
+                )
+            elif "task_index" in frames.table.column_names:
+                frames = frames.with_table(frames.table.drop(["task_index"]))
+
+            metadata = LeRobotMetadata(
+                info=LeRobotInfo(
+                    fps=(
+                        int(robotics_row.fps) if robotics_row.fps is not None else None
+                    ),
+                    robot_type=robotics_row.robot_type,
+                ),
+                stats=LeRobotStatsFile({}),
+                tasks=LeRobotTasks(
+                    {
+                        task_index: task
+                        for task, task_index in state.generic_task_to_index.items()
+                    }
+                ),
+            )
         else:
-            frames = Tabular.from_rows(
-                [
-                    frame if isinstance(frame, Row) else DictRow(frame)
-                    for frame in row["frames"]
-                ]
+            raise ValueError(
+                "write_lerobot requires LeRobotRow or RoboticsRow inputs. "
+                "Call to_robot_rows(...) before write_lerobot(...) when writing "
+                "raw robotics rows."
             )
         if frames.num_rows <= 0:
             # empty frames
@@ -266,29 +321,38 @@ class LeRobotWriterSink(BaseSink):
 
         if isinstance(row, LeRobotRow):
             base_row = row._row
-            video_inputs = [
-                (video_ref.key, video_ref.video) for video_ref in row.videos.values()
-            ]
+            video_inputs = list(row.videos.items())
             source_stats_by_key = {key: row.stats.get(key) for key, _ in video_inputs}
             frame_count = row.length
         else:
-            base_row = DictRow(
-                {
-                    key: value
-                    for key, value in row.items()
-                    if key not in {"frames", "metadata"}
-                    and not isinstance(value, VideoFile)
-                },
-                shard_id=row.shard_id,
-            )
-            video_inputs = [
-                (key, value)
-                for key, value in row.items()
-                if isinstance(value, VideoFile)
-            ]
-            source_stats_by_key: dict[str, LeRobotFeatureStats | None] = {
-                key: None for key, _ in video_inputs
-            }
+            robotics_row = cast(RoboticsRow, row)
+            base_values: dict[str, Any] = {}
+            if isinstance(row, Mapping):
+                base_values.update(
+                    {
+                        key: value
+                        for key, value in row.items()
+                        if key not in {"frames", "metadata"}
+                        and not isinstance(value, VideoSource)
+                    }
+                )
+            try:
+                episode_index = int(robotics_row.episode_id)
+            except ValueError:
+                episode_index = -1
+            if not (0 <= episode_index < 2**63):
+                digest = hashlib.blake2b(
+                    robotics_row.episode_id.encode("utf-8"),
+                    digest_size=8,
+                ).digest()
+                episode_index = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+            base_values.setdefault("episode_index", episode_index)
+            base_values.setdefault("episode_id", robotics_row.episode_id)
+            if robotics_row.task is not None:
+                base_values.setdefault("task", robotics_row.task)
+            base_row = DictRow(base_values, shard_id=row.shard_id)
+            video_inputs = list(robotics_row.videos.items())
+            source_stats_by_key = {key: None for key, _ in video_inputs}
             frame_count = frames.num_rows
 
         if state.metadata is None:
@@ -300,6 +364,8 @@ class LeRobotWriterSink(BaseSink):
             raise ValueError(
                 "LeRobot writer requires stable fps and robot_type within each shard"
             )
+        elif is_generic_robotics_row:
+            state.metadata = metadata
         elif metadata.tasks.index_to_task != state.metadata.tasks.index_to_task:
             raise ValueError(
                 "LeRobot writer encountered mismatched task metadata across episodes"
@@ -410,7 +476,7 @@ class LeRobotWriterSink(BaseSink):
         state: _LeRobotShardState,
         *,
         video_key: str,
-        video: VideoFile,
+        video: VideoSource,
         frame_count: int,
         source_stats: LeRobotFeatureStats | None,
     ) -> tuple[str, dict[str, Any], LeRobotFeatureInfo | None]:
@@ -419,12 +485,11 @@ class LeRobotWriterSink(BaseSink):
             frame_count=frame_count,
             quantile_bins=self.quantile_bins,
         )
-        written = await self._video_writer(state, video_key).write_video(
-            # source video
-            video,
-            # callback to not shove lerobot logic inside video writer
+        written = await video.write_to(
+            self._video_writer(state, video_key),
             frame_observer=accumulator.observe_rgb_frame,
-            # if this episode has no video stats, or if we have been force to manually recompute all episodes, use transcode
+            # Remux can reuse source video stats. Transcode when stats are missing,
+            # explicitly stale, or the caller requests recomputation.
             force_transcode=(
                 self.force_recompute_video_stats
                 or source_stats is None

--- a/src/refiner/pipeline/sinks/reducer/lerobot.py
+++ b/src/refiner/pipeline/sinks/reducer/lerobot.py
@@ -144,17 +144,17 @@ class LeRobotMetaReduceSink(BaseSink):
         )
 
         # tasks
-        for current in tasks_tables[1:]:
-            if not current.equals(tasks_tables[0]):
-                raise ValueError(
-                    "LeRobot reduce encountered mismatched canonical task tables "
-                    "across stage-1 shard outputs"
-                )
-        tasks = (
-            LeRobotTasks({})
-            if not tasks_tables
-            else LeRobotTasks.from_table(tasks_tables[0])
-        )
+        task_items: dict[int, str] = {}
+        for table in tasks_tables:
+            for task_index, task in LeRobotTasks.from_table(table).items():
+                existing = task_items.get(task_index)
+                if existing is not None and existing != task:
+                    raise ValueError(
+                        "LeRobot reduce encountered conflicting task_index "
+                        f"{task_index}: {existing!r} vs {task!r}"
+                    )
+                task_items[task_index] = task
+        tasks = LeRobotTasks(task_items)
 
         # info jsons
         if not info_items:

--- a/src/refiner/pipeline/utils/cache/decoder_cache.py
+++ b/src/refiner/pipeline/utils/cache/decoder_cache.py
@@ -61,8 +61,8 @@ class OpenedVideoSourceCache(LeaseCache[str, OpenedVideoSource]):
         source = await asyncio.get_running_loop().run_in_executor(
             io_executor(),
             partial(
-                _open_video_source,
-                uri=key,
+                open_video_source,
+                video=DataFile.resolve(key),
             ),
         )
         return source, 0
@@ -106,13 +106,16 @@ def _probe_video_source(
     )
 
 
-def _open_video_source(
-    *,
-    uri: str,
-) -> OpenedVideoSource:
+def open_video_source(video: Any) -> OpenedVideoSource:
     import av
 
-    input_file = DataFile.resolve(uri).open("rb")
+    source_name = str(video)
+    if isinstance(video, DataFile):
+        source_name = str(video)
+        input_file = video.open(mode="rb")
+    else:
+        source_name = str(getattr(video, "uri", type(video).__name__))
+        input_file = video.open()
     try:
         container = av.open(input_file, mode="r")
         stream = cast(
@@ -122,12 +125,12 @@ def _open_video_source(
         if stream is None:
             container.close()
             input_file.close()
-            raise ValueError(f"Video source has no video stream for {uri!r}")
+            raise ValueError(f"Video source has no video stream for {source_name!r}")
         probe = _probe_video_source(
             container=container,
         )
         return OpenedVideoSource(
-            uri=uri,
+            uri=source_name,
             probe=probe,
             input_file=input_file,
             container=container,
@@ -190,5 +193,6 @@ __all__ = [
     "OpenedVideoSourceCache",
     "VideoSourceProbe",
     "get_opened_video_source_cache",
+    "open_video_source",
     "reset_opened_video_source_cache",
 ]

--- a/src/refiner/robotics/__init__.py
+++ b/src/refiner/robotics/__init__.py
@@ -1,5 +1,8 @@
 from refiner.robotics.motion import motion_trim
 from refiner.robotics.reward import reward_score
+from refiner.robotics.row import (
+    RoboticsRow,
+)
 from refiner.robotics.lerobot_format import (
     LeRobotFeatureInfo,
     LeRobotFeatureStats,
@@ -15,6 +18,7 @@ from refiner.robotics.lerobot_format import (
 __all__ = [
     "motion_trim",
     "reward_score",
+    "RoboticsRow",
     "LeRobotRow",
     "LeRobotTabular",
     "LeRobotFeatureInfo",

--- a/src/refiner/robotics/lerobot_format/__init__.py
+++ b/src/refiner/robotics/lerobot_format/__init__.py
@@ -2,7 +2,6 @@ from refiner.robotics.lerobot_format.tabular import LeRobotTabular
 from refiner.robotics.lerobot_format.row import (
     LeRobotRow,
     LeRobotStatsView,
-    LeRobotVideoRef,
     LeRobotVideosView,
 )
 from refiner.robotics.lerobot_format.metadata import (
@@ -35,7 +34,6 @@ __all__ = [
     "LeRobotStatsView",
     "LeRobotTasks",
     "LeRobotVideoInfo",
-    "LeRobotVideoRef",
     "LeRobotVideosView",
     "compute_feature_stats",
     "compute_table_stats",

--- a/src/refiner/robotics/lerobot_format/row.py
+++ b/src/refiner/robotics/lerobot_format/row.py
@@ -4,68 +4,21 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import pyarrow as pa
+
 from refiner.io import DataFolder
-from refiner.video import VideoFile
+from refiner.video import VideoFile, VideoSource
 from refiner.pipeline.data.row import Row
-from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.data.tabular import Tabular, set_or_append_column
 from refiner.robotics.lerobot_format.metadata.info import DEFAULT_VIDEO_PATH
 from refiner.robotics.lerobot_format.metadata.metadata import LeRobotMetadata
 from refiner.robotics.lerobot_format.metadata.stats import (
     LeRobotFeatureStats,
 )
+from refiner.robotics.row import RoboticsRow
 
 if TYPE_CHECKING:
     from refiner.robotics.lerobot_format.tabular import LeRobotTabular
-
-
-@dataclass(frozen=True, slots=True)
-class LeRobotVideoRef:
-    _row: "LeRobotRow"
-    key: str
-
-    @property
-    def video(self) -> VideoFile:
-        return self._row._build_video_file(self.key)
-
-    @property
-    def uri(self) -> str:
-        return self.video.uri
-
-    @property
-    def from_timestamp_s(self) -> float | None:
-        return self.video.from_timestamp_s
-
-    @property
-    def to_timestamp_s(self) -> float | None:
-        return self.video.to_timestamp_s
-
-    def with_timestamps(
-        self,
-        *,
-        from_timestamp_s: float | None = None,
-        to_timestamp_s: float | None = None,
-    ) -> "LeRobotRow":
-        return self._row.with_video(
-            self.key,
-            from_timestamp_s=from_timestamp_s,
-            to_timestamp_s=to_timestamp_s,
-        )
-
-    def with_uri(self, uri: str) -> "LeRobotRow":
-        return self._row.with_video(self.key, uri=uri)
-
-    def shift(self, delta_s: float) -> "LeRobotRow":
-        from_timestamp = self._row._row.get(f"videos/{self.key}/from_timestamp")
-        to_timestamp = self._row._row.get(f"videos/{self.key}/to_timestamp")
-        return self._row.with_video(
-            self.key,
-            from_timestamp_s=(
-                float(from_timestamp) + delta_s if from_timestamp is not None else None
-            ),
-            to_timestamp_s=(
-                float(to_timestamp) + delta_s if to_timestamp is not None else None
-            ),
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,16 +62,15 @@ class LeRobotStatsView(Mapping[str, LeRobotFeatureStats]):
 
 
 @dataclass(frozen=True, slots=True)
-class LeRobotVideosView(Mapping[str, LeRobotVideoRef]):
+class LeRobotVideosView(Mapping[str, VideoFile]):
     _row: "LeRobotRow"
 
-    def __getitem__(self, key: str) -> LeRobotVideoRef:
+    def __getitem__(self, key: str) -> VideoFile:
         row = self._row
         uri_key = f"videos/{key}/uri"
         if uri_key not in row._row:
             row = row.update({uri_key: row._build_default_video_uri(key)})
-        row._build_video_file(key)
-        return LeRobotVideoRef(row, key)
+        return row._build_video_file(key)
 
     def __iter__(self) -> Iterator[str]:
         video_keys = {
@@ -133,7 +85,7 @@ class LeRobotVideosView(Mapping[str, LeRobotVideoRef]):
 
 
 @dataclass(frozen=True, slots=True)
-class LeRobotRow(Row):
+class LeRobotRow(Row, RoboticsRow):
     _row: Row
     metadata: LeRobotMetadata
     frames: Sequence[Row] | Tabular
@@ -166,8 +118,97 @@ class LeRobotRow(Row):
         return int(self._row["episode_index"])
 
     @property
+    def episode_id(self) -> str:
+        episode_id = self._row.get("episode_id")
+        return str(episode_id) if episode_id is not None else str(self.episode_index)
+
+    @property
     def tasks(self) -> list[str]:
         return list(self._row.get("tasks", []))
+
+    @property
+    def task(self) -> str | None:
+        task = self._row.get("task")
+        return task if isinstance(task, str) else None
+
+    @property
+    def num_frames(self) -> int:
+        return self.to_frame_table().num_rows
+
+    def _frame_values(self, key: str) -> Any:
+        return self.to_frame_table().column(key)
+
+    @property
+    def timestamps(self) -> Any:
+        return self._optional_frame_values("timestamp")
+
+    @property
+    def actions(self) -> Any:
+        return self._optional_frame_values("action")
+
+    @property
+    def states(self) -> Any:
+        return self._optional_frame_values("observation.state")
+
+    def observations(self, name: str | None = None) -> Any:
+        table = self.to_frame_table()
+        values: dict[str, Any] = {
+            key[len("observation.") :]: table.column(key)
+            for key in table.names
+            if key.startswith("observation.")
+        }
+        values.update({f"videos/{key}": video for key, video in self.videos.items()})
+        if name is None:
+            return values
+        normalized_name = (
+            name[len("observation.") :] if name.startswith("observation.") else name
+        )
+        return values[normalized_name]
+
+    def _optional_frame_values(self, key: str) -> Any:
+        table = self.to_frame_table()
+        return table.column(key) if key in table.names else None
+
+    def with_timestamps(self, values: Any) -> "LeRobotRow":
+        return self._with_frame_values("timestamp", values)
+
+    def with_actions(self, values: Any) -> "LeRobotRow":
+        return self._with_frame_values("action", values)
+
+    def with_observation(self, key: str, values: Any) -> "LeRobotRow":
+        frame_key = key if key.startswith("observation.") else f"observation.{key}"
+        return self._with_frame_values(frame_key, values)
+
+    def _with_frame_values(self, key: str, values: Any) -> "LeRobotRow":
+        frames = self.to_frame_table()
+        value_type = (
+            frames.table.schema.field(key).type
+            if key in frames.table.column_names
+            else None
+        )
+        column = (
+            values
+            if isinstance(values, (pa.Array, pa.ChunkedArray))
+            else pa.array(values, type=value_type)
+        )
+        return self.update(
+            frames=frames.with_table(set_or_append_column(frames.table, key, column))
+        )
+
+    def to_frame_table(self) -> Tabular:
+        return (
+            self.frames
+            if isinstance(self.frames, Tabular)
+            else Tabular.from_rows(self.frames)
+        )
+
+    @property
+    def fps(self) -> float | None:
+        return self.metadata.info.fps
+
+    @property
+    def robot_type(self) -> str | None:
+        return self.metadata.info.robot_type
 
     @property
     def length(self) -> int:
@@ -202,7 +243,8 @@ class LeRobotRow(Row):
         file_idx = self._row.get(f"videos/{key}/file_index")
         if chunk is None or file_idx is None or self.root is None:
             raise KeyError(key)
-        return DEFAULT_VIDEO_PATH.format(
+        video_path = self.metadata.info.video_path or DEFAULT_VIDEO_PATH
+        return video_path.format(
             video_key=key,
             chunk_index=chunk,
             file_index=file_idx,
@@ -216,21 +258,38 @@ class LeRobotRow(Row):
     def stats(self) -> LeRobotStatsView:
         return LeRobotStatsView(self)
 
+    def select_frames(self, indices: Sequence[int]) -> "LeRobotRow":
+        frames = self.to_frame_table()
+        selected = frames.table.take(pa.array(indices, type=pa.int64()))
+        if "frame_index" in selected.column_names:
+            selected = set_or_append_column(
+                selected,
+                "frame_index",
+                pa.array(range(selected.num_rows), type=pa.int64()),
+            )
+        return self.update(
+            {
+                "length": selected.num_rows,
+                "frames": frames.with_table(selected),
+            }
+        )
+
+    def drop_stats(self, feature: str) -> "LeRobotRow":
+        return self.stats.drop(feature)
+
     def with_video(
         self,
         key: str,
-        *,
-        uri: str | None = None,
-        from_timestamp_s: float | None = None,
-        to_timestamp_s: float | None = None,
+        video: VideoSource,
     ) -> "LeRobotRow":
+        if not isinstance(video, VideoFile):
+            raise TypeError("LeRobotRow.with_video requires a VideoFile")
         patch: dict[str, Any] = {}
-        if uri is not None:
-            patch[f"videos/{key}/uri"] = uri
-        if from_timestamp_s is not None:
-            patch[f"videos/{key}/from_timestamp"] = from_timestamp_s
-        if to_timestamp_s is not None:
-            patch[f"videos/{key}/to_timestamp"] = to_timestamp_s
+        patch[f"videos/{key}/uri"] = video.uri
+        if video.from_timestamp_s is not None:
+            patch[f"videos/{key}/from_timestamp"] = video.from_timestamp_s
+        if video.to_timestamp_s is not None:
+            patch[f"videos/{key}/to_timestamp"] = video.to_timestamp_s
         return self.update(patch)
 
     def with_stats(
@@ -283,6 +342,5 @@ class LeRobotRow(Row):
 __all__ = [
     "LeRobotRow",
     "LeRobotStatsView",
-    "LeRobotVideoRef",
     "LeRobotVideosView",
 ]

--- a/src/refiner/robotics/motion.py
+++ b/src/refiner/robotics/motion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import cast
 
 import numpy as np
 import pyarrow as pa
@@ -8,10 +9,12 @@ import pyarrow as pa
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
 from refiner.pipeline.planning import describe_builtin
-from refiner.robotics.lerobot_format import LeRobotRow
+from refiner.robotics.row import RoboticsRow
 
 
-def _motion_energy(values: np.ndarray | list[object]) -> np.ndarray:
+def _motion_energy(values: object) -> np.ndarray:
+    if isinstance(values, (pa.Array, pa.ChunkedArray)):
+        values = values.to_pylist()
     values = np.asarray(values, dtype=np.float32)
     values = values.reshape(-1, 1) if values.ndim == 1 else values
     energy = np.zeros(len(values), dtype=np.float32)
@@ -28,15 +31,16 @@ def motion_trim(
     *,
     threshold: float = 0.001,
     pad_frames: int = 0,
+    timestamp_key: str = "timestamp",
     action_key: str = "action",
-    state_key: str = "observation.state",
+    state_key: str | Sequence[str] = "observation.state",
 ) -> Callable[[Row], Row]:
-    """Return a row mapper that trims LeRobot episodes to the active motion window.
+    """Return a row mapper that trims robotics episodes to the active motion window.
 
     The trim span is inferred from the earliest action/state activity above the
-    threshold and then applied to the episode frame list. LeRobot video timestamp
-    fields are updated on the row itself, and stale video stats are dropped so
-    downstream sinks recompute them.
+    threshold and then applied to the episode frame data. Video timestamps are
+    clipped to the same span, and stale video stats are dropped so writers
+    recompute them.
     """
 
     if not action_key:
@@ -47,55 +51,66 @@ def motion_trim(
         raise ValueError("threshold must be >= 0")
     if pad_frames < 0:
         raise ValueError("pad_frames must be >= 0")
+    if not timestamp_key:
+        raise ValueError("timestamp_key cannot be empty")
 
     @describe_builtin(
         "robotics:motion_trim",
         threshold=threshold,
         pad_frames=pad_frames,
+        timestamp_key=timestamp_key,
         action_key=action_key,
         state_key=state_key,
     )
     def _trim(row: Row) -> Row:
-        if not isinstance(row, LeRobotRow):
-            raise ValueError("motion_trim requires LeRobotRow inputs")
+        if not isinstance(row, RoboticsRow):
+            raise ValueError("motion_trim requires RoboticsRow inputs")
 
-        frames = (
-            row.frames
-            if isinstance(row.frames, Tabular)
-            else Tabular.from_rows(row.frames)
-        )
-        frame_table = frames.table
-        if frame_table.num_rows <= 0 or any(
-            key not in frame_table.column_names
-            for key in ("timestamp", action_key, state_key)
-        ):
+        if row.num_frames <= 0:
             raise ValueError(
-                "motion_trim requires LeRobot-format rows with non-empty 'frames' "
-                f"containing 'timestamp', '{action_key}', and '{state_key}'"
+                "motion_trim requires robotics rows with non-empty frames "
+                f"containing '{timestamp_key}', '{action_key}', and '{state_key}'"
             )
         if row.shard_id is not None:
-            row.log_throughput("frames_in", frames.num_rows, unit="frames")
+            row.log_throughput("frames_in", row.num_frames, unit="frames")
 
-        # timestamps
-        timestamp_column = frame_table.column("timestamp")
-        timestamps = np.asarray(
-            timestamp_column.to_numpy(zero_copy_only=False),
-            dtype=np.float32,
+        try:
+            frame_table = row.to_frame_table()
+            timestamp_values = row.timestamps
+            if timestamp_values is None:
+                timestamp_values = frame_table.column(timestamp_key)
+            action_values = row.actions
+            if action_values is None:
+                action_values = frame_table.column(action_key)
+            state_values = row.states
+            if state_values is None:
+                if not isinstance(state_key, str):
+                    raise KeyError(state_key)
+                state_values = frame_table.column(state_key)
+        except KeyError as exc:
+            raise ValueError(
+                "motion_trim requires robotics rows with non-empty frames "
+                f"containing '{timestamp_key}', '{action_key}', and '{state_key}'"
+            ) from exc
+
+        # Normalize timestamps to a dense float array for window selection.
+        timestamps = (
+            np.asarray(
+                timestamp_values.to_numpy(zero_copy_only=False), dtype=np.float32
+            )
+            if isinstance(timestamp_values, (pa.Array, pa.ChunkedArray))
+            else np.asarray(timestamp_values, dtype=np.float32)
         ).reshape(-1)
 
         # compute motion energy for actions and state
-        action_active = np.flatnonzero(
-            _motion_energy(frame_table.column(action_key).to_pylist()) > threshold
-        )
-        state_active = np.flatnonzero(
-            _motion_energy(frame_table.column(state_key).to_pylist()) > threshold
-        )
+        action_active = np.flatnonzero(_motion_energy(action_values) > threshold)
+        state_active = np.flatnonzero(_motion_energy(state_values) > threshold)
         if action_active.size == 0 and state_active.size == 0:
             if row.shard_id is not None:
                 row.log_throughput("episodes_fully_trimmed", 1, unit="episodes")
-                row.log_throughput("frames_removed", frames.num_rows, unit="frames")
+                row.log_throughput("frames_removed", row.num_frames, unit="frames")
                 row.log_histogram("trim_fraction", 1.0, unit="ratio")
-            return row.update(frames=[])
+            return cast(Row, row.select_frames([]))
 
         start_candidates = [
             int(active[0])
@@ -108,56 +123,57 @@ def motion_trim(
             if active.size > 0
         ]
         start_idx = max(0, min(start_candidates) - 1 - pad_frames)
-        end_idx = min(frame_table.num_rows - 1, max(end_candidates) + pad_frames)
-        kept_table = frame_table.slice(start_idx, end_idx - start_idx + 1)
+        end_idx = min(row.num_frames - 1, max(end_candidates) + pad_frames)
+        keep_indices = list(range(start_idx, end_idx + 1))
         kept_start_ts = float(timestamps[start_idx])
-        removed_frames = frame_table.num_rows - kept_table.num_rows
+        removed_frames = row.num_frames - len(keep_indices)
         if row.shard_id is not None:
             if removed_frames > 0:
                 row.log_throughput("episodes_trimmed", 1, unit="episodes")
                 row.log_throughput("frames_removed", removed_frames, unit="frames")
-            row.log_throughput("frames_out", kept_table.num_rows, unit="frames")
+            row.log_throughput("frames_out", len(keep_indices), unit="frames")
             row.log_histogram(
                 "trim_fraction",
-                removed_frames / max(1, frame_table.num_rows),
+                removed_frames / max(1, row.num_frames),
                 unit="ratio",
             )
         kept_duration_s = (
             float(timestamps[end_idx + 1]) - kept_start_ts
-            if end_idx + 1 < frame_table.num_rows
+            if end_idx + 1 < row.num_frames
             else None
         )
-        kept_table = set_or_append_column(
-            kept_table,
-            "frame_index",
-            pa.array(range(kept_table.num_rows), type=pa.int64()),
-        )
-        kept_table = set_or_append_column(
-            kept_table,
-            "timestamp",
-            pa.array(
-                (timestamps[start_idx : end_idx + 1] - kept_start_ts).tolist(),
-                type=kept_table.column("timestamp").type,
-            ),
-        )
-
-        trimmed = row.update(frames=frames.with_table(kept_table))
-        for video_key, video_ref in row.videos.items():
-            base_from_ts = video_ref.from_timestamp_s or 0.0
-            trimmed_from_ts = base_from_ts + kept_start_ts
-            trimmed_to_ts = (
-                trimmed_from_ts + kept_duration_s
-                if kept_duration_s is not None
-                else video_ref.to_timestamp_s
+        trimmed = row.select_frames(keep_indices)
+        shifted_timestamps = (timestamps[keep_indices] - kept_start_ts).tolist()
+        if trimmed.timestamps is not None:
+            trimmed = trimmed.with_timestamps(shifted_timestamps)
+        else:
+            frame_table = trimmed.to_frame_table()
+            value_type = (
+                frame_table.table.schema.field(timestamp_key).type
+                if timestamp_key in frame_table.names
+                else None
             )
+            trimmed = trimmed.update(
+                frames=Tabular(
+                    set_or_append_column(
+                        frame_table.table,
+                        timestamp_key,
+                        pa.array(shifted_timestamps, type=value_type),
+                    )
+                )
+            )
+        for video_key, video in row.videos.items():
+            trimmed_to_ts = kept_duration_s
             trimmed = trimmed.with_video(
                 video_key,
-                from_timestamp_s=trimmed_from_ts,
-                to_timestamp_s=trimmed_to_ts,
+                video.clipped(
+                    from_timestamp_s=kept_start_ts,
+                    to_timestamp_s=trimmed_to_ts,
+                ),
             )
-            trimmed = trimmed.stats.drop(video_key)
+            trimmed = trimmed.drop_stats(video_key)
 
-        return trimmed
+        return cast(Row, trimmed)
 
     return _trim
 

--- a/src/refiner/robotics/reward.py
+++ b/src/refiner/robotics/reward.py
@@ -188,7 +188,7 @@ async def _sample_video_frames(
 ) -> list[DecodedVideoFrame]:
     target_indexes = set(_sample_indexes(row.length, max_frames=max_frames))
     frames: list[DecodedVideoFrame] = []
-    async for frame in row.videos[video_key].video.iter_frames():
+    async for frame in row.videos[video_key].iter_frames():
         if frame.index in target_indexes:
             frames.append(frame)
         if len(frames) == len(target_indexes):

--- a/src/refiner/robotics/row.py
+++ b/src/refiner/robotics/row.py
@@ -1,0 +1,926 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, replace as dataclass_replace
+from typing import Any, Protocol, TypeVar, cast, runtime_checkable
+
+import pyarrow as pa
+
+from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.data.datatype import asset_storage, asset_type
+from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.data.tabular import set_or_append_column
+from refiner.video import VideoSource, video_from_storage_value
+
+
+RoboticsRowT = TypeVar("RoboticsRowT", bound="RoboticsRow")
+_FrameSource = str | tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _RoboticsRowSpec:
+    episode_id_key: str | None = None
+    task_key: str | None = None
+    fps: float | None = None
+    fps_key: str | None = None
+    robot_type: str | None = None
+    robot_type_key: str | None = None
+    nested_frames_key: str | None = None
+    frame_sources: Mapping[str, _FrameSource] | None = None
+    video_sources: Mapping[str, tuple[str, str | None]] | None = None
+    stats_key: str | None = "stats"
+    stats_prefix: str = "stats/"
+
+    @classmethod
+    def from_options(
+        cls,
+        *,
+        episode_id_key: str | None = None,
+        task_key: str | None = None,
+        fps: float | None = None,
+        fps_key: str | None = None,
+        robot_type: str | None = None,
+        robot_type_key: str | None = None,
+        nested_frames_key: str | None = None,
+        timestamp_key: str | None = "timestamp",
+        action_key: str | None = "action",
+        state_key: str | Sequence[str] | None = "observation.state",
+        extra_observation_keys: Mapping[str, str] | Iterable[str] | None = None,
+        video_keys: Mapping[str, str] | Iterable[str] | None = None,
+        schema: pa.Schema | None = None,
+        stats_key: str | None = "stats",
+        stats_prefix: str = "stats/",
+    ) -> "_RoboticsRowSpec":
+        return cls(
+            episode_id_key=episode_id_key,
+            task_key=task_key,
+            fps=fps,
+            fps_key=fps_key,
+            robot_type=robot_type,
+            robot_type_key=robot_type_key,
+            nested_frames_key=nested_frames_key,
+            frame_sources=_semantic_source_map(
+                timestamp_key=timestamp_key,
+                action_key=action_key,
+                state_key=state_key,
+                extra_observation_keys=extra_observation_keys,
+            ),
+            video_sources=_video_sources(schema=schema, video_keys=video_keys),
+            stats_key=stats_key,
+            stats_prefix=stats_prefix,
+        )
+
+    @property
+    def frame_source_map(self) -> Mapping[str, _FrameSource]:
+        return self.frame_sources or {}
+
+    @property
+    def video_source_map(self) -> Mapping[str, tuple[str, str | None]]:
+        return self.video_sources or {}
+
+    def wrap(self, row: Row) -> RoboticsRow:
+        return _RoboticsRowView(row, self)
+
+
+@runtime_checkable
+class RoboticsRow(Protocol):
+    """Common semantic view over one robotics episode."""
+
+    @property
+    def shard_id(self) -> str | None: ...
+
+    @property
+    def episode_id(self) -> str: ...
+
+    @property
+    def num_frames(self) -> int: ...
+
+    @property
+    def task(self) -> str | None: ...
+
+    @property
+    def fps(self) -> float | None: ...
+
+    @property
+    def robot_type(self) -> str | None: ...
+
+    @property
+    def videos(self) -> Mapping[str, VideoSource]: ...
+
+    @property
+    def stats(self) -> Mapping[str, Any]: ...
+
+    @property
+    def timestamps(self) -> Any: ...
+
+    @property
+    def actions(self) -> Any: ...
+
+    @property
+    def states(self) -> Any: ...
+
+    def observations(self, name: str | None = None) -> Any: ...
+
+    def with_timestamps(self: RoboticsRowT, values: Any) -> RoboticsRowT: ...
+
+    def with_actions(self: RoboticsRowT, values: Any) -> RoboticsRowT: ...
+
+    def with_observation(
+        self: RoboticsRowT,
+        key: str,
+        values: Any,
+    ) -> RoboticsRowT: ...
+
+    def with_video(
+        self: RoboticsRowT,
+        key: str,
+        video: VideoSource,
+    ) -> RoboticsRowT: ...
+
+    def select_frames(
+        self: RoboticsRowT,
+        indices: Sequence[int],
+    ) -> RoboticsRowT: ...
+
+    def to_frame_table(self) -> Tabular: ...
+
+    def drop_stats(self: RoboticsRowT, feature: str) -> RoboticsRowT: ...
+
+    def update(
+        self: RoboticsRowT,
+        patch: Mapping[str, Any] | None = None,
+        /,
+        **kwargs: Any,
+    ) -> RoboticsRowT: ...
+
+
+class _RoboticsRowView(Row, RoboticsRow):
+    def __init__(
+        self,
+        row: Row,
+        spec: _RoboticsRowSpec,
+    ) -> None:
+        self._row = row
+        self._spec = spec
+
+    def __getitem__(self, key: str) -> Any:
+        return self._row[key]
+
+    def __iter__(self) -> Iterator[str]:
+        hidden = set(self._source_frame_keys())
+        for key in tuple(hidden):
+            if "/" in key and key not in self._row:
+                hidden.add(key.split("/", 1)[0])
+        nested_frames_key = _valid_nested_frames_key(
+            self._row,
+            self._spec.nested_frames_key,
+        )
+        if nested_frames_key is not None:
+            hidden.add(nested_frames_key)
+        hidden.update(
+            source_key for source_key, _ in self._spec.video_source_map.values()
+        )
+        for key in tuple(hidden):
+            if "/" in key and key not in self._row:
+                hidden.add(key.split("/", 1)[0])
+        for key in self._row:
+            if key not in hidden:
+                yield key
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    @property
+    def shard_id(self) -> str | None:
+        return self._row.shard_id
+
+    @property
+    def episode_id(self) -> str:
+        if self._spec.episode_id_key is None:
+            return "-1"
+        value = self._row.get(self._spec.episode_id_key)
+        return str(value) if value is not None else "-1"
+
+    @property
+    def num_frames(self) -> int:
+        table = self._nested_frame_table()
+        if table is not None:
+            return table.num_rows
+        first_key = self._first_source_frame_key()
+        if first_key is None:
+            return -1
+        return len(_get_path(self._row, first_key))
+
+    @property
+    def task(self) -> str | None:
+        if self._spec.task_key is None:
+            return None
+        value = self._row.get(self._spec.task_key)
+        return value if isinstance(value, str) else None
+
+    @property
+    def fps(self) -> float | None:
+        if self._spec.fps is not None:
+            return self._spec.fps
+        if self._spec.fps_key is None:
+            return None
+        value = self._row.get(self._spec.fps_key)
+        return float(value) if value is not None else None
+
+    @property
+    def robot_type(self) -> str | None:
+        if self._spec.robot_type is not None:
+            return self._spec.robot_type
+        if self._spec.robot_type_key is None:
+            return None
+        value = self._row.get(self._spec.robot_type_key)
+        return str(value) if value is not None else None
+
+    @property
+    def videos(self) -> Mapping[str, VideoSource]:
+        videos: dict[str, VideoSource] = {}
+        for key, (source_key, storage) in self._spec.video_source_map.items():
+            value = _get_path(self._row, source_key, default=None)
+            video = video_from_storage_value(storage, value, fps=int(self.fps or 30))
+            if video is not None:
+                videos[key] = video
+        return videos
+
+    @property
+    def stats(self) -> Mapping[str, Any]:
+        stats: dict[str, Any] = {}
+        if self._spec.stats_key is not None:
+            value = self._row.get(self._spec.stats_key)
+            if isinstance(value, Mapping):
+                stats.update(value)
+        if self._spec.stats_prefix:
+            for key in self._row:
+                if not key.startswith(self._spec.stats_prefix):
+                    continue
+                rest = key[len(self._spec.stats_prefix) :]
+                feature, _, stat_name = rest.partition("/")
+                if not feature or not stat_name:
+                    continue
+                feature_stats = stats.setdefault(feature, {})
+                if isinstance(feature_stats, dict):
+                    feature_stats[stat_name] = self._row[key]
+        return stats
+
+    def _frame_values(self, key: str) -> Any:
+        table = self._nested_frame_table()
+        if table is not None:
+            source_key = self._source_frame_key(key, table_names=table.names)
+            if isinstance(source_key, tuple):
+                return _concat_frame_values([table.column(key) for key in source_key])
+            return table.column(source_key)
+        source_key = self._source_frame_key(key)
+        if isinstance(source_key, tuple):
+            return _concat_frame_values(
+                [_get_path(self._row, key) for key in source_key]
+            )
+        return _get_path(self._row, source_key)
+
+    @property
+    def timestamps(self) -> Any:
+        return self._optional_frame_values("timestamp")
+
+    @property
+    def actions(self) -> Any:
+        return self._optional_frame_values("action")
+
+    @property
+    def states(self) -> Any:
+        return self._optional_frame_values("observation.state")
+
+    def observations(self, name: str | None = None) -> Any:
+        values: dict[str, Any] = {}
+        states = self.states
+        if states is not None:
+            values["state"] = states
+        for semantic_key in self._spec.frame_source_map:
+            observation_key = _strip_observation_prefix(semantic_key)
+            if observation_key == semantic_key or observation_key == "state":
+                continue
+            try:
+                values[observation_key] = self._frame_values(semantic_key)
+            except KeyError:
+                continue
+        values.update({f"videos/{key}": video for key, video in self.videos.items()})
+        if name is None:
+            return values
+        normalized_name = _strip_observation_prefix(name)
+        return values[normalized_name]
+
+    def _optional_frame_values(self, key: str) -> Any:
+        try:
+            return self._frame_values(key)
+        except KeyError:
+            return None
+
+    def with_timestamps(self, values: Any) -> "_RoboticsRowView":
+        return self._with_frame_values("timestamp", values)
+
+    def with_actions(self, values: Any) -> "_RoboticsRowView":
+        return self._with_frame_values("action", values)
+
+    def with_observation(self, key: str, values: Any) -> "_RoboticsRowView":
+        return self._with_frame_values(_observation_semantic_key(key), values)
+
+    def _with_frame_values(self, key: str, values: Any) -> "_RoboticsRowView":
+        table = self._nested_frame_table()
+        if table is None:
+            mapped_source_key = self._spec.frame_source_map.get(key, key)
+            source_key = (
+                mapped_source_key if isinstance(mapped_source_key, str) else key
+            )
+            next_mapping = dict(self._spec.frame_source_map)
+            next_mapping[key] = source_key
+            return self._replace(
+                self._row.update(_set_path(self._row, source_key, values)),
+                frame_sources=next_mapping,
+            )
+        mapped_source_key = self._spec.frame_source_map.get(key, key)
+        source_key = mapped_source_key if isinstance(mapped_source_key, str) else key
+        frame_table = set_or_append_column(
+            table.table,
+            source_key,
+            _as_arrow_column(
+                values,
+                length=table.num_rows,
+                value_type=table.table.schema.field(source_key).type
+                if source_key in table.table.column_names
+                else None,
+            ),
+        )
+        nested_frames_key = self._require_nested_frames_key()
+        next_mapping = dict(self._spec.frame_source_map)
+        next_mapping[key] = source_key
+        return self._replace(
+            self._row.update({nested_frames_key: table.with_table(frame_table)}),
+            frame_sources=next_mapping,
+        )
+
+    def select_frames(self, indices: Sequence[int]) -> "_RoboticsRowView":
+        table = self._nested_frame_table()
+        if table is not None:
+            selected = _select_frame_table(table, indices)
+            nested_frames_key = self._require_nested_frames_key()
+            return self._replace(
+                self._row.update(
+                    {nested_frames_key: selected, "length": selected.num_rows}
+                )
+            )
+
+        patch: dict[str, Any] = {
+            source_key: _take_values(_get_path(self._row, source_key), indices)
+            for source_key in self._source_frame_keys()
+            if _has_path(self._row, source_key)
+        }
+        if "length" in self._row:
+            patch["length"] = len(indices)
+        if "frame_index" in patch:
+            patch["frame_index"] = list(range(len(indices)))
+        return self._replace(self._row.update(patch))
+
+    def to_frame_table(self) -> Tabular:
+        table = self._nested_frame_table()
+        if table is not None:
+            return self._semantic_frame_table(table)
+        return Tabular(
+            pa.table(
+                {
+                    semantic_key: _source_values(self._row, source_key)
+                    for semantic_key, source_key in self._spec.frame_source_map.items()
+                    if _has_source(self._row, source_key)
+                }
+            )
+        )
+
+    def drop_stats(self, feature: str) -> "_RoboticsRowView":
+        row = self._row
+        if self._spec.stats_key is not None:
+            value = row.get(self._spec.stats_key)
+            if isinstance(value, Mapping) and feature in value:
+                next_stats = dict(value)
+                next_stats.pop(feature, None)
+                row = row.update({self._spec.stats_key: next_stats})
+        if self._spec.stats_prefix:
+            prefix = f"{self._spec.stats_prefix}{feature}/"
+            row = row.drop(*[key for key in row if key.startswith(prefix)])
+        return self._replace(row)
+
+    def with_video(self, key: str, video: VideoSource) -> "_RoboticsRowView":
+        source_key = self._spec.video_source_map.get(key, (key, None))[0]
+        next_sources = dict(self._spec.video_source_map)
+        next_sources[key] = (source_key, None)
+        return self._replace(
+            self._row.update(_set_path(self._row, source_key, video)),
+            video_sources=next_sources,
+        )
+
+    def update(
+        self,
+        patch: Mapping[str, Any] | None = None,
+        /,
+        **kwargs: Any,
+    ) -> "_RoboticsRowView":
+        return self._replace(self._row.update(patch, **kwargs))
+
+    def _nested_frame_table(self) -> Tabular | None:
+        nested_frames_key = _valid_nested_frames_key(
+            self._row,
+            self._spec.nested_frames_key,
+        )
+        if nested_frames_key is None:
+            return None
+        value = self._row.get(nested_frames_key)
+        if value is None:
+            return None
+        if isinstance(value, Tabular):
+            return value
+        if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+            return None
+        return Tabular.from_rows(_frame_rows(value))
+
+    def _require_nested_frames_key(self) -> str:
+        if self._spec.nested_frames_key is None:
+            raise ValueError("row has no nested frame key")
+        return self._spec.nested_frames_key
+
+    def _replace(
+        self,
+        row: Row,
+        *,
+        frame_sources: Mapping[str, _FrameSource] | None = None,
+        video_sources: Mapping[str, tuple[str, str | None]] | None = None,
+    ) -> "_RoboticsRowView":
+        spec = dataclass_replace(
+            self._spec,
+            frame_sources=(
+                frame_sources
+                if frame_sources is not None
+                else self._spec.frame_source_map
+            ),
+            video_sources=(
+                video_sources
+                if video_sources is not None
+                else self._spec.video_source_map
+            ),
+        )
+        return _RoboticsRowView(row, spec)
+
+    def _source_frame_key(
+        self,
+        semantic_key: str,
+        *,
+        table_names: Sequence[str] | None = None,
+    ) -> _FrameSource:
+        source_key = self._spec.frame_source_map.get(semantic_key, semantic_key)
+        if isinstance(source_key, tuple):
+            if table_names is not None and not all(
+                key in table_names for key in source_key
+            ):
+                raise KeyError(semantic_key)
+            if table_names is None and not all(
+                _has_path(self._row, key) for key in source_key
+            ):
+                raise KeyError(semantic_key)
+            return source_key
+        if table_names is not None and source_key not in table_names:
+            raise KeyError(semantic_key)
+        if table_names is None and not _has_path(self._row, source_key):
+            raise KeyError(semantic_key)
+        return source_key
+
+    def _source_frame_keys(self) -> tuple[str, ...]:
+        keys: list[str] = []
+        for source_key in self._spec.frame_source_map.values():
+            if isinstance(source_key, tuple):
+                keys.extend(source_key)
+            else:
+                keys.append(source_key)
+        return tuple(dict.fromkeys(keys))
+
+    def _first_source_frame_key(self) -> str | None:
+        for source_key in self._source_frame_keys():
+            if _has_path(self._row, source_key):
+                return source_key
+        return None
+
+    def _semantic_frame_table(self, table: Tabular) -> Tabular:
+        columns: dict[str, pa.Array | pa.ChunkedArray] = {}
+        for semantic_key, source_key in self._spec.frame_source_map.items():
+            if isinstance(source_key, tuple):
+                if all(key in table.names for key in source_key):
+                    columns[semantic_key] = _concat_frame_values(
+                        [table.column(key) for key in source_key]
+                    )
+            elif source_key in table.names:
+                columns[semantic_key] = table.column(source_key)
+        return Tabular(pa.table(columns))
+
+
+def _robot_row_converter(
+    *,
+    episode_id_key: str | None = None,
+    task_key: str | None = None,
+    fps: float | None = None,
+    fps_key: str | None = None,
+    robot_type: str | None = None,
+    robot_type_key: str | None = None,
+    nested_frames_key: str | None = None,
+    timestamp_key: str | None = "timestamp",
+    action_key: str | None = "action",
+    state_key: str | Sequence[str] | None = "observation.state",
+    extra_observation_keys: Mapping[str, str] | Iterable[str] | None = None,
+    video_keys: Mapping[str, str] | Iterable[str] | None = None,
+    stats_key: str | None = "stats",
+    stats_prefix: str = "stats/",
+    episode_ends_key: str | None = None,
+    schema: pa.Schema | None = None,
+) -> Callable[[Row], Row] | Callable[[Row], Iterable[Row]]:
+    if episode_ends_key is not None:
+
+        def split_row(row: Row) -> Iterable[Row]:
+            return cast(
+                Iterable[Row],
+                _rows_from_episode_ends(
+                    row,
+                    episode_id_key=episode_id_key,
+                    task_key=task_key,
+                    fps=fps,
+                    fps_key=fps_key,
+                    robot_type=robot_type,
+                    robot_type_key=robot_type_key,
+                    timestamp_key=timestamp_key,
+                    action_key=action_key,
+                    state_key=state_key,
+                    extra_observation_keys=extra_observation_keys,
+                    video_keys=video_keys,
+                    schema=schema,
+                    stats_key=stats_key,
+                    stats_prefix=stats_prefix,
+                    episode_ends_key=episode_ends_key,
+                ),
+            )
+
+        return split_row
+
+    spec = _RoboticsRowSpec.from_options(
+        episode_id_key=episode_id_key,
+        task_key=task_key,
+        fps=fps,
+        fps_key=fps_key,
+        robot_type=robot_type,
+        robot_type_key=robot_type_key,
+        nested_frames_key=nested_frames_key,
+        timestamp_key=timestamp_key,
+        action_key=action_key,
+        state_key=state_key,
+        extra_observation_keys=extra_observation_keys,
+        video_keys=video_keys,
+        schema=schema,
+        stats_key=stats_key,
+        stats_prefix=stats_prefix,
+    )
+
+    def map_row(row: Row) -> Row:
+        return cast(Row, spec.wrap(row))
+
+    return map_row
+
+
+def _valid_nested_frames_key(row: Row, key: str | None) -> str | None:
+    if key is None or key not in row:
+        return None
+    value = row[key]
+    if isinstance(value, Tabular):
+        return key
+    if isinstance(value, str | bytes):
+        return None
+    return key if isinstance(value, Sequence) else None
+
+
+def _rows_from_episode_ends(
+    row: Row,
+    *,
+    episode_id_key: str | None,
+    task_key: str | None,
+    fps: float | None,
+    fps_key: str | None,
+    robot_type: str | None,
+    robot_type_key: str | None,
+    timestamp_key: str | None,
+    action_key: str | None,
+    state_key: str | Sequence[str] | None,
+    extra_observation_keys: Mapping[str, str] | Iterable[str] | None,
+    video_keys: Mapping[str, str] | Iterable[str] | None,
+    schema: pa.Schema | None,
+    stats_key: str | None,
+    stats_prefix: str,
+    episode_ends_key: str,
+) -> Iterator[RoboticsRow]:
+    episode_ends = [int(value) for value in _get_path(row, episode_ends_key)]
+    spec = _RoboticsRowSpec.from_options(
+        episode_id_key=episode_id_key,
+        task_key=task_key,
+        fps=fps,
+        fps_key=fps_key,
+        robot_type=robot_type,
+        robot_type_key=robot_type_key,
+        nested_frames_key=None,
+        timestamp_key=timestamp_key,
+        action_key=action_key,
+        state_key=state_key,
+        extra_observation_keys=extra_observation_keys,
+        video_keys=video_keys,
+        schema=schema,
+        stats_key=stats_key,
+        stats_prefix=stats_prefix,
+    )
+    start = 0
+    for episode_idx, end in enumerate(episode_ends):
+        if episode_id_key is None:
+            split_row = row
+        else:
+            split_row = row.update(
+                {episode_id_key: f"{row.get(episode_id_key, '-1')}-{episode_idx}"}
+            )
+        for source_key in spec.frame_source_map.values():
+            for key in _source_keys(source_key):
+                if _has_path(row, key):
+                    split_row = split_row.update(
+                        _set_path(
+                            split_row,
+                            key,
+                            _slice_values(_get_path(row, key), start, end),
+                        )
+                    )
+        video_fps = int(spec.wrap(row).fps or 30)
+        for source_key, storage in spec.video_source_map.values():
+            if not _has_path(row, source_key):
+                continue
+            value = _get_path(row, source_key)
+            video = video_from_storage_value(storage, value, fps=video_fps)
+            if video is None:
+                continue
+            clip_fps = int(getattr(video, "fps", video_fps))
+            split_row = split_row.update(
+                _set_path(
+                    split_row,
+                    source_key,
+                    video.clipped(
+                        from_timestamp_s=start / clip_fps,
+                        to_timestamp_s=end / clip_fps,
+                    ),
+                )
+            )
+        if task_key is not None and task_key in row:
+            split_row = split_row.update({task_key: row[task_key]})
+        if fps_key is not None and fps_key in row:
+            split_row = split_row.update({fps_key: row[fps_key]})
+        if robot_type_key is not None and robot_type_key in row:
+            split_row = split_row.update({robot_type_key: row[robot_type_key]})
+        yield spec.wrap(split_row)
+        start = end
+
+
+def _video_sources(
+    *,
+    schema: pa.Schema | None,
+    video_keys: Mapping[str, str] | Iterable[str] | None,
+) -> dict[str, tuple[str, str | None]]:
+    sources: dict[str, tuple[str, str | None]] = {}
+    if schema is not None:
+        for field in schema:
+            if asset_type(field) == "video":
+                sources[field.name] = (field.name, asset_storage(field))
+    if video_keys is None:
+        return sources
+    if isinstance(video_keys, Mapping):
+        mapped_keys = cast(Mapping[str, str], video_keys)
+        sources.update(
+            {key: (source_key, None) for key, source_key in mapped_keys.items()}
+        )
+    else:
+        sources.update({key: (key, None) for key in video_keys})
+    return sources
+
+
+def _semantic_source_map(
+    *,
+    timestamp_key: str | None = "timestamp",
+    action_key: str | None = "action",
+    state_key: str | Sequence[str] | None = "observation.state",
+    extra_observation_keys: Mapping[str, str] | Iterable[str] | None = None,
+) -> dict[str, _FrameSource]:
+    fields: dict[str, _FrameSource] = {}
+    if timestamp_key is not None:
+        fields["timestamp"] = timestamp_key
+    if action_key is not None:
+        fields["action"] = action_key
+    if state_key is not None:
+        fields["observation.state"] = _state_source_key(state_key)
+    fields.update(_observation_source_map(extra_observation_keys))
+    return fields
+
+
+def _state_source_key(state_key: str | Sequence[str]) -> _FrameSource:
+    if isinstance(state_key, str):
+        return state_key
+    keys = tuple(state_key)
+    if not keys:
+        raise ValueError("state_key sequence cannot be empty")
+    if not all(isinstance(key, str) for key in keys):
+        raise TypeError("state_key sequence values must be strings")
+    return keys
+
+
+def _observation_source_map(
+    extra_observation_keys: Mapping[str, str] | Iterable[str] | None,
+) -> dict[str, str]:
+    if extra_observation_keys is None:
+        return {}
+    if isinstance(extra_observation_keys, Mapping):
+        mapped_keys = cast(Mapping[str, str], extra_observation_keys)
+        return {
+            _observation_semantic_key(key): source_key
+            for key, source_key in mapped_keys.items()
+        }
+    return {_observation_semantic_key(key): key for key in extra_observation_keys}
+
+
+def _observation_semantic_key(key: str) -> str:
+    return key if key.startswith("observation.") else f"observation.{key}"
+
+
+def _strip_observation_prefix(key: str) -> str:
+    prefix = "observation."
+    return key[len(prefix) :] if key.startswith(prefix) else key
+
+
+def _frame_rows(value: Sequence[Any]) -> list[Row]:
+    return [
+        item
+        if isinstance(item, Row)
+        else DictRow(_flatten_mapping(item))
+        if isinstance(item, Mapping)
+        else DictRow({"value": item})
+        for item in value
+    ]
+
+
+def _flatten_mapping(value: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
+    flat: dict[str, Any] = {}
+    for key, item in value.items():
+        path = f"{prefix}/{key}" if prefix else str(key)
+        if isinstance(item, Mapping):
+            flat.update(_flatten_mapping(item, path))
+        else:
+            flat[path] = item
+    return flat
+
+
+_MISSING = object()
+
+
+def _get_path(row: Mapping[str, Any], key: str, default: Any = _MISSING) -> Any:
+    if key in row:
+        return row[key]
+    current: Any = row
+    for part in key.split("/"):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            if default is _MISSING:
+                raise KeyError(key)
+            return default
+    return current
+
+
+def _has_path(row: Mapping[str, Any], key: str) -> bool:
+    try:
+        _get_path(row, key)
+    except KeyError:
+        return False
+    return True
+
+
+def _source_keys(source_key: _FrameSource) -> tuple[str, ...]:
+    return source_key if isinstance(source_key, tuple) else (source_key,)
+
+
+def _has_source(row: Mapping[str, Any], source_key: _FrameSource) -> bool:
+    return all(_has_path(row, key) for key in _source_keys(source_key))
+
+
+def _source_values(row: Mapping[str, Any], source_key: _FrameSource) -> Any:
+    if isinstance(source_key, tuple):
+        return _concat_frame_values([_get_path(row, key) for key in source_key])
+    values = _get_path(row, source_key)
+    if isinstance(values, pa.ChunkedArray | pa.Array):
+        return values
+    return _frame_value_list(values)
+
+
+def _set_path(row: Mapping[str, Any], key: str, values: Any) -> dict[str, Any]:
+    if "/" not in key or key in row:
+        return {key: values}
+    head, *tail = key.split("/")
+    current = dict(row.get(head, {})) if isinstance(row.get(head), Mapping) else {}
+    root = current
+    for part in tail[:-1]:
+        child = current.get(part)
+        next_child = dict(child) if isinstance(child, Mapping) else {}
+        current[part] = next_child
+        current = next_child
+    current[tail[-1]] = values
+    return {head: root}
+
+
+def _slice_values(values: Any, start: int, end: int) -> Any:
+    if isinstance(values, pa.ChunkedArray | pa.Array):
+        return values.slice(start, end - start)
+    return values[start:end]
+
+
+def _select_frame_table(table: Tabular, indices: Sequence[int]) -> Tabular:
+    selected = table.table.take(pa.array(indices, type=pa.int64()))
+    if "frame_index" in selected.column_names:
+        selected = set_or_append_column(
+            selected,
+            "frame_index",
+            pa.array(range(selected.num_rows), type=pa.int64()),
+        )
+    return table.with_table(selected)
+
+
+def _as_arrow_column(
+    values: Any,
+    *,
+    length: int,
+    value_type: pa.DataType | None = None,
+) -> pa.Array | pa.ChunkedArray:
+    if isinstance(values, pa.ChunkedArray):
+        return values
+    if isinstance(values, pa.Array):
+        return values
+    if isinstance(values, pa.Scalar):
+        return pa.repeat(values, length)
+    return pa.array(values, type=value_type)
+
+
+def _concat_frame_values(values: Sequence[Any]) -> Any:
+    columns = [_frame_value_list(value) for value in values]
+    if not columns:
+        return []
+    length = len(columns[0])
+    if any(len(column) != length for column in columns):
+        raise ValueError("source keys must have matching frame counts")
+    concatenated = [
+        [
+            item
+            for column in columns
+            for item in _frame_feature_values(column[frame_idx])
+        ]
+        for frame_idx in range(length)
+    ]
+    if any(isinstance(value, pa.ChunkedArray | pa.Array) for value in values):
+        return pa.array(concatenated)
+    return concatenated
+
+
+def _frame_value_list(values: Any) -> list[Any]:
+    if isinstance(values, pa.ChunkedArray | pa.Array):
+        return values.to_pylist()
+    if isinstance(values, str | bytes):
+        raise TypeError("frame-aligned values must be a sequence of frames")
+    if hasattr(values, "tolist"):
+        value_list = values.tolist()
+        return value_list if isinstance(value_list, list) else [value_list]
+    return list(values)
+
+
+def _frame_feature_values(value: Any) -> list[Any]:
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, str | bytes):
+        return [value]
+    if isinstance(value, Sequence):
+        return list(value)
+    return [value]
+
+
+def _take_values(values: Any, indices: Sequence[int]) -> Any:
+    if isinstance(values, pa.ChunkedArray):
+        return values.take(pa.array(indices, type=pa.int64()))
+    if isinstance(values, pa.Array):
+        return values.take(pa.array(indices, type=pa.int64()))
+    return [values[index] for index in indices]
+
+
+__all__ = [
+    "RoboticsRow",
+]

--- a/src/refiner/video/__init__.py
+++ b/src/refiner/video/__init__.py
@@ -3,7 +3,6 @@ from refiner.video.decode import (
     DecodedVideoFrame,
     export_clip,
     iter_frame_windows,
-    iter_frames,
 )
 from refiner.video.remux import (
     PreparedVideoSource,
@@ -22,7 +21,13 @@ from refiner.video.transcode import (
     TranscodeWriter,
     VideoTranscodeConfig,
 )
-from refiner.video.types import VideoFile
+from refiner.video.types import (
+    VideoBytes,
+    VideoFile,
+    VideoFrameArray,
+    VideoSource,
+    video_from_storage_value,
+)
 from refiner.video.writer import (
     VideoStreamWriter,
     WrittenVideo,
@@ -37,6 +42,10 @@ __all__ = [
     "RemuxWriter",
     "TranscodeWriter",
     "VideoFile",
+    "VideoBytes",
+    "VideoFrameArray",
+    "VideoSource",
+    "video_from_storage_value",
     "VideoPtsAlignment",
     "VideoStreamWriter",
     "VideoTranscodeConfig",
@@ -44,7 +53,6 @@ __all__ = [
     "WrittenVideoSegment",
     "export_clip",
     "iter_frame_windows",
-    "iter_frames",
     "prepared_source_is_remuxable",
     "prepare_video_source",
     "probe_for_remux",

--- a/src/refiner/video/decode.py
+++ b/src/refiner/video/decode.py
@@ -4,7 +4,7 @@ import io
 from collections import deque
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from refiner.video.remux import (
     RemuxWriter,
@@ -17,10 +17,15 @@ from refiner.video.remux import (
 if TYPE_CHECKING:
     import av
 
-    from refiner.video.types import VideoFile
+    from refiner.video.types import VideoBytes, VideoFile, VideoSource
     from refiner.video.transcode import VideoTranscodeConfig
 
 _FRAME_TIMESTAMP_EPSILON_S = 1e-6
+
+
+class _NonClosingBytesIO(io.BytesIO):
+    def close(self) -> None:
+        pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,22 +45,29 @@ class DecodedFrameWindow:
     frames: tuple[DecodedVideoFrame | None, ...]
 
 
-class _NonClosingBytesIO(io.BytesIO):
-    def close(self) -> None:
-        pass
-
-
 async def export_clip(
-    video: VideoFile,
+    video: VideoSource,
     *,
     force_transcode: bool = False,
     transcode_config: VideoTranscodeConfig | None = None,
 ) -> bytes:
     from refiner.video.transcode import TranscodeWriter, VideoTranscodeConfig
+    from refiner.video.types import VideoFrameArray
 
-    config = transcode_config or VideoTranscodeConfig()
-    prepared = await prepare_video_source(video=video)
     output_file = _NonClosingBytesIO()
+    config = transcode_config or VideoTranscodeConfig()
+    if isinstance(video, VideoFrameArray):
+        writer = TranscodeWriter.open_file(
+            output_file=output_file,
+            config=config,
+            fps=video.fps,
+            movflags=None,
+        )
+        writer.append_frame_arrays(video.iter_frame_arrays())
+        writer.close()
+        return output_file.getvalue()
+    encoded_video = cast("VideoFile | VideoBytes", video)
+    prepared = await prepare_video_source(video=encoded_video)
     try:
         if not force_transcode and prepared_source_is_remuxable(prepared):
             probe = prepared.probe
@@ -90,8 +102,8 @@ async def export_clip(
         prepared.close()
 
 
-async def iter_frames(
-    video: VideoFile,
+async def iter_encoded_frames(
+    video: VideoFile | VideoBytes,
 ) -> AsyncIterator[DecodedVideoFrame]:
     prepared = await prepare_video_source(video=video)
     try:
@@ -116,7 +128,7 @@ async def iter_frames(
 
 
 async def iter_frame_windows(
-    video: VideoFile,
+    video: VideoSource,
     *,
     offsets: Sequence[int],
     stride: int = 1,
@@ -134,7 +146,7 @@ async def iter_frame_windows(
     frames_by_index: dict[int, DecodedVideoFrame] = {}
     pending_anchor_indexes: deque[int] = deque()
 
-    async for frame in iter_frames(video):
+    async for frame in video.iter_frames():
         buffer.append(frame)
         frames_by_index[frame.index] = frame
         if frame.index % stride == 0:
@@ -244,5 +256,4 @@ __all__ = [
     "DecodedVideoFrame",
     "export_clip",
     "iter_frame_windows",
-    "iter_frames",
 ]

--- a/src/refiner/video/remux.py
+++ b/src/refiner/video/remux.py
@@ -1,30 +1,33 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import partial
 from typing import IO, Any
 from typing import TYPE_CHECKING
 
 from refiner.io import DataFolder
+from refiner.execution.asyncio.runtime import io_executor
 from refiner.pipeline.utils.cache.decoder_cache import (
     OpenedVideoSource,
     VideoSourceProbe,
     get_opened_video_source_cache,
+    open_video_source,
     reset_opened_video_source_cache,
 )
 from refiner.pipeline.utils.cache.lease_cache import CacheLease
 from refiner.utils import check_required_dependencies
 
 if TYPE_CHECKING:
-    from refiner.video.types import VideoFile
+    from refiner.video.types import VideoBytes, VideoFile
 
 _SEGMENTED_MP4_MOVFLAGS = "frag_keyframe+default_base_moof"
 
 
-def video_from_timestamp_s(video: VideoFile) -> float:
+def video_from_timestamp_s(video: VideoFile | VideoBytes) -> float:
     return float(video.from_timestamp_s or 0.0)
 
 
-def video_to_timestamp_s(video: VideoFile) -> float | None:
+def video_to_timestamp_s(video: VideoFile | VideoBytes) -> float | None:
     return video.to_timestamp_s
 
 
@@ -37,8 +40,9 @@ class VideoPtsAlignment:
 
 @dataclass(slots=True)
 class PreparedVideoSource:
-    lease: CacheLease[str, OpenedVideoSource]
-    video: VideoFile
+    lease: CacheLease[str, OpenedVideoSource] | None
+    source: OpenedVideoSource | None
+    video: VideoFile | VideoBytes
     uri: str
     probe: VideoSourceProbe | None
     alignment: VideoPtsAlignment | None
@@ -46,7 +50,11 @@ class PreparedVideoSource:
     stream: Any
 
     def close(self) -> None:
-        self.lease.release()
+        if self.lease is not None:
+            self.lease.release()
+            return
+        if self.source is not None:
+            self.source.close()
 
 
 class RemuxWriter:
@@ -188,7 +196,7 @@ def prepared_source_is_remuxable(prepared: PreparedVideoSource) -> bool:
 def probe_for_remux(
     *,
     probe: VideoSourceProbe | None,
-    video: VideoFile,
+    video: VideoFile | VideoBytes,
 ) -> tuple[VideoSourceProbe | None, VideoPtsAlignment | None]:
     if probe is None:
         return None, None
@@ -209,11 +217,25 @@ def probe_for_remux(
 
 async def prepare_video_source(
     *,
-    video: VideoFile,
+    video: VideoFile | VideoBytes,
 ) -> PreparedVideoSource:
     check_required_dependencies("video decoding", ["av"], dist="video")
-    lease = await get_opened_video_source_cache().acquire(video.uri)
-    source = lease.resource
+    from refiner.video.types import VideoFile
+
+    lease: CacheLease[str, OpenedVideoSource] | None = None
+    direct_source: OpenedVideoSource | None = None
+    if isinstance(video, VideoFile):
+        lease = await get_opened_video_source_cache().acquire(video.uri)
+        source = lease.resource
+    else:
+        import asyncio
+
+        source = await asyncio.get_running_loop().run_in_executor(
+            io_executor(),
+            partial(open_video_source, video=video),
+        )
+        direct_source = source
+
     try:
         start_pts = 0
         if source.stream.time_base is not None:
@@ -242,6 +264,7 @@ async def prepare_video_source(
         probe, alignment = probe_for_remux(probe=source.probe, video=video)
         return PreparedVideoSource(
             lease=lease,
+            source=direct_source,
             video=video,
             uri=source.uri,
             probe=probe,
@@ -250,7 +273,10 @@ async def prepare_video_source(
             stream=source.stream,
         )
     except Exception:
-        lease.release()
+        if lease is not None:
+            lease.release()
+        elif direct_source is not None:
+            direct_source.close()
         raise
 
 

--- a/src/refiner/video/transcode.py
+++ b/src/refiner/video/transcode.py
@@ -181,6 +181,28 @@ class TranscodeWriter:
 
         return from_timestamp, self.duration_s
 
+    def append_frame_arrays(
+        self,
+        frames: Any,
+        *,
+        frame_observer: FrameObserver | None = None,
+    ) -> tuple[float, float]:
+        import av
+
+        from_timestamp = self.duration_s
+        for frame_index, frame_array in enumerate(frames):
+            array = np.asarray(frame_array, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(array, format="rgb24")
+            self.ensure_stream(width=frame.width, height=frame.height)
+            if frame_observer is not None:
+                frame_observer(frame_index, array)
+            self.write_frame(frame)
+
+        if self.frames_written <= 0 or self.duration_s <= from_timestamp:
+            raise ValueError("Video segment contains no frames")
+
+        return from_timestamp, self.duration_s
+
     def close(self) -> None:
         container = self.container
         if container is None:

--- a/src/refiner/video/types.py
+++ b/src/refiner/video/types.py
@@ -1,18 +1,75 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
-from dataclasses import dataclass
-from typing import IO
+import io
+import math
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from fractions import Fraction
+from typing import IO, TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import numpy as np
 
 from refiner.io import DataFile
-from refiner.video.decode import (
-    DecodedFrameWindow,
-    DecodedVideoFrame,
-    export_clip,
-    iter_frame_windows,
-    iter_frames,
-)
-from refiner.video.transcode import VideoTranscodeConfig
+
+if TYPE_CHECKING:
+    from refiner.video.decode import DecodedFrameWindow, DecodedVideoFrame
+    from refiner.video.transcode import FrameObserver
+    from refiner.video.writer import VideoStreamWriter, WrittenVideo
+
+
+@runtime_checkable
+class VideoSource(Protocol):
+    def clipped(
+        self,
+        *,
+        from_timestamp_s: float | None = None,
+        to_timestamp_s: float | None = None,
+    ) -> "VideoSource": ...
+
+    def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]: ...
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]: ...
+
+    async def write_to(
+        self,
+        writer: VideoStreamWriter,
+        *,
+        frame_observer: FrameObserver | None = None,
+        force_transcode: bool = False,
+    ) -> WrittenVideo: ...
+
+
+def _compose_clip_bounds(
+    *,
+    current_from: float | None,
+    current_to: float | None,
+    from_timestamp_s: float | None,
+    to_timestamp_s: float | None,
+) -> tuple[float | None, float | None]:
+    relative_from = 0.0 if from_timestamp_s is None else float(from_timestamp_s)
+    if relative_from < 0:
+        raise ValueError("from_timestamp_s must be >= 0")
+    if to_timestamp_s is not None and float(to_timestamp_s) < relative_from:
+        raise ValueError("to_timestamp_s must be >= from_timestamp_s")
+
+    base_from = float(current_from or 0.0)
+    next_from = base_from + relative_from
+    next_to = (
+        current_to if to_timestamp_s is None else base_from + float(to_timestamp_s)
+    )
+    if current_to is not None:
+        current_to_value = float(current_to)
+        if next_from > current_to_value:
+            raise ValueError("clip start is beyond the current video view")
+        if next_to is not None and next_to > current_to_value:
+            raise ValueError("clip end is beyond the current video view")
+    return next_from, next_to
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,23 +82,31 @@ class VideoFile:
     def uri(self) -> str:
         return str(self.data_file)
 
-    def open(self, mode: str = "rb") -> IO[bytes]:
-        return self.data_file.open(mode=mode)
+    def open(self) -> IO[bytes]:
+        return self.data_file.open(mode="rb")
 
-    async def export_clip(
+    def clipped(
         self,
         *,
-        force_transcode: bool = False,
-        transcode_config: VideoTranscodeConfig | None = None,
-    ) -> bytes:
-        return await export_clip(
-            self,
-            force_transcode=force_transcode,
-            transcode_config=transcode_config,
+        from_timestamp_s: float | None = None,
+        to_timestamp_s: float | None = None,
+    ) -> "VideoFile":
+        next_from, next_to = _compose_clip_bounds(
+            current_from=self.from_timestamp_s,
+            current_to=self.to_timestamp_s,
+            from_timestamp_s=from_timestamp_s,
+            to_timestamp_s=to_timestamp_s,
+        )
+        return VideoFile(
+            data_file=self.data_file,
+            from_timestamp_s=next_from,
+            to_timestamp_s=next_to,
         )
 
     def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
-        return iter_frames(self)
+        from refiner.video.decode import iter_encoded_frames
+
+        return iter_encoded_frames(self)
 
     def iter_frame_windows(
         self,
@@ -50,6 +115,8 @@ class VideoFile:
         stride: int = 1,
         drop_incomplete: bool = True,
     ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
         return iter_frame_windows(
             self,
             offsets=offsets,
@@ -57,5 +124,215 @@ class VideoFile:
             drop_incomplete=drop_incomplete,
         )
 
+    async def write_to(
+        self,
+        writer: VideoStreamWriter,
+        *,
+        frame_observer: FrameObserver | None = None,
+        force_transcode: bool = False,
+    ) -> WrittenVideo:
+        return await writer.write_encoded_video(
+            self,
+            frame_observer=frame_observer,
+            force_transcode=force_transcode,
+        )
 
-__all__ = ["VideoFile"]
+
+@dataclass(frozen=True, slots=True)
+class VideoBytes:
+    data: bytes = field(repr=False)
+    uri: str | None = None
+    from_timestamp_s: float | None = None
+    to_timestamp_s: float | None = None
+
+    def open(self) -> IO[bytes]:
+        return io.BytesIO(self.data)
+
+    def clipped(
+        self,
+        *,
+        from_timestamp_s: float | None = None,
+        to_timestamp_s: float | None = None,
+    ) -> "VideoBytes":
+        next_from, next_to = _compose_clip_bounds(
+            current_from=self.from_timestamp_s,
+            current_to=self.to_timestamp_s,
+            from_timestamp_s=from_timestamp_s,
+            to_timestamp_s=to_timestamp_s,
+        )
+        return VideoBytes(
+            data=self.data,
+            uri=self.uri,
+            from_timestamp_s=next_from,
+            to_timestamp_s=next_to,
+        )
+
+    def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
+        from refiner.video.decode import iter_encoded_frames
+
+        return iter_encoded_frames(self)
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
+        return iter_frame_windows(
+            self,
+            offsets=offsets,
+            stride=stride,
+            drop_incomplete=drop_incomplete,
+        )
+
+    async def write_to(
+        self,
+        writer: VideoStreamWriter,
+        *,
+        frame_observer: FrameObserver | None = None,
+        force_transcode: bool = False,
+    ) -> WrittenVideo:
+        return await writer.write_encoded_video(
+            self,
+            frame_observer=frame_observer,
+            force_transcode=force_transcode,
+        )
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class VideoFrameArray:
+    frames: Any = field(repr=False, compare=False)
+    fps: int = 30
+    _array: np.ndarray = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if int(self.fps) <= 0:
+            raise ValueError("fps must be > 0")
+        array = np.asarray(self.frames)
+        if array.ndim != 4:
+            raise ValueError(
+                "video frame arrays must have shape [frames, height, width, channels]"
+            )
+        if int(array.shape[3]) != 3:
+            raise ValueError("video frame arrays must have 3 RGB channels")
+        if array.dtype != np.uint8:
+            array = np.clip(array, 0, 255).astype(np.uint8)
+        if not array.flags.c_contiguous:
+            array = np.ascontiguousarray(array)
+        object.__setattr__(self, "fps", int(self.fps))
+        object.__setattr__(self, "_array", array)
+
+    @property
+    def frame_count(self) -> int:
+        return int(self._array.shape[0])
+
+    @property
+    def duration_s(self) -> float:
+        return self.frame_count / float(self.fps)
+
+    def iter_frame_arrays(self) -> Iterator[np.ndarray]:
+        yield from self._array
+
+    def clipped(
+        self,
+        *,
+        from_timestamp_s: float | None = None,
+        to_timestamp_s: float | None = None,
+    ) -> "VideoFrameArray":
+        start_s = 0.0 if from_timestamp_s is None else float(from_timestamp_s)
+        end_s = self.duration_s if to_timestamp_s is None else float(to_timestamp_s)
+        if start_s < 0:
+            raise ValueError("from_timestamp_s must be >= 0")
+        if end_s < start_s:
+            raise ValueError("to_timestamp_s must be >= from_timestamp_s")
+        if start_s > self.duration_s or end_s > self.duration_s + 1e-6:
+            raise ValueError("clip bounds are beyond the current video view")
+        start_idx = max(0, min(self.frame_count, int(math.floor(start_s * self.fps))))
+        end_idx = max(
+            start_idx, min(self.frame_count, int(math.ceil(end_s * self.fps)))
+        )
+        return VideoFrameArray(self._array[start_idx:end_idx], fps=self.fps)
+
+    async def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
+        import av
+        from refiner.video.decode import DecodedVideoFrame
+
+        for index, frame_array in enumerate(self._array):
+            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            frame.pts = index
+            frame.time_base = Fraction(1, self.fps)
+            yield DecodedVideoFrame(
+                index=index,
+                pts=index,
+                timestamp_s=index / float(self.fps),
+                width=int(frame.width),
+                height=int(frame.height),
+                frame=frame,
+            )
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
+        return iter_frame_windows(
+            self,
+            offsets=offsets,
+            stride=stride,
+            drop_incomplete=drop_incomplete,
+        )
+
+    async def write_to(
+        self,
+        writer: VideoStreamWriter,
+        *,
+        frame_observer: FrameObserver | None = None,
+        force_transcode: bool = False,
+    ) -> WrittenVideo:
+        return await writer.write_frame_array_video(
+            self,
+            frame_observer=frame_observer,
+        )
+
+
+def video_from_storage_value(
+    storage: str | None,
+    value: Any,
+    *,
+    fps: int = 30,
+) -> VideoSource | None:
+    if value is None:
+        return None
+    if isinstance(value, VideoSource):
+        return value
+    if storage in {None, "path"} and isinstance(value, str):
+        return VideoFile(DataFile.resolve(value))
+    if storage in {None, "bytes"} and isinstance(value, bytes):
+        return VideoBytes(data=value)
+    if storage in {None, "bytes_with_path"} and isinstance(value, Mapping):
+        data = value.get("bytes")
+        path = value.get("path")
+        if isinstance(data, bytes):
+            return VideoBytes(data=data, uri=path if isinstance(path, str) else None)
+    if storage in {None, "frame_array"}:
+        try:
+            return VideoFrameArray(value, fps=fps)
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = [
+    "VideoBytes",
+    "VideoFile",
+    "VideoFrameArray",
+    "VideoSource",
+    "video_from_storage_value",
+]

--- a/src/refiner/video/writer.py
+++ b/src/refiner/video/writer.py
@@ -21,7 +21,7 @@ from refiner.video.transcode import (
     TranscodeWriter,
     VideoTranscodeConfig,
 )
-from refiner.video.types import VideoFile
+from refiner.video.types import VideoBytes, VideoFile, VideoFrameArray
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,9 +57,9 @@ class VideoStreamWriter:
     _next_file_index: int = field(default=0, init=False)
     _commit_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
 
-    async def write_video(
+    async def write_encoded_video(
         self,
-        video: VideoFile,
+        video: VideoFile | VideoBytes,
         *,
         frame_observer: FrameObserver | None = None,
         force_transcode: bool = False,
@@ -73,6 +73,17 @@ class VideoStreamWriter:
             )
         finally:
             prepared.close()
+
+    async def write_frame_array_video(
+        self,
+        video: VideoFrameArray,
+        *,
+        frame_observer: FrameObserver | None = None,
+    ) -> WrittenVideo:
+        return await self._commit_frame_arrays(
+            video,
+            frame_observer=frame_observer,
+        )
 
     def close(self) -> None:
         if self._writer is None:
@@ -104,6 +115,53 @@ class VideoStreamWriter:
                 ),
             )
 
+    async def _commit_frame_arrays(
+        self,
+        video: VideoFrameArray,
+        *,
+        frame_observer: FrameObserver | None,
+    ) -> WrittenVideo:
+        async with self._commit_lock:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                io_executor(),
+                partial(
+                    self._commit_frame_arrays_sync,
+                    video,
+                    frame_observer=frame_observer,
+                ),
+            )
+
+    def _commit_frame_arrays_sync(
+        self,
+        video: VideoFrameArray,
+        *,
+        frame_observer: FrameObserver | None,
+    ) -> WrittenVideo:
+        writer = self._ensure_transcode_writer(video.fps)
+        file_index = self._next_file_index
+        from_timestamp, to_timestamp = writer.append_frame_arrays(
+            video.iter_frame_arrays(),
+            frame_observer=frame_observer,
+        )
+        if writer.stream is None:
+            raise RuntimeError("Transcode writer did not initialize an output stream")
+        segment = WrittenVideoSegment(
+            stream_key=self.stream_key,
+            file_index=file_index,
+            output_rel=self._current_output_rel,
+            from_timestamp=from_timestamp,
+            to_timestamp=to_timestamp,
+            fps=int(writer.fps),
+            width=int(writer.stream.width),
+            height=int(writer.stream.height),
+            codec=self.transcode_config.codec,
+            pix_fmt=self.transcode_config.pix_fmt,
+        )
+        if writer.size_bytes >= self.video_bytes_limit:
+            self._rotate_writer()
+        return WrittenVideo(segment=segment, mode="transcode")
+
     def _commit_sync(
         self,
         prepared: PreparedVideoSource,
@@ -111,11 +169,7 @@ class VideoStreamWriter:
         frame_observer: FrameObserver | None,
         force_transcode: bool,
     ) -> WrittenVideo:
-        if not self._should_transcode(
-            prepared,
-            frame_observer=frame_observer,
-            force_transcode=force_transcode,
-        ):
+        if not force_transcode and prepared_source_is_remuxable(prepared):
             probe = prepared.probe
             if probe is None:
                 raise RuntimeError("Remux path selected without a source probe")
@@ -140,7 +194,13 @@ class VideoStreamWriter:
                 self._rotate_writer()
             return WrittenVideo(segment=segment, mode="remux")
 
-        fps = self._transcode_fps(prepared)
+        fps = (
+            int(prepared.probe.fps)
+            if prepared.probe is not None and prepared.probe.fps is not None
+            else int(self._writer.fps)
+            if isinstance(self._writer, TranscodeWriter)
+            else None
+        )
         if fps is None:
             raise ValueError("Prepared transcode item is missing FPS")
         writer = self._ensure_transcode_writer(fps)
@@ -166,23 +226,6 @@ class VideoStreamWriter:
         if writer.size_bytes >= self.video_bytes_limit:
             self._rotate_writer()
         return WrittenVideo(segment=segment, mode="transcode")
-
-    def _should_transcode(
-        self,
-        prepared: PreparedVideoSource,
-        *,
-        frame_observer: FrameObserver | None,
-        force_transcode: bool,
-    ) -> bool:
-        _ = frame_observer
-        return force_transcode or not prepared_source_is_remuxable(prepared)
-
-    def _transcode_fps(self, prepared: PreparedVideoSource) -> int | None:
-        if prepared.probe is not None and prepared.probe.fps is not None:
-            return int(prepared.probe.fps)
-        if isinstance(self._writer, TranscodeWriter):
-            return int(self._writer.fps)
-        return None
 
     def _ensure_transcode_writer(self, fps: int) -> TranscodeWriter:
         writer = self._writer

--- a/tests/pipeline/test_datatype.py
+++ b/tests/pipeline/test_datatype.py
@@ -28,6 +28,7 @@ def test_datatype_constructors_produce_arrow_types_and_metadata() -> None:
     assert datatype.asset_storage(datatype.video_path()) == "path"
     assert datatype.asset_storage(datatype.video_bytes()) == "bytes"
     assert datatype.asset_storage(datatype.video_bytes_with_path()) == "bytes_with_path"
+    assert datatype.asset_storage(datatype.video_frame_array()) == "frame_array"
     assert datatype.list(datatype.uint8()) == pa.list_(pa.uint8())
     assert datatype.list(datatype.uint8(), size=3) == pa.list_(pa.uint8(), list_size=3)
     assert datatype.struct({"x": datatype.float32()}) == pa.struct(

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Iterator, cast
+from typing import Any, Iterator, cast
 
 import av
 import fsspec
 import numpy as np
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -16,13 +18,17 @@ import refiner as mdr
 from refiner.io import DataFile, DataFolder
 from refiner.video.remux import reset_opened_video_source_cache
 from refiner.video.transcode import VideoTranscodeConfig
+from refiner.video.types import VideoSource
 from refiner.video.writer import VideoStreamWriter
-from refiner.pipeline.data.row import DictRow
+from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sinks.lerobot import LeRobotWriterSink
 from refiner.pipeline.sinks.reducer.lerobot import LeRobotMetaReduceSink
+from refiner.robotics.row import RoboticsRow, _robot_row_converter
 from refiner.robotics.lerobot_format import (
     LeRobotInfo,
     LeRobotMetadata,
+    LeRobotRow,
     LeRobotStatsFile,
     LeRobotTasks,
 )
@@ -34,6 +40,177 @@ _ALOHA_REPO_IDS = (
     "macrodata/aloha_static_battery_ep000_004",
     "macrodata/aloha_static_battery_ep005_009",
 )
+
+
+class _FakeRoboticsRow(Row, RoboticsRow):
+    def __init__(
+        self,
+        *,
+        episode_id: str,
+        frame_table: Tabular,
+        task: str | None = None,
+        fps: float | None = None,
+        robot_type: str | None = None,
+        videos: Mapping[str, VideoSource] | None = None,
+    ) -> None:
+        self._data = {"episode_id": episode_id}
+        self._frame_table = frame_table
+        self._task = task
+        self._fps = fps
+        self._robot_type = robot_type
+        self._videos = dict(videos or {})
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    @property
+    def episode_id(self) -> str:
+        return str(self._data["episode_id"])
+
+    @property
+    def num_frames(self) -> int:
+        return self._frame_table.num_rows
+
+    @property
+    def task(self) -> str | None:
+        return self._task
+
+    @property
+    def fps(self) -> float | None:
+        return self._fps
+
+    @property
+    def robot_type(self) -> str | None:
+        return self._robot_type
+
+    @property
+    def videos(self) -> Mapping[str, VideoSource]:
+        return self._videos
+
+    @property
+    def stats(self) -> Mapping[str, Any]:
+        return {}
+
+    def _frame_values(self, key: str) -> Any:
+        return self._frame_table.column(key)
+
+    @property
+    def timestamps(self) -> Any:
+        return (
+            self._frame_values("timestamp")
+            if "timestamp" in self._frame_table.names
+            else None
+        )
+
+    @property
+    def actions(self) -> Any:
+        return (
+            self._frame_values("action")
+            if "action" in self._frame_table.names
+            else None
+        )
+
+    @property
+    def states(self) -> Any:
+        return (
+            self._frame_values("observation.state")
+            if "observation.state" in self._frame_table.names
+            else None
+        )
+
+    def observations(self, name: str | None = None) -> Any:
+        values: dict[str, Any] = {
+            key[len("observation.") :]: self._frame_table.column(key)
+            for key in self._frame_table.names
+            if key.startswith("observation.")
+        }
+        values.update({f"videos/{key}": video for key, video in self.videos.items()})
+        if name is None:
+            return values
+        normalized_name = (
+            name[len("observation.") :] if name.startswith("observation.") else name
+        )
+        return values[normalized_name]
+
+    def with_timestamps(self, values: Any) -> "_FakeRoboticsRow":
+        return self._with_frame_values("timestamp", values)
+
+    def with_actions(self, values: Any) -> "_FakeRoboticsRow":
+        return self._with_frame_values("action", values)
+
+    def with_observation(self, key: str, values: Any) -> "_FakeRoboticsRow":
+        frame_key = key if key.startswith("observation.") else f"observation.{key}"
+        return self._with_frame_values(frame_key, values)
+
+    def _with_frame_values(self, key: str, values: Any) -> "_FakeRoboticsRow":
+        table = self._frame_table.table
+        column = (
+            values
+            if isinstance(values, (pa.Array, pa.ChunkedArray))
+            else pa.array(values)
+        )
+        if key in table.column_names:
+            table = table.set_column(table.column_names.index(key), key, column)
+        else:
+            table = table.append_column(key, column)
+        return self._with_frame_table(self._frame_table.with_table(table))
+
+    def select_frames(self, indices: Sequence[int]) -> "_FakeRoboticsRow":
+        selected = self._frame_table.table.take(pa.array(indices, type=pa.int64()))
+        return self._with_frame_table(self._frame_table.with_table(selected))
+
+    def to_frame_table(self) -> Tabular:
+        return self._frame_table
+
+    def with_video(self, key: str, video: VideoSource) -> "_FakeRoboticsRow":
+        videos = dict(self._videos)
+        videos[key] = video
+        return _FakeRoboticsRow(
+            episode_id=self.episode_id,
+            frame_table=self._frame_table,
+            task=self.task,
+            fps=self.fps,
+            robot_type=self.robot_type,
+            videos=videos,
+        )
+
+    def drop_stats(self, feature: str) -> "_FakeRoboticsRow":
+        _ = feature
+        return self
+
+    def _with_frame_table(self, frame_table: Tabular) -> "_FakeRoboticsRow":
+        return _FakeRoboticsRow(
+            episode_id=self.episode_id,
+            frame_table=frame_table,
+            task=self.task,
+            fps=self.fps,
+            robot_type=self.robot_type,
+            videos=self.videos,
+        )
+
+    def update(
+        self,
+        patch: Mapping[str, Any] | None = None,
+        /,
+        **kwargs: Any,
+    ) -> "_FakeRoboticsRow":
+        data = dict(self._data)
+        data.update(patch or {})
+        data.update(kwargs)
+        return _FakeRoboticsRow(
+            episode_id=str(data["episode_id"]),
+            frame_table=self._frame_table,
+            task=self.task,
+            fps=self.fps,
+            robot_type=self.robot_type,
+            videos=self.videos,
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -119,6 +296,10 @@ def _sampled_frame_count(
     return len(range(0, frame_count, sample_stride))
 
 
+def _robot_row(row: Row, **kwargs: Any) -> RoboticsRow:
+    return cast(RoboticsRow, _robot_row_converter(**kwargs)(row))
+
+
 def _episode(
     *,
     episode_index: int,
@@ -128,26 +309,103 @@ def _episode(
     from_ts: float,
     to_ts: float,
     values: list[float],
-) -> dict:
-    return {
-        "episode_index": episode_index,
-        "task": task,
-        "frames": [
+) -> RoboticsRow:
+    return _robot_row(
+        DictRow(
+            {
+                "episode_id": str(episode_index),
+                "episode_index": episode_index,
+                "task": task,
+                "frames": [
+                    {
+                        "frame_index": i,
+                        "timestamp": float(i) / 10.0,
+                        "task_index": task_index,
+                        "observation.state": [v],
+                    }
+                    for i, v in enumerate(values)
+                ],
+                "observation.images.main": mdr.video.VideoFile(
+                    DataFile.resolve(str(video_path)),
+                    from_timestamp_s=from_ts,
+                    to_timestamp_s=to_ts,
+                ),
+            }
+        ),
+        episode_id_key="episode_id",
+        task_key="task",
+        fps=10,
+        robot_type="mockbot",
+        nested_frames_key="frames",
+        video_keys=("observation.images.main",),
+    )
+
+
+def _robotics_episode(
+    *,
+    episode_index: int,
+    task: str,
+    task_index: int,
+    values: list[float],
+) -> RoboticsRow:
+    return _robot_row(
+        DictRow(
+            {
+                "episode_id": str(episode_index),
+                "episode_index": episode_index,
+                "task": task,
+                "frames": [
+                    {
+                        "frame_index": i,
+                        "timestamp": float(i) / 10.0,
+                        "task_index": task_index,
+                        "observation.state": [v],
+                    }
+                    for i, v in enumerate(values)
+                ],
+            }
+        ),
+        episode_id_key="episode_id",
+        task_key="task",
+        fps=10,
+        robot_type="mockbot",
+        nested_frames_key="frames",
+    )
+
+
+def _lerobot_episode(
+    *,
+    episode_index: int,
+    task: str,
+    task_index: int,
+    values: list[float],
+    metadata: LeRobotMetadata | None = None,
+    shard_id: str | None = None,
+) -> LeRobotRow:
+    frames = [
+        DictRow(
             {
                 "frame_index": i,
                 "timestamp": float(i) / 10.0,
                 "task_index": task_index,
                 "observation.state": [v],
             }
-            for i, v in enumerate(values)
-        ],
-        "observation.images.main": mdr.video.VideoFile(
-            DataFile.resolve(str(video_path)),
-            from_timestamp_s=from_ts,
-            to_timestamp_s=to_ts,
+        )
+        for i, v in enumerate(values)
+    ]
+    return LeRobotRow(
+        DictRow(
+            {
+                "episode_index": episode_index,
+                "episode_id": str(episode_index),
+                "task": task,
+                "length": len(frames),
+            },
+            shard_id=shard_id,
         ),
-        "metadata": _metadata(),
-    }
+        metadata=metadata or _metadata(),
+        frames=frames,
+    )
 
 
 def _metadata(
@@ -257,44 +515,18 @@ def test_write_lerobot_launch_local_runs_stage1_then_stage2(tmp_path: Path) -> N
     out_root = tmp_path / "local-launch"
     pipeline = mdr.from_items(
         [
-            {
-                "episode_index": 0,
-                "task": "pick",
-                "frames": [
-                    {
-                        "frame_index": 0,
-                        "timestamp": 0.0,
-                        "task_index": 0,
-                        "observation.state": [1.0],
-                    },
-                    {
-                        "frame_index": 1,
-                        "timestamp": 0.1,
-                        "task_index": 0,
-                        "observation.state": [2.0],
-                    },
-                ],
-                "metadata": _metadata(),
-            },
-            {
-                "episode_index": 1,
-                "task": "place",
-                "frames": [
-                    {
-                        "frame_index": 0,
-                        "timestamp": 0.0,
-                        "task_index": 1,
-                        "observation.state": [3.0],
-                    },
-                    {
-                        "frame_index": 1,
-                        "timestamp": 0.1,
-                        "task_index": 1,
-                        "observation.state": [4.0],
-                    },
-                ],
-                "metadata": _metadata(),
-            },
+            _robotics_episode(
+                episode_index=0,
+                task="pick",
+                task_index=0,
+                values=[1.0, 2.0],
+            ),
+            _robotics_episode(
+                episode_index=1,
+                task="place",
+                task_index=1,
+                values=[3.0, 4.0],
+            ),
         ],
         items_per_shard=1,
     ).write_lerobot(str(out_root))
@@ -309,6 +541,97 @@ def test_write_lerobot_launch_local_runs_stage1_then_stage2(tmp_path: Path) -> N
     assert (out_root / "meta" / "info.json").exists()
     assert (out_root / "meta" / "stats.json").exists()
     assert (out_root / "meta" / "tasks.parquet").exists()
+
+
+def test_write_lerobot_accepts_generic_robotics_rows(tmp_path: Path) -> None:
+    out_root = tmp_path / "generic-robotics"
+    rows = [
+        _FakeRoboticsRow(
+            episode_id="demo-pick",
+            task="pick",
+            fps=10,
+            robot_type="mockbot",
+            frame_table=Tabular.from_rows(
+                [
+                    DictRow(
+                        {
+                            "frame_index": 0,
+                            "timestamp": 0.0,
+                            "observation.state": [1.0],
+                        }
+                    ),
+                    DictRow(
+                        {
+                            "frame_index": 1,
+                            "timestamp": 0.1,
+                            "observation.state": [2.0],
+                        }
+                    ),
+                ]
+            ),
+        ),
+        _FakeRoboticsRow(
+            episode_id="demo-place",
+            task="place",
+            fps=10,
+            robot_type="mockbot",
+            frame_table=Tabular.from_rows(
+                [
+                    DictRow(
+                        {
+                            "frame_index": 0,
+                            "timestamp": 0.0,
+                            "observation.state": [3.0],
+                        }
+                    ),
+                    DictRow(
+                        {
+                            "frame_index": 1,
+                            "timestamp": 0.1,
+                            "observation.state": [4.0],
+                        }
+                    ),
+                ]
+            ),
+        ),
+    ]
+
+    finalized: list[FinalizedShardWorker] = []
+    for shard_id, worker_id, row in [
+        ("shard-1", "worker-1", rows[0]),
+        ("shard-2", "worker-2", rows[1]),
+    ]:
+        writer = LeRobotWriterSink(str(out_root))
+        finalized.append(FinalizedShardWorker(shard_id=shard_id, worker_id=worker_id))
+        with set_active_run_context(
+            job_id="job",
+            stage_index=0,
+            worker_id=worker_id,
+            worker_name=None,
+            runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime()),
+        ):
+            writer.write_shard_block(shard_id, [row])
+            writer.on_shard_complete(shard_id)
+
+    reducer = LeRobotMetaReduceSink(output=str(out_root))
+    with set_active_run_context(
+        job_id="job",
+        stage_index=1,
+        worker_id="local",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime(finalized)),
+    ):
+        reducer.write_block([DictRow({"task_rank": 0}, shard_id="reduce")])
+
+    tasks = pq.read_table(out_root / "meta" / "tasks.parquet")
+    assert sorted(tasks.column("task").to_pylist()) == ["pick", "place"]
+    episodes = pq.read_table(
+        out_root / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    )
+    assert sorted(task[0] for task in episodes.column("tasks").to_pylist()) == [
+        "pick",
+        "place",
+    ]
 
 
 def test_lerobot_video_writer_reuses_opened_remux_source_for_same_uri(
@@ -342,24 +665,18 @@ def test_lerobot_video_writer_reuses_opened_remux_source_for_same_uri(
         output_rel_template="videos/{stream_key}/chunk-{chunk_index}/file-{file_index:03d}.mp4",
         output_context={"chunk_index": "000"},
     )
-    asyncio.run(
-        writer.write_video(
-            mdr.video.VideoFile(
-                DataFile.resolve(uri),
-                from_timestamp_s=0.0,
-                to_timestamp_s=0.3,
-            ),
-        )
+    first_video = mdr.video.VideoFile(
+        DataFile.resolve(uri),
+        from_timestamp_s=0.0,
+        to_timestamp_s=0.3,
     )
-    asyncio.run(
-        writer.write_video(
-            mdr.video.VideoFile(
-                DataFile.resolve(uri),
-                from_timestamp_s=0.3,
-                to_timestamp_s=0.6,
-            ),
-        )
+    asyncio.run(first_video.write_to(writer))
+    second_video = mdr.video.VideoFile(
+        DataFile.resolve(uri),
+        from_timestamp_s=0.3,
+        to_timestamp_s=0.6,
     )
+    asyncio.run(second_video.write_to(writer))
     writer.close()
 
     assert read_open_calls == 1
@@ -516,44 +833,20 @@ def test_write_lerobot_preserves_stable_task_index_mapping(tmp_path: Path) -> No
     out_root = tmp_path / "task-index"
     pipeline = mdr.from_items(
         [
-            {
-                "episode_index": 0,
-                "task": "pick",
-                "frames": [
-                    {
-                        "frame_index": 0,
-                        "timestamp": 0.0,
-                        "task_index": 5,
-                        "observation.state": [1.0],
-                    },
-                    {
-                        "frame_index": 1,
-                        "timestamp": 0.1,
-                        "task_index": 5,
-                        "observation.state": [2.0],
-                    },
-                ],
-                "metadata": _metadata({1: "place", 5: "pick"}),
-            },
-            {
-                "episode_index": 1,
-                "task": "place",
-                "frames": [
-                    {
-                        "frame_index": 0,
-                        "timestamp": 0.0,
-                        "task_index": 1,
-                        "observation.state": [3.0],
-                    },
-                    {
-                        "frame_index": 1,
-                        "timestamp": 0.1,
-                        "task_index": 1,
-                        "observation.state": [4.0],
-                    },
-                ],
-                "metadata": _metadata({1: "place", 5: "pick"}),
-            },
+            _lerobot_episode(
+                episode_index=0,
+                task="pick",
+                task_index=5,
+                values=[1.0, 2.0],
+                metadata=_metadata({1: "place", 5: "pick"}),
+            ),
+            _lerobot_episode(
+                episode_index=1,
+                task="place",
+                task_index=1,
+                values=[3.0, 4.0],
+                metadata=_metadata({1: "place", 5: "pick"}),
+            ),
         ],
         items_per_shard=10,
     ).write_lerobot(str(out_root))
@@ -590,20 +883,12 @@ def test_write_lerobot_raises_on_unmapped_frame_task_index(tmp_path: Path) -> No
         ):
             writer.write_block(
                 [
-                    DictRow(
-                        {
-                            "episode_index": 0,
-                            "task": "pick",
-                            "frames": [
-                                {
-                                    "frame_index": 0,
-                                    "timestamp": 0.0,
-                                    "task_index": 7,
-                                    "observation.state": [1.0],
-                                }
-                            ],
-                            "metadata": _metadata(),
-                        },
+                    _lerobot_episode(
+                        episode_index=0,
+                        task="pick",
+                        task_index=7,
+                        values=[1.0],
+                        metadata=_metadata(),
                         shard_id="shard-1",
                     )
                 ]
@@ -629,49 +914,15 @@ def test_write_lerobot_stage2_keeps_only_finalized_worker_outputs(
     tmp_path: Path,
 ) -> None:
     out_root = tmp_path / "cleanup"
-    row = DictRow(
-        {
-            "episode_index": 0,
-            "task": "pick",
-            "frames": [
-                {
-                    "frame_index": 0,
-                    "timestamp": 0.0,
-                    "task_index": 0,
-                    "observation.state": [1.0],
-                },
-                {
-                    "frame_index": 1,
-                    "timestamp": 0.1,
-                    "task_index": 0,
-                    "observation.state": [2.0],
-                },
-            ],
-            "metadata": _metadata(),
-        },
-        shard_id="shard-1",
-    )
-
     for worker_id, values in [("1", [1.0, 2.0]), ("2", [9.0, 10.0])]:
         writer = LeRobotWriterSink(str(out_root))
         runtime = cast(RuntimeLifecycle, _FinalizedWorkersRuntime())
-        worker_row = row.update(
-            {
-                "frames": [
-                    {
-                        "frame_index": 0,
-                        "timestamp": 0.0,
-                        "task_index": 0,
-                        "observation.state": [values[0]],
-                    },
-                    {
-                        "frame_index": 1,
-                        "timestamp": 0.1,
-                        "task_index": 0,
-                        "observation.state": [values[1]],
-                    },
-                ],
-            }
+        worker_row = _lerobot_episode(
+            episode_index=0,
+            task="pick",
+            task_index=0,
+            values=values,
+            shard_id="shard-1",
         )
         with set_active_run_context(
             job_id="job",

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -164,6 +164,7 @@ def test_compile_pipeline_plan_uses_builtin_calls_for_builtin_steps() -> None:
     assert steps[1]["args"] == {
         "action_key": "action",
         "state_key": "observation.state",
+        "timestamp_key": "timestamp",
         "threshold": 0.25,
         "pad_frames": 2,
     }

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -174,7 +174,7 @@ def test_lerobot_reader_emits_episode_rows(tmp_path: Path) -> None:
     assert int(frame_rows[0]["frame_index"]) == 0
     assert int(frame_rows[1]["frame_index"]) == 1
 
-    video = first.videos["observation.images.main"].video
+    video = first.videos["observation.images.main"]
     assert isinstance(video, VideoFile)
     assert video.uri.endswith("/videos/observation.images.main/chunk-000/file-000.mp4")
     assert video.from_timestamp_s == 0.0

--- a/tests/robotics/test_motion.py
+++ b/tests/robotics/test_motion.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from typing import cast
 
 from refiner.io import DataFolder
 from refiner.pipeline.data.row import DictRow
+from refiner.pipeline.data.tabular import Tabular
 from refiner.robotics import motion_trim
 from refiner.robotics.lerobot_format import (
     LeRobotInfo,
@@ -99,7 +101,40 @@ def test_motion_trim_returns_empty_frames_when_no_motion() -> None:
     trimmed = motion_trim(threshold=0.25, pad_frames=0)(row)
     assert isinstance(trimmed, LeRobotRow)
 
-    assert trimmed["frames"] == []
+    assert trimmed.num_frames == 0
     video = trimmed.videos["observation.images.main"]
     assert video.from_timestamp_s == pytest.approx(5.0)
     assert video.to_timestamp_s == pytest.approx(5.3)
+
+
+def test_motion_trim_accepts_custom_timestamp_key() -> None:
+    frames = [
+        _frame(frame_index=0, timestamp=0.0, action=0.0, state=0.0),
+        _frame(frame_index=1, timestamp=0.1, action=1.0, state=0.0),
+        _frame(frame_index=2, timestamp=0.2, action=1.0, state=0.0),
+    ]
+    row = _row(
+        frames=frames,
+        from_ts=2.0,
+        to_ts=2.3,
+    ).update(
+        frames=Tabular.from_rows(
+            [
+                frame.drop("timestamp").update({"time_s": frame["timestamp"]})
+                for frame in frames
+            ]
+        ),
+    )
+
+    trimmed = cast(
+        LeRobotRow,
+        motion_trim(threshold=0.25, timestamp_key="time_s")(row),
+    )
+
+    trimmed_frames = trimmed.to_frame_table()
+    assert "time_s" in trimmed_frames.table.column_names
+    assert "timestamp" not in trimmed_frames.table.column_names
+    np.testing.assert_allclose(
+        [float(frame["time_s"]) for frame in trimmed_frames],
+        [0.0, 0.1],
+    )

--- a/tests/robotics/test_robotics_row.py
+++ b/tests/robotics/test_robotics_row.py
@@ -1,0 +1,635 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from refiner.pipeline import from_items
+from refiner.pipeline.data import datatype
+from refiner.pipeline.data.row import DictRow
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.data.tabular import Tabular
+from refiner.robotics import motion_trim
+from refiner.robotics.row import (
+    RoboticsRow,
+    _robot_row_converter,
+)
+from refiner.video import VideoBytes, VideoFile, VideoFrameArray
+
+
+def _robot_row(row: Row, **kwargs: Any) -> RoboticsRow:
+    return cast(RoboticsRow, _robot_row_converter(**kwargs)(row))
+
+
+def _robot_rows(
+    rows: Row | Tabular,
+    *,
+    layout: str = "episode_rows",
+    **kwargs: Any,
+) -> list[RoboticsRow]:
+    assert layout == "episode_rows"
+    if isinstance(rows, Tabular):
+        converter = _robot_row_converter(**cast(Any, {**kwargs, "schema": rows.schema}))
+        return [cast(RoboticsRow, converter(row)) for row in rows]
+    converter = _robot_row_converter(**kwargs)
+    converted = converter(rows)
+    if kwargs.get("episode_ends_key") is not None:
+        return [cast(RoboticsRow, row) for row in converted]
+    return [cast(RoboticsRow, converted)]
+
+
+def test_to_robot_rows_does_not_treat_video_uri_frames_as_frame_table() -> None:
+    row = DictRow(
+        {
+            "id": "episode-1",
+            "task": "pick the cup",
+            "frames": "clips/episode-1.mp4",
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        episode_id_key="id",
+        task_key="task",
+        video_keys={"observation.images.main": "frames"},
+    )
+
+    assert robotics_row.episode_id == "episode-1"
+    assert robotics_row.task == "pick the cup"
+    assert robotics_row.num_frames == -1
+    video = robotics_row.videos["observation.images.main"]
+    assert isinstance(video, VideoFile)
+    assert video.uri.endswith("/clips/episode-1.mp4")
+
+
+def test_to_robot_rows_exposes_stats_and_embedded_video_bytes() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "camera_bytes": b"video bytes",
+            "stats/action/min": [0.0],
+            "stats/action/max": [1.0],
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        video_keys={"observation.images.main": "camera_bytes"},
+    )
+
+    video = robotics_row.videos["observation.images.main"]
+    assert isinstance(video, VideoBytes)
+    assert video.open().read() == b"video bytes"
+    assert robotics_row.stats["action"]["min"] == [0.0]
+    assert robotics_row.stats["action"]["max"] == [1.0]
+
+    without_action_stats = robotics_row.drop_stats("action")
+    assert without_action_stats.stats == {}
+
+
+def test_to_robot_rows_uses_video_asset_schema() -> None:
+    table = Tabular.from_rows(
+        [
+            DictRow({"episode_id": "episode-1", "camera": "clips/episode-1.mp4"}),
+        ],
+        schema=datatype.schema_with_dtypes(
+            None,
+            {"camera": datatype.video_path()},
+        ),
+    )
+
+    robotics_row = list(_robot_rows(table, episode_id_key="episode_id"))[0]
+
+    video = robotics_row.videos["camera"]
+    assert isinstance(video, VideoFile)
+    assert video.uri.endswith("/clips/episode-1.mp4")
+
+
+def test_to_robot_rows_uses_video_frame_array_asset_schema() -> None:
+    frames = np.zeros((2, 4, 5, 3), dtype=np.uint8)
+    table = Tabular.from_rows(
+        [
+            DictRow({"episode_id": "episode-1", "camera": frames}),
+        ],
+        schema=datatype.schema_with_dtypes(
+            None,
+            {"camera": datatype.video_frame_array()},
+        ),
+    )
+
+    robotics_row = list(_robot_rows(table, episode_id_key="episode_id", fps=12))[0]
+
+    video = robotics_row.videos["camera"]
+    assert isinstance(video, VideoFrameArray)
+    video_frames = list(video.iter_frame_arrays())
+    assert len(video_frames) == 2
+    assert video_frames[0].shape == (4, 5, 3)
+    assert video.fps == 12
+
+
+def test_to_robot_rows_accepts_unmapped_key_iterables() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "action": [[0.0]],
+            "observation.state": [[1.0]],
+            "qvel": [[2.0]],
+            "front_video": "clips/episode-1.mp4",
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        extra_observation_keys=("qvel",),
+        video_keys=("front_video",),
+    )
+
+    assert robotics_row.observations("qvel") == [[2.0]]
+    video = robotics_row.videos["front_video"]
+    assert isinstance(video, VideoFile)
+    assert video.uri.endswith("/clips/episode-1.mp4")
+
+
+def test_to_robot_rows_iteration_hides_nested_source_containers() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "label": "keep",
+            "obs": {
+                "qpos": [[1.0], [2.0]],
+                "front": "clips/episode-1.mp4",
+            },
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        episode_id_key="episode_id",
+        timestamp_key=None,
+        action_key=None,
+        state_key="obs/qpos",
+        video_keys={"observation.images.front": "obs/front"},
+    )
+
+    assert dict(cast(Row, robotics_row).items()) == {
+        "episode_id": "episode-1",
+        "label": "keep",
+    }
+    assert robotics_row.states == [[1.0], [2.0]]
+    video = robotics_row.videos["observation.images.front"]
+    assert isinstance(video, VideoFile)
+    assert video.uri.endswith("/clips/episode-1.mp4")
+
+
+def test_to_robot_rows_accepts_tabular_input() -> None:
+    table = Tabular.from_rows(
+        [
+            DictRow({"episode_id": "episode-1", "task": "pick"}),
+            DictRow({"episode_id": "episode-2", "task": "place"}),
+        ]
+    )
+
+    rows = list(_robot_rows(table, episode_id_key="episode_id", task_key="task"))
+
+    assert [row.episode_id for row in rows] == ["episode-1", "episode-2"]
+    assert [row.task for row in rows] == ["pick", "place"]
+
+
+def test_to_robot_rows_defaults_do_not_assume_fps_or_robot_type_keys() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "fps": 10,
+            "robot_type": "mockbot",
+        }
+    )
+
+    robotics_row = _robot_row(row)
+
+    assert robotics_row.fps is None
+    assert robotics_row.robot_type is None
+
+
+def test_to_robot_rows_defaults_to_no_episode_id_source() -> None:
+    row = DictRow({"episode_id": "source-value", "action": [[0.0]]})
+
+    robotics_row = _robot_row(row, timestamp_key=None, state_key=None)
+
+    assert robotics_row.episode_id == "-1"
+    assert dict(cast(Row, robotics_row).items())["episode_id"] == "source-value"
+
+
+def test_to_robot_rows_accepts_literal_fps_and_robot_type() -> None:
+    row = DictRow({"episode_id": "episode-1"})
+
+    robotics_row = _robot_row(row, fps=20.0, robot_type="koch")
+
+    assert robotics_row.fps == 20.0
+    assert robotics_row.robot_type == "koch"
+
+
+def test_to_robot_rows_preserves_explicit_fps_and_robot_type_keys() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "source_fps": "15",
+            "source_robot": "aloha",
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        fps_key="source_fps",
+        robot_type_key="source_robot",
+    )
+
+    assert robotics_row.fps == 15.0
+    assert robotics_row.robot_type == "aloha"
+
+
+def test_to_robot_rows_reuses_literal_fps_and_robot_type_for_episode_splits() -> None:
+    row = DictRow(
+        {
+            "dataset_id": "pusht",
+            "episode_ends": [1, 2],
+            "action": [[0.0], [1.0]],
+        }
+    )
+
+    rows = list(
+        _robot_rows(
+            row,
+            episode_id_key="dataset_id",
+            episode_ends_key="episode_ends",
+            timestamp_key=None,
+            state_key=None,
+            fps=30.0,
+            robot_type="pusht",
+        )
+    )
+
+    assert [row.fps for row in rows] == [30.0, 30.0]
+    assert [row.robot_type for row in rows] == ["pusht", "pusht"]
+
+
+def test_pipeline_to_robot_rows_forwards_literals_and_explicit_keys() -> None:
+    literal_row = (
+        from_items([{"episode_id": "episode-1"}])
+        .to_robot_rows(
+            fps=12.5,
+            robot_type="literalbot",
+        )
+        .materialize()[0]
+    )
+    keyed_row = (
+        from_items(
+            [{"episode_id": "episode-2", "source_fps": 7, "source_robot": "keybot"}]
+        )
+        .to_robot_rows(
+            fps_key="source_fps",
+            robot_type_key="source_robot",
+        )
+        .materialize()[0]
+    )
+
+    assert isinstance(literal_row, RoboticsRow)
+    assert literal_row.fps == 12.5
+    assert literal_row.robot_type == "literalbot"
+    assert isinstance(keyed_row, RoboticsRow)
+    assert keyed_row.fps == 7.0
+    assert keyed_row.robot_type == "keybot"
+
+
+def test_to_robot_rows_output_can_be_motion_trimmed() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "timestamp": [0.0, 0.1, 0.2, 0.3],
+            "action": [[0.0], [0.0], [1.0], [1.0]],
+            "observation.state": [[0.0], [0.0], [0.0], [0.0]],
+        }
+    )
+    robotics_row = _robot_row(row)
+
+    trimmed = cast(RoboticsRow, motion_trim(threshold=0.25)(cast(Row, robotics_row)))
+
+    assert trimmed.num_frames == 2
+    assert trimmed.timestamps == pytest.approx([0.0, 0.1])
+
+
+def test_to_robot_rows_maps_alternate_semantic_keys() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "time_s": [0.0, 0.1, 0.2],
+            "actions": [[0.0], [1.0], [1.0]],
+            "obs/qpos": [[0.0], [0.0], [0.0]],
+            "camera": ["frame-0", "frame-1", "frame-2"],
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        timestamp_key="time_s",
+        action_key="actions",
+        state_key="obs/qpos",
+        extra_observation_keys={"images.main": "camera"},
+    )
+
+    assert robotics_row.num_frames == 3
+    assert robotics_row.actions == [[0.0], [1.0], [1.0]]
+    assert robotics_row.observations("state") == [[0.0], [0.0], [0.0]]
+    assert set(robotics_row.observations()) == {"state", "images.main"}
+    assert robotics_row.observations("images.main") == [
+        "frame-0",
+        "frame-1",
+        "frame-2",
+    ]
+    assert robotics_row.to_frame_table().table.column_names == [
+        "timestamp",
+        "action",
+        "observation.state",
+        "observation.images.main",
+    ]
+    updated = robotics_row.with_actions([[2.0], [2.0], [2.0]]).with_observation(
+        "state",
+        [[3.0], [3.0], [3.0]],
+    )
+    assert updated.actions == [[2.0], [2.0], [2.0]]
+    assert updated.states == [[3.0], [3.0], [3.0]]
+
+
+def test_to_robot_rows_concatenates_tuple_state_key_sources() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "timestamp": [0.0, 0.1, 0.2],
+            "actions": [[0.0], [0.1], [0.2]],
+            "obs": {
+                "joint_pos": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                "joint_vel": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+            },
+            "eef_pos": np.asarray(
+                [[10.0, 11.0, 12.0], [13.0, 14.0, 15.0], [16.0, 17.0, 18.0]],
+                dtype=np.float32,
+            ),
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        action_key="actions",
+        state_key=("obs/joint_pos", "obs/joint_vel", "eef_pos"),
+    )
+
+    expected_state = [
+        [1.0, 2.0, 0.1, 0.2, 10.0, 11.0, 12.0],
+        [3.0, 4.0, 0.3, 0.4, 13.0, 14.0, 15.0],
+        [5.0, 6.0, 0.5, 0.6, 16.0, 17.0, 18.0],
+    ]
+    assert robotics_row.states == expected_state
+    assert robotics_row.observations("state") == expected_state
+
+    frame_table = robotics_row.to_frame_table()
+    assert frame_table.table.column_names == [
+        "timestamp",
+        "action",
+        "observation.state",
+    ]
+    assert frame_table.column("observation.state").to_pylist() == expected_state
+
+    selected = robotics_row.select_frames([2, 0])
+    assert selected.states == [expected_state[2], expected_state[0]]
+    assert selected.actions == [[0.2], [0.0]]
+
+
+def test_to_robot_rows_concatenates_tuple_state_key_nested_frames() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "frames": Tabular.from_rows(
+                [
+                    DictRow(
+                        {
+                            "actions": [0.0],
+                            "obs/joint_pos": [1.0, 2.0],
+                            "obs/joint_vel": [0.1, 0.2],
+                            "eef_pos": [10.0, 11.0, 12.0],
+                        }
+                    ),
+                    DictRow(
+                        {
+                            "actions": [1.0],
+                            "obs/joint_pos": [3.0, 4.0],
+                            "obs/joint_vel": [0.3, 0.4],
+                            "eef_pos": [13.0, 14.0, 15.0],
+                        }
+                    ),
+                ]
+            ),
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        nested_frames_key="frames",
+        timestamp_key=None,
+        action_key="actions",
+        state_key=("obs/joint_pos", "obs/joint_vel", "eef_pos"),
+    )
+
+    expected_state = [
+        [1.0, 2.0, 0.1, 0.2, 10.0, 11.0, 12.0],
+        [3.0, 4.0, 0.3, 0.4, 13.0, 14.0, 15.0],
+    ]
+    assert robotics_row.states.to_pylist() == expected_state
+    assert robotics_row.observations("state").to_pylist() == expected_state
+    assert (
+        robotics_row.to_frame_table().column("observation.state").to_pylist()
+        == expected_state
+    )
+
+
+def test_to_robot_rows_maps_nested_semantic_keys() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "frames": Tabular.from_rows(
+                [
+                    DictRow({"time_s": 0.0, "actions": [0.0]}),
+                    DictRow({"time_s": 0.1, "actions": [1.0]}),
+                ]
+            ),
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        nested_frames_key="frames",
+        timestamp_key="time_s",
+        action_key="actions",
+    )
+
+    assert robotics_row.num_frames == 2
+    assert robotics_row.timestamps.to_pylist() == [0.0, 0.1]
+    assert robotics_row.to_frame_table().table.column_names == ["timestamp", "action"]
+
+
+def test_to_robot_rows_flattens_nested_frame_dicts() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "steps": [
+                {"observation": {"state": [0.0]}, "action": [0.0]},
+                {"observation": {"state": [1.0]}, "action": [1.0]},
+            ],
+        }
+    )
+
+    robotics_row = _robot_row(
+        row,
+        nested_frames_key="steps",
+        state_key="observation/state",
+        action_key="action",
+        timestamp_key=None,
+    )
+
+    assert robotics_row.num_frames == 2
+    assert robotics_row.states.to_pylist() == [[0.0], [1.0]]
+
+
+def test_to_robot_rows_splits_dataset_arrays_with_episode_ends() -> None:
+    row = DictRow(
+        {
+            "dataset_id": "pusht",
+            "meta": {"episode_ends": [2, 5]},
+            "data": {
+                "obs": [[0.0], [0.1], [1.0], [1.1], [1.2]],
+                "action": [[0.0], [0.1], [1.0], [1.1], [1.2]],
+            },
+        }
+    )
+
+    rows = list(
+        _robot_rows(
+            row,
+            episode_id_key="dataset_id",
+            episode_ends_key="meta/episode_ends",
+            timestamp_key=None,
+            state_key="data/obs",
+            action_key="data/action",
+        )
+    )
+
+    assert [row.episode_id for row in rows] == ["pusht-0", "pusht-1"]
+    assert [row.num_frames for row in rows] == [2, 3]
+    assert rows[1].actions == [[1.0], [1.1], [1.2]]
+
+
+def test_to_robot_rows_splits_video_frame_arrays_with_episode_ends() -> None:
+    frames = np.arange(5 * 2 * 2 * 3, dtype=np.uint8).reshape(5, 2, 2, 3)
+    row = DictRow(
+        {
+            "dataset_id": "pusht",
+            "episode_ends": [2, 5],
+            "actions": [[0.0], [0.1], [1.0], [1.1], [1.2]],
+            "front": frames,
+        }
+    )
+
+    rows = list(
+        _robot_rows(
+            row,
+            episode_id_key="dataset_id",
+            episode_ends_key="episode_ends",
+            timestamp_key=None,
+            action_key="actions",
+            state_key=None,
+            video_keys={"observation.images.front": "front"},
+            fps=10,
+        )
+    )
+
+    videos = [row.videos["observation.images.front"] for row in rows]
+
+    assert [
+        video.frame_count for video in videos if isinstance(video, VideoFrameArray)
+    ] == [
+        2,
+        3,
+    ]
+    assert isinstance(videos[0], VideoFrameArray)
+    assert isinstance(videos[1], VideoFrameArray)
+    np.testing.assert_array_equal(
+        np.asarray(list(videos[0].iter_frame_arrays())),
+        frames[:2],
+    )
+    np.testing.assert_array_equal(
+        np.asarray(list(videos[1].iter_frame_arrays())),
+        frames[2:],
+    )
+
+
+def test_to_robot_rows_splits_tuple_state_key_sources_with_episode_ends() -> None:
+    row = DictRow(
+        {
+            "dataset_id": "robomimic",
+            "meta": {"episode_ends": [2, 4]},
+            "actions": [[0.0], [0.1], [1.0], [1.1]],
+            "obs": {
+                "joint_pos": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+                "joint_vel": [[0.1], [0.2], [0.3], [0.4]],
+                "eef_pos": np.asarray(
+                    [[10.0, 11.0], [12.0, 13.0], [14.0, 15.0], [16.0, 17.0]],
+                    dtype=np.float32,
+                ),
+            },
+        }
+    )
+
+    rows = list(
+        _robot_rows(
+            row,
+            episode_id_key="dataset_id",
+            episode_ends_key="meta/episode_ends",
+            timestamp_key=None,
+            action_key="actions",
+            state_key=("obs/joint_pos", "obs/joint_vel", "obs/eef_pos"),
+        )
+    )
+
+    assert [row.episode_id for row in rows] == ["robomimic-0", "robomimic-1"]
+    assert [row.num_frames for row in rows] == [2, 2]
+    assert rows[0].states == [
+        [1.0, 2.0, 0.1, 10.0, 11.0],
+        [3.0, 4.0, 0.2, 12.0, 13.0],
+    ]
+    assert rows[1].states == [
+        [5.0, 6.0, 0.3, 14.0, 15.0],
+        [7.0, 8.0, 0.4, 16.0, 17.0],
+    ]
+
+
+def test_motion_trim_works_with_mapped_semantic_keys() -> None:
+    row = DictRow(
+        {
+            "episode_id": "episode-1",
+            "time_s": [0.0, 0.1, 0.2, 0.3],
+            "actions": [[0.0], [0.0], [1.0], [1.0]],
+            "qpos": [[0.0], [0.0], [0.0], [0.0]],
+        }
+    )
+    robotics_row = _robot_row(
+        row,
+        timestamp_key="time_s",
+        action_key="actions",
+        state_key="qpos",
+    )
+
+    trimmed = cast(RoboticsRow, motion_trim(threshold=0.25)(cast(Row, robotics_row)))
+
+    assert trimmed.num_frames == 2
+    assert trimmed.timestamps == pytest.approx([0.0, 0.1])
+    assert "time_s" not in trimmed.to_frame_table().table.column_names
+    assert "timestamp" in trimmed.to_frame_table().table.column_names

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 import os
 from refiner.io import DataFile
-from refiner.video import VideoFile
 from refiner.pipeline.utils.cache.file_cache import get_media_cache
 from refiner.pipeline.utils.cache.lease_cache import LeaseCache
 
 
 def test_media_cache_async_context_reuses_download() -> None:
     uri = "memory://context-manager.bin"
-    with VideoFile(DataFile.resolve(uri)).open("wb") as f:
+    with DataFile.resolve(uri).open(mode="wb") as f:
         f.write(b"context-manager")
 
     cache = get_media_cache("context-manager")
@@ -29,7 +28,7 @@ def test_media_cache_async_context_reuses_download() -> None:
 
 def test_media_cache_file_lease_can_be_acquired_and_released_twice() -> None:
     uri = "memory://lease-same-file.bin"
-    with VideoFile(DataFile.resolve(uri)).open("wb") as f:
+    with DataFile.resolve(uri).open(mode="wb") as f:
         f.write(b"lease-reuse")
 
     cache = get_media_cache("lease-same-file")

--- a/tests/test_video_decode.py
+++ b/tests/test_video_decode.py
@@ -6,6 +6,8 @@ import numpy as np
 
 import refiner as mdr
 from refiner.io import DataFile
+from refiner.io import DataFolder
+from refiner.video import VideoStreamWriter, VideoTranscodeConfig
 
 
 def _write_video(path, *, num_frames: int = 5, fps: int = 5) -> None:
@@ -29,12 +31,12 @@ def _write_video(path, *, num_frames: int = 5, fps: int = 5) -> None:
             container.mux(packet)
 
 
-async def _collect_frames(video: mdr.video.VideoFile):
+async def _collect_frames(video: mdr.video.VideoSource):
     return [frame async for frame in video.iter_frames()]
 
 
 async def _collect_windows(
-    video: mdr.video.VideoFile,
+    video: mdr.video.VideoSource,
     *,
     offsets: list[int],
     stride: int = 1,
@@ -63,6 +65,49 @@ def test_iter_frames_respects_clip_bounds(tmp_path) -> None:
 
     assert [frame.index for frame in frames] == [0, 1, 2]
     assert [frame.timestamp_s for frame in frames] == [0.2, 0.4, 0.6]
+
+
+def test_video_frame_array_clip_returns_frame_view() -> None:
+    frames = np.stack([np.full((4, 4, 3), value, dtype=np.uint8) for value in range(6)])
+    video = mdr.video.VideoFrameArray(frames, fps=10)
+
+    clipped = video.clipped(from_timestamp_s=0.2, to_timestamp_s=0.5)
+
+    assert isinstance(clipped, mdr.video.VideoFrameArray)
+    clipped_frames = list(clipped.iter_frame_arrays())
+    assert len(clipped_frames) == 3
+    assert clipped_frames[0].shape == (4, 4, 3)
+    assert [int(frame[0, 0, 0]) for frame in clipped_frames] == [2, 3, 4]
+
+
+def test_video_frame_array_iter_frames() -> None:
+    frames = np.stack([np.full((4, 4, 3), value, dtype=np.uint8) for value in range(3)])
+    video = mdr.video.VideoFrameArray(frames, fps=5)
+
+    decoded = asyncio.run(_collect_frames(video))
+
+    assert [frame.index for frame in decoded] == [0, 1, 2]
+    assert [frame.timestamp_s for frame in decoded] == [0.0, 0.2, 0.4]
+
+
+def test_video_stream_writer_accepts_video_frame_array(tmp_path) -> None:
+    video = mdr.video.VideoFrameArray(
+        np.stack([np.full((8, 8, 3), value, dtype=np.uint8) for value in range(4)]),
+        fps=10,
+    )
+    writer = VideoStreamWriter(
+        folder=DataFolder.resolve(tmp_path),
+        stream_key="camera",
+        transcode_config=VideoTranscodeConfig(),
+        video_bytes_limit=1024 * 1024,
+        output_rel_template="videos/{stream_key}/file-{file_index:03d}.mp4",
+    )
+
+    written = asyncio.run(video.write_to(writer))
+    writer.close()
+
+    assert written.segment.fps == 10
+    assert written.segment.to_timestamp == 0.4
 
 
 def test_iter_frame_windows_supports_lookahead(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add a generic RoboticsRow protocol and pipeline.to_robot_rows conversion path for episode rows and episode-end splits
- unify LeRobot and generic robotics writing around shared video source types, including file, bytes, and frame-array videos
- update motion trimming, LeRobot writer/reader behavior, and robotics/video docs around the shared row/video interfaces

## Validation
- uv run ruff check src/refiner/robotics/row.py src/refiner/pipeline/pipeline.py src/refiner/video/decode.py tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py tests/test_video_decode.py
- uv run ty check src/refiner/robotics/row.py src/refiner/pipeline/pipeline.py src/refiner/video/decode.py tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py tests/test_video_decode.py
- uv run pytest tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py tests/test_video_decode.py tests/robotics/test_motion.py tests/test_cache.py -q
- real-video LeRobot copy benchmark against hf://datasets/macrodata/aloha_static_battery_ep005_009 compared with main