### PR TITLE
[codex] Resolve absolute LeRobot video URIs directly

### DIFF
--- a/src/refiner/robotics/lerobot_format/row.py
+++ b/src/refiner/robotics/lerobot_format/row.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 
-from refiner.io import DataFolder
+from refiner.io import DataFile, DataFolder
 from refiner.video import VideoFile, VideoSource
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
@@ -224,14 +224,19 @@ class LeRobotRow(Row, RoboticsRow):
         uri = self._row.get(f"videos/{key}/uri")
         if uri is None:
             uri = self._build_default_video_uri(key)
+        uri = str(uri)
         to_timestamp = self._row.get(f"videos/{key}/to_timestamp")
         if to_timestamp is None:
             raise KeyError(key)
         from_timestamp = self._row.get(f"videos/{key}/from_timestamp")
-        if self.root is None:
+        if "://" in uri or uri.startswith("/"):
+            data_file = DataFile.resolve(uri)
+        elif self.root is not None:
+            data_file = self.root.file(uri)
+        else:
             raise KeyError(key)
         return VideoFile(
-            data_file=self.root.file(str(uri)),
+            data_file=data_file,
             from_timestamp_s=float(from_timestamp)
             if from_timestamp is not None
             else 0.0,

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -10,12 +10,17 @@ import pytest
 from typing import cast
 
 import refiner as mdr
+from refiner.io import DataFolder
+from refiner.pipeline.data.row import DictRow
 from refiner.video import VideoFile
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.robotics.lerobot_format import (
+    LeRobotInfo,
     LeRobotMetadata,
     LeRobotRow,
+    LeRobotStatsFile,
+    LeRobotTasks,
     remap_task_index_table,
 )
 
@@ -179,6 +184,35 @@ def test_lerobot_reader_emits_episode_rows(tmp_path: Path) -> None:
     assert video.uri.endswith("/videos/observation.images.main/chunk-000/file-000.mp4")
     assert video.from_timestamp_s == 0.0
     assert video.to_timestamp_s == 1.0
+
+
+def test_lerobot_row_uses_absolute_video_uri_directly() -> None:
+    uri = "hf://datasets/org/repo/videos/chunk-000/file-000.mp4"
+    row = LeRobotRow(
+        DictRow(
+            {
+                "episode_index": 0,
+                "length": 1,
+                "videos/observation.images.main/uri": uri,
+                "videos/observation.images.main/from_timestamp": 0.0,
+                "videos/observation.images.main/to_timestamp": 1.0,
+            }
+        ),
+        metadata=LeRobotMetadata(
+            info=LeRobotInfo(fps=10),
+            stats=LeRobotStatsFile({}),
+            tasks=LeRobotTasks({0: "pick"}),
+        ),
+        frames=[],
+        root=DataFolder.resolve("hf://datasets/org/repo"),
+    )
+
+    video = row.videos["observation.images.main"]
+
+    assert isinstance(video, VideoFile)
+    assert video.uri == uri
+
+    assert row.update(root=None).videos["observation.images.main"].uri == uri
 
 
 def test_lerobot_reader_exposes_episode_shard_planning_knobs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Resolve absolute LeRobot video URIs directly instead of joining them under the dataset root.

## Why

Rows can store `videos/<key>/uri` as an absolute URI, for example after `with_video(...)` stores a `VideoFile.uri`. The old path always called `root.file(uri)`, so an `hf://datasets/...` URI was treated as root-relative and became a bad nested path like `hf://datasets/org/repo/hf://datasets/org/repo/...`.

## Validation

- `uv run ruff check src/refiner/robotics/lerobot_format/row.py tests/robotics/test_motion.py`
- `uv run ty check src/refiner/robotics/lerobot_format/row.py tests/robotics/test_motion.py`
- `uv run pytest tests/robotics/test_motion.py -q`
- `uv run pytest tests/readers/test_lerobot_reader.py tests/robotics/test_motion.py -q`
