### PR TITLE
Preserve generic robotics rows across vectorized ops

### DIFF
--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -178,6 +178,17 @@ class RefinerPipeline:
         stats_prefix: str = "stats/",
         episode_ends_key: str | None = None,
     ) -> "RefinerPipeline":
+        """Expose rows through the RoboticsRow semantic view.
+
+        This does not materialize semantic properties such as ``episode_id`` or
+        ``num_frames`` as physical table columns. Vectorized operations after this
+        step still address the underlying source columns, so use the original key
+        names in expressions unless you have explicitly created new columns. Row-level
+        operations and iteration can still access the semantic properties directly:
+        ``.filter(lambda row: row.episode_id == "ep-1")`` uses the view property,
+        while ``.filter(col("episode_id") == "ep-1")`` requires a physical
+        ``episode_id`` column.
+        """
         from refiner.robotics.row import _robot_row_converter
 
         converter = _robot_row_converter(

--- a/src/refiner/robotics/__init__.py
+++ b/src/refiner/robotics/__init__.py
@@ -3,6 +3,7 @@ from refiner.robotics.reward import reward_score
 from refiner.robotics.row import (
     RoboticsRow,
 )
+from refiner.robotics.tabular import RoboticsTabular
 from refiner.robotics.lerobot_format import (
     LeRobotFeatureInfo,
     LeRobotFeatureStats,
@@ -19,6 +20,7 @@ __all__ = [
     "motion_trim",
     "reward_score",
     "RoboticsRow",
+    "RoboticsTabular",
     "LeRobotRow",
     "LeRobotTabular",
     "LeRobotFeatureInfo",

--- a/src/refiner/robotics/row.py
+++ b/src/refiner/robotics/row.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace as dataclass_replace
-from typing import Any, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, runtime_checkable
 
 import pyarrow as pa
 
@@ -11,6 +11,9 @@ from refiner.pipeline.data.datatype import asset_storage, asset_type
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.data.tabular import set_or_append_column
 from refiner.video import VideoSource, video_from_storage_value
+
+if TYPE_CHECKING:
+    from refiner.robotics.tabular import RoboticsTabular
 
 
 RoboticsRowT = TypeVar("RoboticsRowT", bound="RoboticsRow")
@@ -189,6 +192,12 @@ class _RoboticsRowView(Row, RoboticsRow):
 
     def __len__(self) -> int:
         return sum(1 for _ in self)
+
+    @property
+    def tabular_type(self) -> type["RoboticsTabular"]:
+        from refiner.robotics.tabular import RoboticsTabular
+
+        return RoboticsTabular
 
     @property
     def shard_id(self) -> str | None:
@@ -425,6 +434,12 @@ class _RoboticsRowView(Row, RoboticsRow):
         **kwargs: Any,
     ) -> "_RoboticsRowView":
         return self._replace(self._row.update(patch, **kwargs))
+
+    def drop(self, *keys: str) -> "_RoboticsRowView":
+        return self._replace(self._row.drop(*keys))
+
+    def with_shard_id(self, shard_id: str) -> "_RoboticsRowView":
+        return self._replace(self._row.with_shard_id(shard_id))
 
     def _nested_frame_table(self) -> Tabular | None:
         nested_frames_key = _valid_nested_frames_key(

--- a/src/refiner/robotics/tabular.py
+++ b/src/refiner/robotics/tabular.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pyarrow as pa
+
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.data.tabular import Tabular
+from refiner.robotics.row import _RoboticsRowSpec, _RoboticsRowView
+from refiner.video import VideoSource
+
+_MISSING = object()
+_SIDE_DATA_ROW_INDEX = "__robotics_side_data_row_index"
+
+
+@dataclass(init=False, frozen=True, slots=True)
+class RoboticsTabular(Tabular):
+    _tabular: Tabular
+    spec: _RoboticsRowSpec
+    side_data: Mapping[str, tuple[Any, ...]]
+
+    def __init__(
+        self,
+        tabular: Tabular,
+        *,
+        spec: _RoboticsRowSpec,
+        side_data: Mapping[str, tuple[Any, ...]] | None = None,
+    ) -> None:
+        object.__setattr__(self, "_tabular", tabular)
+        object.__setattr__(self, "spec", spec)
+        object.__setattr__(self, "side_data", side_data or {})
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: Sequence[Row],
+        *,
+        schema: pa.Schema | None = None,
+    ) -> "RoboticsTabular | Tabular":
+        if not rows:
+            raise ValueError("RoboticsTabular.from_rows requires at least one row")
+        if not all(isinstance(row, _RoboticsRowView) for row in rows):
+            return Tabular.from_rows(rows, schema=schema)
+        robotics_rows = tuple(cast(_RoboticsRowView, row) for row in rows)
+        spec = robotics_rows[0]._spec
+        if any(row._spec != spec for row in robotics_rows):
+            return Tabular.from_rows(rows, schema=schema)
+        raw_rows = [row._row for row in robotics_rows]
+        side_data = _side_data(raw_rows)
+        row_index_key = _row_index_key(raw_rows) if side_data else None
+        table_rows = [
+            _without_side_data(row, tuple(side_data)).update({row_index_key: idx})
+            if row_index_key is not None
+            else row
+            for idx, row in enumerate(raw_rows)
+        ]
+        table = Tabular.from_rows(table_rows, schema=schema)
+        if row_index_key is not None:
+            row_order = [int(idx) for idx in table.column(row_index_key).to_pylist()]
+            table = table.with_table(table.table.drop([row_index_key]))
+            side_data = {
+                key: tuple(values[idx] for idx in row_order)
+                for key, values in side_data.items()
+            }
+        return cls(
+            table,
+            spec=spec,
+            side_data=side_data,
+        )
+
+    @property
+    def unit(self) -> pa.Table:
+        return self._tabular.unit
+
+    @property
+    def table(self) -> pa.Table:
+        return self._tabular.table
+
+    @property
+    def tabular_id(self) -> int:
+        return self._tabular.tabular_id
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return self._tabular.names
+
+    @property
+    def columns(self) -> tuple[pa.Array | pa.ChunkedArray, ...]:
+        return self._tabular.columns
+
+    @property
+    def index_by_name(self) -> dict[str, int]:
+        return self._tabular.index_by_name
+
+    @property
+    def shard_idx(self) -> int | None:
+        return self._tabular.shard_idx
+
+    @property
+    def needs_row_indices(self) -> bool:
+        return bool(self.side_data)
+
+    def with_table(
+        self,
+        table: pa.Table,
+        *,
+        row_indices: Sequence[int] | None = None,
+    ) -> "RoboticsTabular":
+        side_data = self.side_data
+        if side_data and row_indices is not None:
+            side_data = {
+                key: tuple(values[int(idx)] for idx in row_indices)
+                for key, values in side_data.items()
+            }
+        elif side_data and table.num_rows != self._tabular.num_rows:
+            raise ValueError(
+                "RoboticsTabular side data length must match table row count"
+            )
+        return RoboticsTabular(
+            self._tabular.with_table(table, row_indices=row_indices),
+            spec=self.spec,
+            side_data=side_data,
+        )
+
+    def __iter__(self) -> Iterator[Row]:
+        for idx, row in enumerate(self._tabular):
+            if self.side_data:
+                row = row.update(
+                    {
+                        key: value
+                        for key, values in self.side_data.items()
+                        if (value := values[idx]) is not _MISSING
+                    }
+                )
+            yield cast(Row, self.spec.wrap(row))
+
+    def to_rows(self) -> list[Row]:
+        return list(self)
+
+
+def _side_data(rows: Sequence[Row]) -> dict[str, tuple[Any, ...]]:
+    keys = tuple(dict.fromkeys(key for row in rows for key in row))
+    side_keys = {
+        key
+        for key in keys
+        if any(_is_side_data_value(row.get(key, _MISSING)) for row in rows)
+    }
+    return {key: tuple(row.get(key, _MISSING) for row in rows) for key in side_keys}
+
+
+def _without_side_data(row: Row, side_keys: Sequence[str]) -> Row:
+    if not side_keys:
+        return row
+    return row.drop(*side_keys)
+
+
+def _row_index_key(rows: Sequence[Row]) -> str:
+    key = _SIDE_DATA_ROW_INDEX
+    while any(key in row for row in rows):
+        key = f"_{key}"
+    return key
+
+
+def _is_side_data_value(value: Any) -> bool:
+    return value is not _MISSING and (
+        isinstance(value, Tabular) or isinstance(value, VideoSource)
+    )
+
+
+__all__ = ["RoboticsTabular"]

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -634,6 +634,65 @@ def test_write_lerobot_accepts_generic_robotics_rows(tmp_path: Path) -> None:
     ]
 
 
+def test_write_lerobot_accepts_to_robot_rows_after_vectorized_filter(
+    tmp_path: Path,
+) -> None:
+    out_root = tmp_path / "generic-filtered"
+
+    stats = (
+        mdr.from_items(
+            [
+                {
+                    "episode_id": "episode-0",
+                    "task": "drop",
+                    "keep": False,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [0.0],
+                            "observation.state": [1.0],
+                        }
+                    ],
+                },
+                {
+                    "episode_id": "episode-1",
+                    "task": "keep",
+                    "keep": True,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [1.0],
+                            "observation.state": [2.0],
+                        }
+                    ],
+                },
+            ]
+        )
+        .to_robot_rows(
+            episode_id_key="episode_id",
+            task_key="task",
+            nested_frames_key="frames",
+            fps=10,
+            robot_type="mockbot",
+        )
+        .filter(mdr.col("keep"))
+        .write_lerobot(str(out_root))
+        .launch_local(
+            name="generic-filtered-write-lerobot",
+            num_workers=1,
+            rundir=str(tmp_path / "workdir-generic-filtered"),
+        )
+    )
+
+    assert stats.failed == 0
+    rows = mdr.read_lerobot(str(out_root)).materialize()
+    assert len(rows) == 1
+    assert rows[0]["tasks"] == ["keep"]
+    assert cast(LeRobotRow, rows[0]).to_frame_table().column("action").to_pylist() == [
+        [1.0]
+    ]
+
+
 def test_lerobot_video_writer_reuses_opened_remux_source_for_same_uri(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/robotics/test_robotics_row.py
+++ b/tests/robotics/test_robotics_row.py
@@ -7,6 +7,7 @@ import pytest
 
 from refiner.pipeline import from_items
 from refiner.pipeline.data import datatype
+from refiner.pipeline.expressions import col
 from refiner.pipeline.data.row import DictRow
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular
@@ -299,6 +300,160 @@ def test_pipeline_to_robot_rows_forwards_literals_and_explicit_keys() -> None:
     assert isinstance(keyed_row, RoboticsRow)
     assert keyed_row.fps == 7.0
     assert keyed_row.robot_type == "keybot"
+
+
+def test_to_robot_rows_preserves_robotics_view_after_vectorized_filter() -> None:
+    rows = (
+        from_items(
+            [
+                {
+                    "episode_id": "episode-0",
+                    "keep": False,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [0.0],
+                            "observation.state": [1.0],
+                        }
+                    ],
+                },
+                {
+                    "episode_id": "episode-1",
+                    "keep": True,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [1.0],
+                            "observation.state": [2.0],
+                        }
+                    ],
+                },
+            ]
+        )
+        .to_robot_rows(
+            episode_id_key="episode_id",
+            nested_frames_key="frames",
+        )
+        .filter(col("keep"))
+        .materialize()
+    )
+
+    assert len(rows) == 1
+    row = cast(RoboticsRow, rows[0])
+    assert isinstance(row, RoboticsRow)
+    assert row.episode_id == "episode-1"
+    assert row.num_frames == 1
+    assert row.actions.to_pylist() == [[1.0]]
+    assert row.states.to_pylist() == [[2.0]]
+
+
+def test_to_robot_rows_preserves_nested_frame_side_data_after_mutation() -> None:
+    rows = (
+        from_items(
+            [
+                {
+                    "episode_id": "episode-1",
+                    "keep": True,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [0.0],
+                            "observation.state": [1.0],
+                        }
+                    ],
+                }
+            ]
+        )
+        .to_robot_rows(
+            episode_id_key="episode_id",
+            nested_frames_key="frames",
+        )
+        .map(lambda row: cast(RoboticsRow, row).with_actions([[2.0]]))
+        .filter(col("keep"))
+        .materialize()
+    )
+
+    assert len(rows) == 1
+    row = cast(RoboticsRow, rows[0])
+    assert isinstance(row, RoboticsRow)
+    assert row.actions.to_pylist() == [[2.0]]
+    assert row.states.to_pylist() == [[1.0]]
+
+
+def test_to_robot_rows_realigns_side_data_when_arrow_rows_are_reordered() -> None:
+    table = (
+        from_items(
+            [
+                {
+                    "episode_id": "episode-0",
+                    "rank": 1,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [0.0],
+                            "observation.state": [10.0],
+                        }
+                    ],
+                },
+                {
+                    "episode_id": "episode-1",
+                    "rank": 0,
+                    "frames": [
+                        {
+                            "timestamp": 0.0,
+                            "action": [1.0],
+                            "observation.state": [20.0],
+                        }
+                    ],
+                },
+            ]
+        )
+        .to_robot_rows(
+            episode_id_key="episode_id",
+            nested_frames_key="frames",
+        )
+        .map(lambda row: cast(RoboticsRow, row).with_actions([[row["rank"]]]))
+        .map_table(lambda table: table.sort_by([("rank", "ascending")]))
+        .materialize()
+    )
+
+    rows = [cast(RoboticsRow, row) for row in table]
+    assert [row.episode_id for row in rows] == ["episode-1", "episode-0"]
+    assert [row.actions.to_pylist() for row in rows] == [[[0]], [[1]]]
+    assert [row.states.to_pylist() for row in rows] == [[[20.0]], [[10.0]]]
+
+
+def test_to_robot_rows_falls_back_for_mixed_row_batches() -> None:
+    rows = (
+        from_items(
+            [
+                {
+                    "episode_id": "episode-1",
+                    "keep": True,
+                    "action": [[0.0]],
+                    "observation.state": [[1.0]],
+                },
+                {
+                    "episode_id": "episode-2",
+                    "keep": True,
+                    "action": [[1.0]],
+                    "observation.state": [[2.0]],
+                },
+            ]
+        )
+        .to_robot_rows(episode_id_key="episode_id")
+        .map(
+            lambda row: (
+                row
+                if cast(RoboticsRow, row).episode_id == "episode-1"
+                else DictRow({"episode_id": row["episode_id"], "keep": row["keep"]})
+            )
+        )
+        .filter(col("keep"))
+        .materialize()
+    )
+
+    assert [row["episode_id"] for row in rows] == ["episode-1", "episode-2"]
 
 
 def test_to_robot_rows_output_can_be_motion_trimmed() -> None:


