### PR TITLE
[codex] Treat HF 403 assets as missing under asset policy

### DIFF
--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -304,6 +304,12 @@ class AssetUploadManager:
             missing = isinstance(e, FileNotFoundError) or any(
                 text in message for text in ("404", "entry not found", "no such file")
             )
+            if (
+                not missing
+                and value.startswith("https://huggingface.co/datasets/")
+                and any(text in message for text in ("403", "forbidden"))
+            ):
+                missing = True
             if self.missing_asset_policy == "error" or not missing:
                 raise
             log_throughput("asset_uploads_failed", 1, shard_id, unit="assets")

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -298,6 +298,48 @@ def test_parquet_sink_can_drop_rows_with_missing_assets(tmp_path) -> None:
     assert out.column("label").to_pylist() == ["keep"]
 
 
+def test_parquet_sink_can_drop_rows_with_hf_forbidden_assets(
+    tmp_path, monkeypatch
+) -> None:
+    class ForbiddenFile:
+        def copy(self, _dest: object) -> None:
+            raise RuntimeError("403, message='Forbidden'")
+
+    monkeypatch.setattr(
+        "refiner.pipeline.sinks.assets.DataFile.resolve",
+        lambda _value: ForbiddenFile(),
+    )
+    output_dir = tmp_path / "parquet-drop-hf-forbidden-assets"
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    table = datatype.apply_dtypes_to_table(
+        pa.table(
+            {
+                "image": [
+                    "https://huggingface.co/datasets/org/repo/resolve/main/frame.png"
+                ],
+                "label": ["drop"],
+            }
+        ),
+        {"image": datatype.image_path()},
+    )
+    sink = ParquetSink(output_dir, upload_assets=True, missing_asset_policy="drop_row")
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        sink.write_shard_block(shard_id, Tabular(table))
+        sink.on_shard_complete(shard_id)
+
+    worker = worker_token_for(worker_id)
+    written = output_dir / f"{shard_id}__w{worker}.parquet"
+    assert pq.read_table(written).num_rows == 0
+
+
 def test_parquet_sink_can_set_missing_list_assets_to_null(tmp_path) -> None:
     source = tmp_path / "source.png"
     missing = tmp_path / "missing.png"


### PR DESCRIPTION
## Summary

Treat Hugging Face dataset asset `403 Forbidden` copy failures as missing assets when a non-error asset policy is configured.

## Why

Some HF dataset media URLs fail as `403 Forbidden` during asset upload. For dataset asset URLs, this should behave like a missing asset under `missing_asset_policy="drop_row"` or `"set_null"` instead of aborting the whole sink write.

## Validation

- `uv run ruff check src/refiner/pipeline/sinks/assets.py tests/pipeline/test_sinks.py`
- `uv run ty check src/refiner/pipeline/sinks/assets.py tests/pipeline/test_sinks.py`
- `uv run pytest tests/pipeline/test_sinks.py -q`
