### PR TITLE
[codex] restrict vllm config to throughput

### DIFF
--- a/docs/inference/providers-and-vllm.md
+++ b/docs/inference/providers-and-vllm.md
@@ -53,9 +53,6 @@ When used with cloud launch, VLLM providers can be represented as runtime
 services so workers call a model server instead of loading the model directly
 inside every worker.
 
-Refiner Cloud currently supports only `config="throughput"` for VLLM runtime
-services.
-
 ## Provider Options
 
 Provider-specific options are passed through `providerOptions`:

--- a/docs/inference/providers-and-vllm.md
+++ b/docs/inference/providers-and-vllm.md
@@ -45,12 +45,16 @@ provider = mdr.inference.AnthropicEndpointProvider(
 ```python
 provider = mdr.inference.VLLMProvider(
     model="Qwen/Qwen2.5-VL-7B-Instruct",
+    config="throughput",
 )
 ```
 
 When used with cloud launch, VLLM providers can be represented as runtime
 services so workers call a model server instead of loading the model directly
 inside every worker.
+
+Refiner Cloud currently supports only `config="throughput"` for VLLM runtime
+services.
 
 ## Provider Options
 

--- a/docs/running-pipelines/resources-gpus-and-services.md
+++ b/docs/running-pipelines/resources-gpus-and-services.md
@@ -44,6 +44,7 @@ instead of loading a model inside every transform worker.
 ```python
 provider = mdr.inference.VLLMProvider(
     model="Qwen/Qwen2.5-VL-7B-Instruct",
+    config="throughput",
 )
 ```
 

--- a/src/refiner/inference/providers/base.py
+++ b/src/refiner/inference/providers/base.py
@@ -103,13 +103,13 @@ class AnthropicEndpointProvider:
 @dataclass(frozen=True, slots=True)
 class VLLMProvider:
     model: str
-    config: Literal["correctness", "throughput"] = "correctness"
+    config: Literal["throughput"] = "throughput"
 
     def __post_init__(self) -> None:
         if not self.model.strip():
             raise ValueError("model_name_or_path must be non-empty")
-        if self.config not in {"correctness", "throughput"}:
-            raise ValueError("config must be 'correctness' or 'throughput'")
+        if self.config != "throughput":
+            raise ValueError("config must be 'throughput'")
 
     def service_definition(self) -> VLLMServiceDefinition:
         return VLLMServiceDefinition(

--- a/src/refiner/robotics/reward.py
+++ b/src/refiner/robotics/reward.py
@@ -47,7 +47,7 @@ def reward_score(
     from refiner.inference import generate_pooling
     from refiner.inference.providers import VLLMProvider
 
-    provider = VLLMProvider(model=model, config="correctness")
+    provider = VLLMProvider(model=model, config="throughput")
 
     async def _score_episode(
         row: Row,

--- a/src/refiner/services/vllm.py
+++ b/src/refiner/services/vllm.py
@@ -12,14 +12,14 @@ from refiner.services.base import RuntimeServiceBinding, RuntimeServiceSpec
 @dataclass(frozen=True, slots=True)
 class VLLMServiceDefinition:
     model_name_or_path: str
-    config: Literal["correctness", "throughput"] = "correctness"
+    config: Literal["throughput"] = "throughput"
     kind: str = "llm"
 
     def __post_init__(self) -> None:
         if not self.model_name_or_path.strip():
             raise ValueError("model_name_or_path must be non-empty")
-        if self.config not in {"correctness", "throughput"}:
-            raise ValueError("config must be 'correctness' or 'throughput'")
+        if self.config != "throughput":
+            raise ValueError("config must be 'throughput'")
 
     @property
     def name(self) -> str:

--- a/tests/inference/test_provider_config.py
+++ b/tests/inference/test_provider_config.py
@@ -115,9 +115,17 @@ def test_vllm_provider_includes_supported_service_config() -> None:
     assert provider.to_builtin_args() == {
         "type": "vllm",
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "config": "correctness",
+        "config": "throughput",
     }
     assert provider.service_definition().to_spec().config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "config": "correctness",
+        "config": "throughput",
     }
+
+
+def test_vllm_provider_rejects_unsupported_config() -> None:
+    with pytest.raises(ValueError, match="config must be 'throughput'"):
+        VLLMProvider(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            config="correctness",  # type: ignore[arg-type]
+        )

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -280,7 +280,7 @@ def test_pipeline_launch_cloud_embeds_runtime_services(monkeypatch) -> None:
         "kind": "llm",
         "config": {
             "model_name_or_path": "Qwen/Qwen3.5-9B",
-            "config": "correctness",
+            "config": "throughput",
         },
     }
     assert request.plan["stages"][0]["runtime_services"] == [expected_service]

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -191,7 +191,7 @@ def test_compile_pipeline_plan_includes_runtime_services_for_builtin_steps() -> 
             "kind": "llm",
             "config": {
                 "model_name_or_path": "Qwen/Qwen3.5-9B",
-                "config": "correctness",
+                "config": "throughput",
             },
         }
     ]

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -46,7 +46,7 @@ def _request() -> CloudRunCreateRequest:
                         kind="llm",
                         config={
                             "model_name_or_path": "Qwen/Qwen3.5-9B",
-                            "config": "correctness",
+                            "config": "throughput",
                         },
                     ),
                 ),