### PR DESCRIPTION
## Summary

This fixes the generic RoboticsRow equivalent of the LeRobot row-lineage issue from PR #138.

Rows produced by to_robot_rows(...) were only wrapped at the row level. If a vectorized op ran afterward, such as filter/select/map_table, execution converted the batch into a plain Tabular and later yielded plain ArrowRowView rows. That stripped the RoboticsRow interface, so pipelines like this broke:

```python
(
    mdr.from_items(rows)
    .to_robot_rows(...)
    .filter(mdr.col("keep"))
    .write_lerobot(out)
)
```

This PR adds a generic RoboticsTabular wrapper so the shared robotics row spec survives vectorized execution and rows are wrapped back into RoboticsRow views when iterated.

Note: to_robot_rows creates a semantic view; it does not materialize view properties as physical table columns. Row predicates can use properties, while vectorized expressions still use real source columns:

```python
.filter(lambda row: row.episode_id == "ep-1")  # uses the RoboticsRow property
.filter(mdr.col("episode_id") == "ep-1")      # requires an episode_id column
```

## Changes

- Add RoboticsTabular in src/refiner/robotics/tabular.py, backed by raw source rows plus the shared _RoboticsRowSpec.
- Keep non-Arrow side values, such as nested frame Tabular objects, in RoboticsTabular side data instead of serializing them into Arrow.
- Realign side data through a temporary row-index column when Tabular.from_rows materializes Arrow-backed rows in a different order.
- Fall back to plain Tabular batching for mixed robotics/plain rows or diverging robotics specs.
- Make _RoboticsRowView.tabular_type return RoboticsTabular through a lazy import.
- Preserve the robotics wrapper through drop(...) and with_shard_id(...).
- Add regression coverage for materializing, mutating, reordering, and writing filtered generic robotics rows.
- Document row-property predicates vs vectorized column expressions on to_robot_rows(...).

## Validation

- uv run ruff format --check src/refiner/pipeline/pipeline.py src/refiner/robotics/__init__.py src/refiner/robotics/row.py src/refiner/robotics/tabular.py tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py
- uv run ruff check src/refiner/pipeline/pipeline.py src/refiner/robotics/__init__.py src/refiner/robotics/row.py src/refiner/robotics/tabular.py tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py
- uv run ty check src/refiner/pipeline/pipeline.py src/refiner/robotics/__init__.py src/refiner/robotics/row.py src/refiner/robotics/tabular.py tests/robotics/test_robotics_row.py tests/pipeline/test_lerobot_sink.py
- uv run pytest tests/robotics/test_robotics_row.py tests/readers/test_lerobot_reader.py tests/pipeline/test_lerobot_sink.py -q

Result: 47 passed.
