### PR TITLE
[codex] Order sharded Zarr store outputs

### DIFF
--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -438,7 +438,7 @@ class RefinerPipeline:
         arrays: Mapping[str, str] | None = None,
         attrs: Mapping[str, str] | None = None,
         episode_ends_path: str | None = "meta/episode_ends",
-        store_template: str = "{shard_id}__w{worker_id}.zarr",
+        store_template: str = "{global_ordinal}__{shard_id}__w{worker_id}.zarr",
         video_frame_batch_size: int = 8,
         array_chunk_bytes: int = 8 * 1024 * 1024,
         reduce_to_single_store: bool = True,
@@ -455,7 +455,8 @@ class RefinerPipeline:
             episode_ends_path: Output Zarr path for cumulative row/episode end
                 offsets. Set to None to omit episode boundaries.
             store_template: Per-shard store path template. Must include
-                ``{shard_id}`` and ``{worker_id}``.
+                ``{shard_id}`` and ``{worker_id}``. ``{global_ordinal}``
+                expands to a zero-padded shard ordinal when available.
             video_frame_batch_size: Maximum decoded video frames to append per
                 video write batch.
             array_chunk_bytes: Target byte size for chunks created for newly

--- a/src/refiner/pipeline/sinks/reducer/zarr.py
+++ b/src/refiner/pipeline/sinks/reducer/zarr.py
@@ -207,6 +207,7 @@ class ZarrReducerSink(FileCleanupReducerSink):
                 self.store_template,
                 shard_id=row.shard_id,
                 worker_id=row.worker_token,
+                global_ordinal=row.global_ordinal,
             )
             for row in sort_finalized_workers(
                 get_finalized_workers(stage_index=stage_index - 1)

--- a/src/refiner/pipeline/sinks/zarr.py
+++ b/src/refiner/pipeline/sinks/zarr.py
@@ -16,7 +16,10 @@ from refiner.pipeline.sinks.base import BaseSink
 from refiner.robotics.row import RoboticsRow
 from refiner.utils import check_required_dependencies
 from refiner.video import VideoSource
-from refiner.worker.context import get_active_worker_token
+from refiner.worker.context import (
+    get_active_shard_global_ordinal,
+    get_active_worker_token,
+)
 
 _DEFAULT_ARRAY_CHUNK_BYTES = 8 * 1024 * 1024
 _MAX_INITIAL_CHUNK_ROWS = 1024
@@ -37,7 +40,7 @@ class ZarrSink(BaseSink):
         arrays: Mapping[str, str] | None = None,
         attrs: Mapping[str, str] | None = None,
         episode_ends_path: str | None = "meta/episode_ends",
-        store_template: str = "{shard_id}__w{worker_id}.zarr",
+        store_template: str = "{global_ordinal}__{shard_id}__w{worker_id}.zarr",
         video_frame_batch_size: int = 8,
         array_chunk_bytes: int = _DEFAULT_ARRAY_CHUNK_BYTES,
         reduce_to_single_store: bool = True,
@@ -324,6 +327,7 @@ class ZarrSink(BaseSink):
             self.store_template,
             shard_id=shard_id,
             worker_id=get_active_worker_token(),
+            global_ordinal=get_active_shard_global_ordinal(shard_id),
         )
         return f"_parts/{relpath}" if self.reduce_to_single_store else relpath
 
@@ -451,11 +455,13 @@ def _validate_store_template(store_template: str) -> None:
             continue
         if conversion is not None or format_spec:
             raise ValueError(
-                "store_template only supports plain {shard_id} and {worker_id} fields"
+                "store_template only supports plain {global_ordinal}, {shard_id}, "
+                "and {worker_id} fields"
             )
-        if field_name not in {"shard_id", "worker_id"}:
+        if field_name not in {"global_ordinal", "shard_id", "worker_id"}:
             raise ValueError(
-                "store_template only supports plain {shard_id} and {worker_id} fields"
+                "store_template only supports plain {global_ordinal}, {shard_id}, "
+                "and {worker_id} fields"
             )
         fields.add(field_name)
     missing_fields = {"shard_id", "worker_id"}.difference(fields)
@@ -471,8 +477,15 @@ def _render_store_relpath(
     *,
     shard_id: str,
     worker_id: str,
+    global_ordinal: int | None = None,
 ) -> str:
-    relpath = store_template.format(shard_id=shard_id, worker_id=worker_id)
+    relpath = store_template.format(
+        global_ordinal=(
+            f"{global_ordinal:012d}" if global_ordinal is not None else "unknown"
+        ),
+        shard_id=shard_id,
+        worker_id=worker_id,
+    )
     _normalize_public_zarr_path(relpath, "rendered store path")
     return relpath
 

--- a/src/refiner/worker/context.py
+++ b/src/refiner/worker/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import TYPE_CHECKING, Any, Generator
@@ -9,6 +10,7 @@ from loguru import logger as _base_logger
 from refiner.worker.metrics.emitter import NOOP_USER_METRICS_EMITTER, UserMetricsEmitter
 
 if TYPE_CHECKING:
+    from refiner.pipeline.data.shard import Shard
     from refiner.services.manager import ServiceManager
     from refiner.worker.lifecycle import FinalizedShardWorker, RuntimeLifecycle
 
