### PR TITLE
[codex] Support multiple Zarr reader inputs

### DIFF
--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -73,6 +73,11 @@ class DataFileSet:
 
         normalized_entries: list[DataFile | DataFolder | _PathSource] = []
 
+        def append_path_source(path: str, path_fs: AbstractFileSystem) -> None:
+            normalized_entries.append(
+                _PathSource(path=path_fs._strip_protocol(path), fs=path_fs)
+            )
+
         for item in inputs:
             if isinstance(item, DataFile):
                 if expect_type == "folder":
@@ -99,13 +104,11 @@ class DataFileSet:
                         "DataFileSet inputs must be str | PathLike | (path, fs) | DataFile | DataFolder"
                     )
                 if expect_type == "folder":
-                    normalized_entries.append(DataFolder(path=path, fs=item_fs))
+                    append_path_source(path, item_fs)
                 elif expect_type == "file":
                     normalized_entries.append(DataFile(path=path, fs=item_fs))
                 else:
-                    normalized_entries.append(
-                        _PathSource(path=item_fs._strip_protocol(path), fs=item_fs)
-                    )
+                    append_path_source(path, item_fs)
                 continue
 
             if isinstance(item, PathLike):
@@ -118,18 +121,18 @@ class DataFileSet:
 
             if fs is not None:
                 if expect_type == "folder":
-                    normalized_entries.append(DataFolder.resolve(item, fs=fs))
+                    append_path_source(item, fs)
                 elif expect_type == "file":
                     normalized_entries.append(DataFile.resolve(item, fs=fs))
                 else:
-                    normalized_entries.append(
-                        _PathSource(path=fs._strip_protocol(item), fs=fs)
-                    )
+                    append_path_source(item, fs)
             else:
                 if expect_type == "folder":
