### PR TITLE
[codex] Replace robotics extra with hf extra

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ Cloud.
 ## Install
 
 ```bash
-pip install macrodata-refiner[robotics]
+pip install macrodata-refiner[hf,video]
 ```
 
 For cloud runs, authenticate once:
@@ -96,4 +96,3 @@ If you store secrets in the platform, use `mdr.Secrets.env(...)`; see
 - Learn the episode model in [Episode Data](episode-data/index.md).
 - Learn common row operations in [Transforms](transforms/index.md).
 - Learn LeRobot output details in [Writing LeRobot](writing-data/lerobot.md).
-

--- a/docs/reference/optional-dependencies.md
+++ b/docs/reference/optional-dependencies.md
@@ -9,7 +9,7 @@ Install extras based on the data and operations you use.
 
 | Extra | Enables |
 | --- | --- |
-| `robotics` | LeRobot workflows, video dependencies, Hugging Face Hub helpers. |
+| `hf` | Hugging Face datasets, Hub APIs, and HF filesystem helpers. |
 | `egocentric` | Egocentric hand tracking. |
 | `hdf5` | HDF5 reader support. |
 | `zarr` | Zarr reader and writer support. |
@@ -21,8 +21,8 @@ Install extras based on the data and operations you use.
 Examples:
 
 ```bash
-pip install macrodata-refiner[robotics]
+pip install macrodata-refiner[hf,video]
+pip install macrodata-refiner[hf]
 pip install macrodata-refiner[hdf5,zarr]
 pip install macrodata-refiner[egocentric]
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,20 +28,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-huggingface = [
-    "datasets>=3.0.0",
-]
 video = [
     "av",
     "pillow",
 ]
-robotics = [
-    "macrodata-refiner[video]",
+hf = [
+    "datasets>=3.0.0",
     "huggingface-hub>=1.4.1",
     "hf>=1.7.1",
 ]
 egocentric = [
-    "macrodata-refiner[robotics]",
+    "macrodata-refiner[hf]",
+    "macrodata-refiner[video]",
     "ego-vision[models]>=0.1.0",
 ]
 text = [
@@ -58,9 +56,9 @@ s3 = [
     "s3fs",
 ]
 testing = [
-    "macrodata-refiner[huggingface]",
     "macrodata-refiner[hdf5]",
-    "macrodata-refiner[robotics]",
+    "macrodata-refiner[hf]",
+    "macrodata-refiner[video]",
     "macrodata-refiner[zarr]",
     "macrodata-refiner[text]",
     "macrodata-refiner[s3]",

--- a/uv.lock
+++ b/uv.lock
@@ -1552,18 +1552,15 @@ egocentric = [
     { name = "ego-vision", extra = ["models"] },
     { name = "hf" },
     { name = "huggingface-hub" },
+    { name = "pillow" },
 ]
 hdf5 = [
     { name = "h5py" },
 ]
-huggingface = [
+hf = [
     { name = "datasets" },
-]
-robotics = [
-    { name = "av" },
     { name = "hf" },
     { name = "huggingface-hub" },
-    { name = "pillow" },
 ]
 s3 = [
     { name = "s3fs" },
@@ -1606,22 +1603,22 @@ dev = [
 requires-dist = [
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
-    { name = "datasets", marker = "extra == 'huggingface'", specifier = ">=3.0.0" },
+    { name = "datasets", marker = "extra == 'hf'", specifier = ">=3.0.0" },
     { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.0" },
     { name = "fsspec", extras = ["http"] },
     { name = "h5py", marker = "extra == 'hdf5'" },
-    { name = "hf", marker = "extra == 'robotics'", specifier = ">=1.7.1" },
+    { name = "hf", marker = "extra == 'hf'", specifier = ">=1.7.1" },
     { name = "httpx" },
-    { name = "huggingface-hub", marker = "extra == 'robotics'", specifier = ">=1.4.1" },
+    { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.4.1" },
     { name = "loguru" },
     { name = "macrodata-refiner", extras = ["hdf5"], marker = "extra == 'testing'" },
-    { name = "macrodata-refiner", extras = ["huggingface"], marker = "extra == 'testing'" },
-    { name = "macrodata-refiner", extras = ["robotics"], marker = "extra == 'egocentric'" },
-    { name = "macrodata-refiner", extras = ["robotics"], marker = "extra == 'testing'" },
+    { name = "macrodata-refiner", extras = ["hf"], marker = "extra == 'egocentric'" },
+    { name = "macrodata-refiner", extras = ["hf"], marker = "extra == 'testing'" },
     { name = "macrodata-refiner", extras = ["s3"], marker = "extra == 'testing'" },
     { name = "macrodata-refiner", extras = ["testing"], marker = "extra == 'all'" },
     { name = "macrodata-refiner", extras = ["text"], marker = "extra == 'testing'" },
-    { name = "macrodata-refiner", extras = ["video"], marker = "extra == 'robotics'" },
+    { name = "macrodata-refiner", extras = ["video"], marker = "extra == 'egocentric'" },
+    { name = "macrodata-refiner", extras = ["video"], marker = "extra == 'testing'" },
     { name = "macrodata-refiner", extras = ["zarr"], marker = "extra == 'testing'" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "numcodecs", marker = "extra == 'zarr'", specifier = "<0.16" },
@@ -1636,7 +1633,7 @@ requires-dist = [
     { name = "warcio", marker = "extra == 'text'" },
     { name = "zarr", marker = "extra == 'zarr'", specifier = ">=2.18,<3" },
 ]
-provides-extras = ["huggingface", "video", "robotics", "egocentric", "text", "hdf5", "zarr", "s3", "testing", "all"]
+provides-extras = ["video", "hf", "egocentric", "text", "hdf5", "zarr", "s3", "testing", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Remove the `robotics` optional dependency extra and add a narrower `hf` extra for Hugging Face filesystem dependencies.

## Changes

- Replace `[project.optional-dependencies].robotics` with `hf` containing `huggingface-hub` and `hf`.
- Keep `video` unchanged.
- Update `egocentric` and `testing` to compose `hf` and `video` directly.
- Update the robotics docs install snippet from `[robotics]` to `[hf,video]`.
- Update `uv.lock` without unrelated lockfile churn.

## Validation

- `uv lock --check`
- `uv run ruff check pyproject.toml`
- `uv run python -c "from importlib.metadata import metadata; meta=metadata('macrodata-refiner'); print([v for v in meta.get_all('Provides-Extra') or [] if v in {'hf','robotics','video','egocentric','testing'}])"`