@@ -41,6 +43,10 @@ _ACTIVE_WORKER_NAME: ContextVar[str | None] = ContextVar(
 )
 _ACTIVE_RUNTIME_LIFECYCLE: ContextVar[RuntimeLifecycle | None] = ContextVar(
     "refiner_active_runtime_lifecycle",
+    default=None,
+)
+_ACTIVE_SHARDS: ContextVar[Mapping[str, "Shard"] | None] = ContextVar(
+    "refiner_active_shards",
     default=None,
 )
 _ACTIVE_SERVICE_MANAGER: ContextVar["ServiceManager" | None] = ContextVar(
@@ -85,6 +91,14 @@ def get_active_worker_token() -> str:
     return worker_token_for(get_active_worker_id())
 
 
+def get_active_shard_global_ordinal(shard_id: str) -> int | None:
+    shards = _ACTIVE_SHARDS.get()
+    if shards is None:
+        return None
+    shard = shards.get(shard_id)
+    return None if shard is None else shard.global_ordinal
+
+
 def get_finalized_workers(
     *, stage_index: int | None = None
 ) -> list["FinalizedShardWorker"]:
@@ -114,6 +128,7 @@ def set_active_run_context(
     worker_id: str,
     worker_name: str | None,
     runtime_lifecycle: RuntimeLifecycle,
+    active_shards: Mapping[str, "Shard"] | None = None,
     service_manager: ServiceManager | None = None,
     user_metrics_emitter: UserMetricsEmitter = NOOP_USER_METRICS_EMITTER,
 ) -> Generator[None, None, None]:
@@ -123,6 +138,9 @@ def set_active_run_context(
     worker_name_token: Token[str | None] = _ACTIVE_WORKER_NAME.set(worker_name)
     lifecycle_token: Token[RuntimeLifecycle | None] = _ACTIVE_RUNTIME_LIFECYCLE.set(
         runtime_lifecycle
+    )
+    shards_token: Token[Mapping[str, "Shard"] | None] = _ACTIVE_SHARDS.set(
+        active_shards
     )
     service_manager_token: Token[ServiceManager | None] = _ACTIVE_SERVICE_MANAGER.set(
         service_manager
@@ -144,6 +162,7 @@ def set_active_run_context(
         _ACTIVE_SERVICE_MANAGER.reset(service_manager_token)
         _ACTIVE_USER_METRICS_EMITTER.reset(metrics_emitter_token)
         _ACTIVE_LOGGER.reset(logger_token)
+        _ACTIVE_SHARDS.reset(shards_token)
         _ACTIVE_RUNTIME_LIFECYCLE.reset(lifecycle_token)
         _ACTIVE_WORKER_NAME.reset(worker_name_token)
         _ACTIVE_WORKER_ID.reset(worker_id_token)
@@ -163,6 +182,7 @@ def set_active_step_index(step_index: int | None) -> Generator[None, None, None]
 __all__ = [
     "get_active_job_id",
     "get_active_service_manager",
+    "get_active_shard_global_ordinal",
     "get_active_stage_index",
     "get_active_step_index",
     "get_active_user_metrics_emitter",

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -243,6 +243,7 @@ class Worker:
             worker_id=self.worker_id,
             worker_name=self.worker_name,
             runtime_lifecycle=self.runtime_lifecycle,
+            active_shards=inflight_by_id,
             service_manager=service_manager,
             user_metrics_emitter=self.user_metrics_emitter,
         ):

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -929,6 +929,7 @@ def test_write_zarr_rejects_rendered_path_traversal(tmp_path: Path) -> None:
             ZarrSink(
                 str(tmp_path / "rendered-escape.zarr"),
                 arrays={"data/action": "action"},
+                store_template="{shard_id}__w{worker_id}.zarr",
             ).write_block([DictRow({"action": [[1.0]]}, shard_id="../escape")])
 
 
@@ -1153,6 +1154,7 @@ def test_write_zarr_empty_shard_completion_replaces_stale_store(
         ZarrSink(
             str(zarr_out),
             arrays={"data/action": "action"},
+            store_template="{shard_id}__w{worker_id}.zarr",
             reduce_to_single_store=False,
         ).on_shard_complete("shard-a")
 
@@ -1215,6 +1217,7 @@ def test_write_zarr_rejects_sharded_schema_drift_after_cleanup(
     reducer = ZarrSink(
         str(zarr_out),
         arrays={"data/action": "action"},
+        store_template="{shard_id}__w{worker_id}.zarr",
         reduce_to_single_store=False,
     ).build_reducer()
     assert reducer is not None


### PR DESCRIPTION
## Summary

Make non-reduced Zarr writer outputs sort by shard order when read through a glob.

The writer now exposes the active shard global ordinal to sinks and includes a zero-padded `{global_ordinal}` prefix in the default Zarr `store_template`. Reducers pass the same ordinal through when resolving finalized store paths, so single-store reduction still finds the same shard outputs.

## Why

A combined read/write/read test showed that non-reduced Zarr outputs could be read with a `*.zarr` glob, but glob order followed hash-like shard IDs. That returned episodes out of original shard order.

## Validation

- `uv run ruff check src/refiner/worker/context.py src/refiner/worker/runner.py src/refiner/pipeline/sinks/zarr.py src/refiner/pipeline/sinks/reducer/zarr.py src/refiner/pipeline/pipeline.py tests/readers/test_zarr_reader.py`
- `uv run ty check src/refiner/worker/context.py src/refiner/worker/runner.py src/refiner/pipeline/sinks/zarr.py src/refiner/pipeline/sinks/reducer/zarr.py src/refiner/pipeline/pipeline.py tests/readers/test_zarr_reader.py`
- `uv run pytest tests/readers/test_zarr_reader.py -q`
- Manual combined-branch roundtrip: read one Zarr dataset with `row_ends`, write `reduce_to_single_store=False`, then read `out/*.zarr`; output stores sorted as `000000000000__...`, `000000000001__...` and rows came back in `[2, 3]` episode order.