-                    normalized_entries.append(
-                        DataFolder.resolve(item, storage_options=storage_options)
+                    item_fs, path = url_to_fs(
+                        item,
+                        **_storage_options_for_path(item, storage_options),
                     )
+                    append_path_source(path, item_fs)
                 elif expect_type == "file":
                     normalized_entries.append(
                         DataFile.resolve(item, storage_options=storage_options)
@@ -139,7 +142,7 @@ class DataFileSet:
                         item,
                         **_storage_options_for_path(item, storage_options),
                     )
-                    normalized_entries.append(_PathSource(path=path, fs=item_fs))
+                    append_path_source(path, item_fs)
 
         return cls(
             entries=tuple(normalized_entries),
@@ -160,9 +163,58 @@ class DataFileSet:
 
     @property
     def datafolders(self) -> tuple[DataFolder, ...]:
-        if not all(isinstance(entry, DataFolder) for entry in self.entries):
+        entries = self.resolved_entries
+        if not all(isinstance(entry, DataFolder) for entry in entries):
             raise TypeError("DataFileSet entries are not all folders")
-        return cast(tuple[DataFolder, ...], self.entries)
+        return cast(tuple[DataFolder, ...], entries)
+
+    @property
+    def resolved_entries(self) -> tuple[DataFile | DataFolder, ...]:
+        entries: list[DataFile | DataFolder] = []
+        seen: set[tuple[int, str]] = set()
+
+        def append_entry(entry: DataFile | DataFolder) -> None:
+            key = (id(entry.fs), entry.path)
+            if key in seen:
+                return
+            seen.add(key)
+            entries.append(entry)
+
+        for entry in self.entries:
+            if isinstance(entry, DataFile | DataFolder):
+                append_entry(entry)
+                continue
+
+            if glob.has_magic(entry.path):
+                matched = entry.fs.glob(entry.path, detail=True)
+                for expanded_path, info in sorted(matched.items()):
+                    if not isinstance(expanded_path, str) or not isinstance(
+                        info, Mapping
+                    ):
+                        continue
+                    if info.get("type") == "directory":
+                        append_entry(DataFolder(path=expanded_path, fs=entry.fs))
+                    elif info.get("type") == "file":
+                        append_entry(DataFile(path=expanded_path, fs=entry.fs))
+                continue
+
+            try:
+                info = entry.fs.info(entry.path)
+            except FileNotFoundError:
+                raise FileNotFoundError(
+                    f"Could not resolve input: {entry.fs.unstrip_protocol(entry.path)!r}"
+                )
+            if info.get("type") == "directory":
+                append_entry(DataFolder(path=entry.path, fs=entry.fs))
+            elif info.get("type") == "file":
+                append_entry(DataFile(path=entry.path, fs=entry.fs))
+            else:
+                raise TypeError(
+                    f"Unsupported file type {info.get('type')!r} for input: "
+                    f"{entry.fs.unstrip_protocol(entry.path)!r}"
+                )
+
+        return tuple(entries)
 
     def expand_sources(self) -> tuple[tuple[DataFile, ...], ...]:
         """Expand each source entry into its concrete files, preserving source grouping."""

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -810,7 +810,7 @@ def read_hdf5(
 
 
 def read_zarr(
-    input: DataFolderLike,
+    input: DataFileSetLike,
     *,
     arrays: PathSelection | None = None,
     attrs: PathSelection | None = None,
@@ -835,6 +835,9 @@ def read_zarr(
     `split_leading_axis` are mutually exclusive. `target_shard_bytes` and
     `num_shards` affect shard planning, not logical row size. `row_batch_size`
     bounds how many logical rows are loaded per array block within each shard.
+
+    Args:
+        input: Zarr group path, glob, or sequence of Zarr group paths.
     """
     return RefinerPipeline(
         source=ZarrReader(

--- a/src/refiner/pipeline/sources/readers/zarr.py
+++ b/src/refiner/pipeline/sources/readers/zarr.py
@@ -4,15 +4,14 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from math import ceil, prod
 from operator import index as integer_index
-from os import PathLike
 from typing import Any
 
-from fsspec import AbstractFileSystem
 from fsspec.implementations.zip import ZipFileSystem
 import pyarrow as pa
 
-from refiner.io.datafile import DataFile, DataFileLike
-from refiner.io.datafolder import DataFolder, DataFolderLike
+from refiner.io.datafile import DataFile
+from refiner.io.datafolder import DataFolder
+from refiner.io.fileset import DataFileSet, DataFileSetLike
 from refiner.pipeline.data.datatype import (
     DTypeMapping,
     dtype_to_plan,
@@ -37,7 +36,7 @@ class ZarrReader(BaseSource):
 
     def __init__(
         self,
-        input: DataFolderLike,
+        input: DataFileSetLike,
         *,
         arrays: PathSelection | None = None,
         attrs: PathSelection | None = None,
@@ -54,7 +53,7 @@ class ZarrReader(BaseSource):
         """Create a Zarr reader.
 
         Args:
-            input: Zarr group path.
+            input: Zarr group path, glob, or sequence of Zarr group paths.
             arrays: Array selections as output-name to Zarr-path mapping, a
                 single path, a path sequence, or None to discover all arrays.
             attrs: Attribute selections with the same shape as ``arrays``.
@@ -76,33 +75,21 @@ class ZarrReader(BaseSource):
                 or None to omit it.
             dtypes: Optional dtype overrides for output columns.
         """
-        zip_input: DataFileLike | None = None
-        if isinstance(input, DataFolder) and input.path.endswith(".zip"):
-            zip_input = (input.path, input.fs)
-        else:
-            if isinstance(input, PathLike):
-                input = str(input)
-            if isinstance(input, str) and input.endswith(".zip"):
-                zip_input = input
-            elif (
-                isinstance(input, tuple)
-                and len(input) == 2
-                and isinstance(input[1], AbstractFileSystem)
-            ):
-                path = input[0]
-                if isinstance(path, PathLike):
-                    path = str(path)
-                if isinstance(path, str) and path.endswith(".zip"):
-                    zip_input = (path, input[1])
-
-        if zip_input is not None:
-            self.zip_file = DataFile.resolve(zip_input)
-            self.root = None
-            self.source_path = self.zip_file.abs_path()
-        else:
-            self.zip_file = None
-            self.root = DataFolder.resolve(input)
-            self.source_path = self.root.abs_path()
+        resolved_inputs: list[tuple[DataFolder | DataFile, str]] = []
+        for entry in DataFileSet.resolve(input).resolved_entries:
+            if isinstance(entry, DataFile):
+                if not entry.path.endswith(".zip"):
+                    raise TypeError("read_zarr file inputs must be .zip Zarr stores")
+                resolved_inputs.append((entry, entry.abs_path()))
+                continue
+            if entry.path.endswith(".zip"):
+                zip_file = DataFile(fs=entry.fs, path=entry.path)
+                resolved_inputs.append((zip_file, zip_file.abs_path()))
+            else:
+                resolved_inputs.append((entry, entry.abs_path()))
+        if not resolved_inputs:
+            raise ValueError("read_zarr requires at least one input")
+        self.inputs = resolved_inputs
         check_required_dependencies("read_zarr", ["zarr"], dist="zarr")
         if row_ends is not None and split_leading_axis:
             raise ValueError("row_ends and split_leading_axis are mutually exclusive")
@@ -157,7 +144,11 @@ class ZarrReader(BaseSource):
 
     def describe(self) -> dict[str, Any]:
         return {
-            "path": self.source_path,
+            "path": (
+                self.inputs[0][1]
+                if len(self.inputs) == 1
+                else [source_path for _input, source_path in self.inputs]
+            ),
             "arrays": dict(self.arrays) if self.arrays is not None else None,
             "attrs": dict(self.attrs) if self.attrs is not None else None,
             "row_ends": self.row_ends,
@@ -176,22 +167,32 @@ class ZarrReader(BaseSource):
         }
 
     def list_shards(self) -> list[Shard]:
-        with self._open_group() as group:
-            arrays = self._selected_arrays(group)
-            split_ranges = self._shard_ranges(group, arrays)
-            return [
-                Shard.from_row_range(
-                    start=start,
-                    end=end,
-                    global_ordinal=index,
-                    start_key=self.source_path,
-                    end_key=self.source_path,
+        shards: list[Shard] = []
+        for source_index, (input, _source_path) in enumerate(self.inputs):
+            with self._open_group(input) as group:
+                arrays = self._selected_arrays(group)
+                split_ranges = self._shard_ranges(group, arrays)
+            source_key = str(source_index)
+            for start, end in split_ranges:
+                shards.append(
+                    Shard.from_row_range(
+                        start=start,
+                        end=end,
+                        global_ordinal=len(shards),
+                        start_key=source_key,
+                        end_key=source_key,
+                    )
                 )
-                for index, (start, end) in enumerate(split_ranges)
-            ]
+        return shards
 
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
-        with self._open_group() as group:
+        try:
+            input, source_path = self.inputs[int(str(shard.start_key))]
+        except (ValueError, IndexError):
+            raise ValueError(
+                f"Zarr shard does not match an input: {shard.start_key!r}"
+            ) from None
+        with self._open_group(input) as group:
             arrays = self._selected_arrays(group)
             if self.row_ends is not None:
                 descriptor = shard.descriptor
@@ -212,7 +213,10 @@ class ZarrReader(BaseSource):
                     block_end = batch[-1][1]
                     block = self._read_arrays(arrays, start=block_start, end=block_end)
                     for offset, (start, end) in enumerate(batch, start=batch_offset):
-                        row = self._row_metadata(index=descriptor.start + offset)
+                        row = self._row_metadata(
+                            source_path,
+                            index=descriptor.start + offset,
+                        )
                         row.update(
                             {
                                 name: value[start - block_start : end - block_start]
@@ -239,7 +243,7 @@ class ZarrReader(BaseSource):
                     )
                     for row_index in range(batch_start, batch_end):
                         offset = (row_index - batch_start) * self.leading_axis_row_size
-                        row = self._row_metadata(index=row_index)
+                        row = self._row_metadata(source_path, index=row_index)
                         row.update(
                             {
                                 name: value[
@@ -252,23 +256,23 @@ class ZarrReader(BaseSource):
                         yield DictRow(row)
                 return
 
-            row = self._row_metadata(index=None)
+            row = self._row_metadata(source_path, index=None)
             row.update(self._read_arrays(arrays))
             row.update(self._read_attrs(group))
             yield DictRow(row)
 
     @contextmanager
-    def _open_group(self) -> Any:
+    def _open_group(self, input: DataFolder | DataFile) -> Any:
         import zarr
         import zarr.storage
 
-        if self.zip_file is not None:
+        if isinstance(input, DataFile):
             handle = None
             zip_fs = None
-            if self.zip_file.is_local:
-                store = zarr.ZipStore(self.zip_file.abs_path(), mode="r")
+            if input.is_local:
+                store = zarr.ZipStore(input.abs_path(), mode="r")
             else:
-                handle = self.zip_file.open("rb", cache_type="none")
+                handle = input.open("rb", cache_type="none")
                 zip_fs = ZipFileSystem(fo=handle, mode="r")
                 store = zarr.storage.FSStore(
                     "/",
@@ -286,8 +290,7 @@ class ZarrReader(BaseSource):
                 if handle is not None:
                     handle.close()
         else:
-            assert self.root is not None
-            store = zarr.storage.FSStore(self.root._join(""), fs=self.root.fs, mode="r")
+            store = zarr.storage.FSStore(input._join(""), fs=input.fs, mode="r")
             yield zarr.open_group(store=store, mode="r")
 
     def _reserved_output_names(self, *, split: bool) -> set[str]:
@@ -298,10 +301,10 @@ class ZarrReader(BaseSource):
             names.add(self.index_column)
         return names
 
-    def _row_metadata(self, *, index: int | None) -> dict[str, Any]:
+    def _row_metadata(self, source_path: str, *, index: int | None) -> dict[str, Any]:
         row: dict[str, Any] = {}
         if self.file_path_column is not None:
-            row[self.file_path_column] = self.source_path
+            row[self.file_path_column] = source_path
         if self.index_column is not None and index is not None:
             row[self.index_column] = index
         return row

--- a/tests/io/test_datafile_datafolder.py
+++ b/tests/io/test_datafile_datafolder.py
@@ -257,6 +257,22 @@ def test_datafileset_resolve_does_not_list_folders_eagerly():
     assert fs.ls_calls == 1
 
 
+def test_datafileset_expands_folder_globs(tmp_path):
+    first = tmp_path / "first.zarr"
+    second = tmp_path / "second.zarr"
+    ignored = tmp_path / "ignored.txt"
+    first.mkdir()
+    second.mkdir()
+    ignored.write_text("nope")
+
+    folders = DataFileSet.resolve(
+        str(tmp_path / "*.zarr"),
+        expect_type="folder",
+    ).datafolders
+
+    assert [folder.abs_path() for folder in folders] == [str(first), str(second)]
+
+
 def test_datafolder_find_filters_prefix_leaks():
     fs = _PrefixLeakingMemoryFS()
     fs.pipe("find-root/file.txt", b"ok")

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -81,6 +81,62 @@ def test_read_zarr_reads_selected_arrays_and_attrs(tmp_path: Path) -> None:
     np.testing.assert_allclose(row["action"][:2], [[0.0], [0.1]])
 
 
+def test_read_zarr_reads_multiple_inputs(tmp_path: Path) -> None:
+    first = tmp_path / "first.zarr"
+    second = tmp_path / "second.zarr"
+    first_root = _open_test_zarr(first, mode="w")
+    second_root = _open_test_zarr(second, mode="w")
+    _create_array(
+        first_root,
+        "data/action",
+        data=np.asarray([[1.0]], dtype=np.float32),
+    )
+    _create_array(
+        second_root,
+        "data/action",
+        data=np.asarray([[2.0]], dtype=np.float32),
+    )
+
+    rows = mdr.read_zarr(
+        [first, second],
+        arrays={"action": "data/action"},
+        file_path_column=None,
+    ).take(2)
+
+    assert [row["action"].item() for row in rows] == [1.0, 2.0]
+
+    shards = mdr.read_zarr(
+        [first, second],
+        arrays={"action": "data/action"},
+        file_path_column=None,
+    ).source.list_shards()
+    assert [(shard.start_key, shard.end_key) for shard in shards] == [
+        ("0", "0"),
+        ("1", "1"),
+    ]
+
+
+def test_read_zarr_reads_folder_glob(tmp_path: Path) -> None:
+    first = tmp_path / "first.zarr"
+    second = tmp_path / "second.zarr"
+    first_root = _open_test_zarr(first, mode="w")
+    second_root = _open_test_zarr(second, mode="w")
+    _create_array(first_root, "data/action", data=np.asarray([[1.0]], dtype=np.float32))
+    _create_array(
+        second_root,
+        "data/action",
+        data=np.asarray([[2.0]], dtype=np.float32),
+    )
+
+    rows = mdr.read_zarr(
+        str(tmp_path / "*.zarr"),
+        arrays={"action": "data/action"},
+        file_path_column=None,
+    ).take(2)
+
+    assert [row["action"].item() for row in rows] == [1.0, 2.0]
+
+
 def test_read_zarr_reads_scalar_arrays(tmp_path: Path) -> None:
     path = tmp_path / "scalar.zarr"
     root = _open_test_zarr(path, mode="w")


### PR DESCRIPTION
## Summary
- allow read_zarr to accept a sequence of Zarr group inputs
- preserve existing single-input behavior
- add coverage for reading multiple local Zarr stores in order

## Validation
- uv run ruff check src/refiner/pipeline/sources/readers/zarr.py src/refiner/pipeline/pipeline.py tests/readers/test_zarr_reader.py
- uv run ty check src/refiner/pipeline/sources/readers/zarr.py src/refiner/pipeline/pipeline.py tests/readers/test_zarr_reader.py
- uv run pytest tests/readers/test_zarr_reader.py -q