### PR TITLE
[codex] default lerobot gop to two

### DIFF
--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -66,6 +66,8 @@ from refiner.pipeline.sources.readers.utils import (
 )
 import pyarrow as pa
 
+_DEFAULT_LEROBOT_ENCODER_OPTIONS: Mapping[str, str] = {"g": "2"}
+
 if TYPE_CHECKING:
     from refiner.launchers.cloud import CloudLaunchResult
     from refiner.launchers.local import LaunchStats
@@ -570,7 +572,7 @@ class RefinerPipeline:
         codec: str = "mpeg4",
         pix_fmt: str = "yuv420p",
         transencoding_threads: int | None = None,
-        encoder_options: Mapping[str, str] | None = None,
+        encoder_options: Mapping[str, str] | None = _DEFAULT_LEROBOT_ENCODER_OPTIONS,
         quantile_bins: int = 5000,
         force_recompute_video_stats: bool = False,
     ) -> "RefinerPipeline":

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -220,6 +220,42 @@ def _reset_opened_source_cache() -> Iterator[None]:
     reset_opened_video_source_cache()
 
 
+def test_lerobot_sink_defaults_encoder_options_to_none(tmp_path: Path) -> None:
+    writer = LeRobotWriterSink(str(tmp_path / "out"))
+
+    assert writer.video_transcode_config.encoder_options is None
+
+
+def test_write_lerobot_defaults_gop_to_two(tmp_path: Path) -> None:
+    pipeline = mdr.from_items([]).write_lerobot(str(tmp_path / "out"))
+    writer = cast(LeRobotWriterSink, pipeline.sink)
+
+    assert writer.video_transcode_config.encoder_options == {"g": "2"}
+
+
+def test_write_lerobot_allows_gop_override(tmp_path: Path) -> None:
+    pipeline = mdr.from_items([]).write_lerobot(
+        str(tmp_path / "out"),
+        encoder_options={"g": "12", "preset": "veryfast"},
+    )
+    writer = cast(LeRobotWriterSink, pipeline.sink)
+
+    assert writer.video_transcode_config.encoder_options == {
+        "g": "12",
+        "preset": "veryfast",
+    }
+
+
+def test_write_lerobot_allows_encoder_options_opt_out(tmp_path: Path) -> None:
+    pipeline = mdr.from_items([]).write_lerobot(
+        str(tmp_path / "out"),
+        encoder_options=None,
+    )
+    writer = cast(LeRobotWriterSink, pipeline.sink)
+
+    assert writer.video_transcode_config.encoder_options is None
+
+
 def _write_video(path: Path, *, fps: int = 10, frames: int = 6) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with av.open(str(path), mode="w") as container:


### PR DESCRIPTION
## Summary

- Default `write_lerobot(...)` encoder options to `{"g": "2"}` at the public pipeline API boundary.
- Keep lower-level writer/sink defaults as `None` and pass encoder options through unchanged.
- Allow callers to opt out by passing `encoder_options=None`, or override GOP with their own encoder options mapping.

## Validation

- `uv run pytest tests/pipeline/test_lerobot_sink.py tests/test_video_decode.py`
- `uv run ruff check --force-exclude src/refiner/pipeline/pipeline.py tests/pipeline/test_lerobot_sink.py`
- `uv run ty check`