@@ -110,7 +110,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
                     "kind": "llm",
                     "config": {
                         "model_name_or_path": "Qwen/Qwen3.5-9B",
-                        "config": "correctness",
+                        "config": "throughput",
                     },
                 }
             ],

--- a/tests/robotics/test_reward.py
+++ b/tests/robotics/test_reward.py
@@ -84,7 +84,7 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
 
     assert services[0].config == {
         "model_name_or_path": "aliangdw/Robometer-4B",
-        "config": "correctness",
+        "config": "throughput",
     }
     assert "robometer_progress" not in result
     assert result["reward_score"] == pytest.approx([3.0 / 9.0, 8.997 / 9.0], abs=0.001)

--- a/tests/services/test_discovery.py
+++ b/tests/services/test_discovery.py
@@ -24,5 +24,5 @@ def test_collect_pipeline_services_supports_nested_service_config() -> None:
     assert len(services) == 1
     assert services[0].config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "config": "correctness",
+        "config": "throughput",
     }

--- a/tests/services/test_manager.py
+++ b/tests/services/test_manager.py
@@ -247,7 +247,7 @@ def test_vllm_service_definition_uses_supported_service_config() -> None:
 
     assert spec.config == {
         "model_name_or_path": "Qwen/Qwen2.5-VL-7B-Instruct",
-        "config": "correctness",
+        "config": "throughput",
     }
     expected_suffix = hashlib.sha256(
         json.dumps(spec.config, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -255,14 +255,18 @@ def test_vllm_service_definition_uses_supported_service_config() -> None:
     assert service.name == f"vllm-{expected_suffix}"
 
 
-def test_vllm_service_definition_name_tracks_service_config_profile() -> None:
-    correctness_service = VLLMServiceDefinition(
-        model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
-        config="correctness",
-    )
-    throughput_service = VLLMServiceDefinition(
+def test_vllm_service_definition_rejects_unsupported_config_profile() -> None:
+    with pytest.raises(ValueError, match="config must be 'throughput'"):
+        VLLMServiceDefinition(
+            model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
+            config="correctness",  # type: ignore[arg-type]
+        )
+
+
+def test_vllm_service_definition_allows_throughput_config_profile() -> None:
+    service = VLLMServiceDefinition(
         model_name_or_path="Qwen/Qwen2.5-VL-7B-Instruct",
         config="throughput",
     )
 
-    assert correctness_service.name != throughput_service.name
+    assert service.to_spec().config["config"] == "throughput"

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -272,7 +272,7 @@ def test_worker_uses_explicit_runtime_services(monkeypatch: pytest.MonkeyPatch) 
     service = RuntimeServiceSpec(
         name="vllm-demo",
         kind="llm",
-        config={"model_name_or_path": "Qwen/Qwen3.5-9B", "config": "correctness"},
+        config={"model_name_or_path": "Qwen/Qwen3.5-9B", "config": "throughput"},
     )
     started_services: list[tuple[RuntimeServiceSpec, ...]] = []
 


### PR DESCRIPTION
## Summary

- Restrict `VLLMProvider` and `VLLMServiceDefinition` to `config="throughput"` only.
- Update Robometer runtime service creation, planning/launcher/cloud expectations, and tests to use the supported VLLM profile.
- Move VLLM documentation into the new provider/runtime-service docs locations from the restructured docs tree.
- Add rejection coverage for the old `config="correctness"` value.

## Impact

VLLM-backed jobs now consistently emit `config="throughput"` and fail fast if callers pass any unsupported VLLM profile.

## Validation

- `uv run pytest tests/inference/test_provider_config.py tests/services/test_manager.py tests/services/test_discovery.py tests/pipeline/test_planning.py tests/launchers/test_cloud_launcher.py tests/platform/test_cloud_client.py tests/robotics/test_reward.py tests/worker/test_runner.py` -> `110 passed`
- `uv run ruff check --force-exclude .`
- `uv run ty check`