### PR TITLE
[codex] update subtask contact sheet prompt

### DIFF
--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -39,7 +39,11 @@ The output column contains a list of segments:
 ## Contact Sheets
 
 Contact sheets reduce video into timestamped image grids. This is often cheaper
-and easier for VLMs than sending the full video.
+and easier for VLMs than sending the full video. By default, the annotator
+samples every `0.5` seconds, resizes each sampled frame to `224px` wide, and
+packs frames chronologically into `5` columns by `4` rows. The default prompt
+instructs the model to read time left-to-right, then top-to-bottom, and to use
+the visible timestamp printed inside each tile when choosing segment boundaries.
 
 | Parameter | Meaning |
 | --- | --- |
@@ -48,6 +52,7 @@ and easier for VLMs than sending the full video.
 | `frames_per_sheet` | Number of frames per sheet image. |
 | `columns` | Contact sheet grid columns. |
 | `include_contact_sheet_manifest` | Add textual sheet descriptions to the prompt. |
+| `min_segment_duration_sec` | Minimum returned segment duration. Defaults to `0.0`, so valid short segments are kept. |
 
 ## Prompting
 
@@ -65,4 +70,3 @@ pipeline = pipeline.map_async(
 
 For lower-level inference controls, see [Generate Text](../inference/generate-text.md)
 and [Multimodal and Structured Output](../inference/multimodal-and-structured-output.md).
-

--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -50,19 +50,5 @@ and easier for VLMs than sending the full video.
 | `include_contact_sheet_manifest` | Add textual sheet descriptions to the prompt. |
 | `min_segment_duration_sec` | Minimum returned segment duration. Defaults to `0.0`, so valid short segments are kept. |
 
-## Prompting
-
-Pass a custom prompt when you have a fixed subtask vocabulary:
-
-```python
-pipeline = pipeline.map_async(
-    mdr.robotics.subtask_annotation(
-        provider=provider,
-        prompt="Label each episode with reach, grasp, move, and place segments.",
-    ),
-    max_in_flight=32,
-)
-```
-
 For lower-level inference controls, see [Generate Text](../inference/generate-text.md)
 and [Multimodal and Structured Output](../inference/multimodal-and-structured-output.md).

--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -39,13 +39,7 @@ The output column contains a list of segments:
 ## Contact Sheets
 
 Contact sheets reduce video into timestamped image grids. This is often cheaper
-and easier for VLMs than sending the full video. By default, the annotator
-samples every `0.5` seconds, resizes each sampled frame to `224px` wide, and
-packs frames chronologically into `5` columns by `4` rows. The default prompt
-instructs the model to read time left-to-right, then top-to-bottom, and to use
-the visible timestamp printed inside each tile when choosing segment boundaries.
-If you override `columns` or `frames_per_sheet`, the default prompt uses the
-resulting contact sheet layout.
+and easier for VLMs than sending the full video.
 
 | Parameter | Meaning |
 | --- | --- |

--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -44,6 +44,8 @@ samples every `0.5` seconds, resizes each sampled frame to `224px` wide, and
 packs frames chronologically into `5` columns by `4` rows. The default prompt
 instructs the model to read time left-to-right, then top-to-bottom, and to use
 the visible timestamp printed inside each tile when choosing segment boundaries.
+If you override `columns` or `frames_per_sheet`, the default prompt uses the
+resulting contact sheet layout.
 
 | Parameter | Meaning |
 | --- | --- |

--- a/docs/examples/annotate-subtasks.md
+++ b/docs/examples/annotate-subtasks.md
@@ -18,7 +18,6 @@ pipeline = (
         mdr.robotics.subtask_annotation(
             provider=provider,
             video_key="observation.images.top",
-            prompt="Segment the manipulation into reach, grasp, move, and place.",
             output_column="predicted_subtasks",
         ),
         max_in_flight=64,
@@ -30,4 +29,3 @@ pipeline = (
 Use [Subtask Annotation](../episode-operations/subtask-annotation.md) for
 parameter details and [Providers and VLLM](../inference/providers-and-vllm.md)
 for model setup.
-

--- a/src/refiner/robotics/subtask_annotation.py
+++ b/src/refiner/robotics/subtask_annotation.py
@@ -30,10 +30,17 @@ if TYPE_CHECKING:
     )
     from refiner.video import VideoFile
 
-_DEFAULT_SUBTASK_ANNOTATION_PROMPT = """Reconstruct the sequence of manipulation events in this robot video from the timestamped contact sheets.
+_DEFAULT_SUBTASK_ANNOTATION_PROMPT = """Reconstruct the sequence of manipulation events in this robot video from timestamped contact sheets.
 
 Return only JSON with this shape:
 {"segments":[{"start_sec":0.0,"end_sec":1.0,"subtask":"short action description"}]}
+
+How to read the images:
+- Each image is a contact sheet with 5 columns and 4 rows.
+- Time runs left-to-right within each row, then continues on the next row.
+- Each tile has a visible timestamp in its top-left corner, such as 012.50s.
+- Use the visible timestamp printed inside the tile, not the tile index, when choosing start_sec and end_sec.
+- Boundaries should normally land on or near one of the visible timestamps.
 
 Rules:
 - Treat each segment as one event that changes what is true about the world.
@@ -41,7 +48,7 @@ Rules:
 - For each event, choose start_sec at the first timestamp where the causal motion for that event is underway, and end_sec at the first timestamp where the resulting world state is achieved.
 - If an action is continuous and changes the same state gradually, keep it as one event.
 - If the same action repeats on different objects or target locations, output separate repeated events.
-- Avoid idle time, camera motion, hesitation, and tiny hand adjustments.
+- Avoid segments for idle time, camera motion, hesitation, or tiny hand adjustments.
 """
 
 if TYPE_CHECKING:

--- a/src/refiner/robotics/subtask_annotation.py
+++ b/src/refiner/robotics/subtask_annotation.py
@@ -101,7 +101,6 @@ def subtask_annotation(
     *,
     provider: SubtaskAnnotationProvider,
     video_key: str | None = None,
-    prompt: str | None = None,
     output_column: str = "predicted_subtasks",
     sample_sec: float = 0.5,
     frame_width: int = 224,
@@ -133,14 +132,13 @@ def subtask_annotation(
 
         selected_video_key = _resolve_video_key(row, video_key)
         video = row.videos[selected_video_key]
-        resolved_prompt = _resolve_prompt(
-            prompt,
+        prompt = _default_prompt(
             frames_per_sheet=frames_per_sheet,
             columns=columns,
         )
         content = await _subtask_annotation_content(
             video=video,
-            prompt=_prompt_with_instruction(resolved_prompt, row.tasks),
+            prompt=_prompt_with_instruction(prompt, row.tasks),
             sample_sec=sample_sec,
             frame_width=frame_width,
             frames_per_sheet=frames_per_sheet,
@@ -181,14 +179,11 @@ def subtask_annotation(
     )
 
 
-def _resolve_prompt(
-    prompt: str | None,
+def _default_prompt(
     *,
     frames_per_sheet: int,
     columns: int,
 ) -> str:
-    if prompt is not None:
-        return prompt
     if frames_per_sheet <= 0:
         raise ValueError("frames_per_sheet must be > 0")
     if columns <= 0:

--- a/src/refiner/robotics/subtask_annotation.py
+++ b/src/refiner/robotics/subtask_annotation.py
@@ -132,13 +132,9 @@ def subtask_annotation(
 
         selected_video_key = _resolve_video_key(row, video_key)
         video = row.videos[selected_video_key]
-        prompt = _default_prompt(
-            frames_per_sheet=frames_per_sheet,
-            columns=columns,
-        )
         content = await _subtask_annotation_content(
             video=video,
-            prompt=_prompt_with_instruction(prompt, row.tasks),
+            tasks=row.tasks,
             sample_sec=sample_sec,
             frame_width=frame_width,
             frames_per_sheet=frames_per_sheet,
@@ -177,22 +173,6 @@ def subtask_annotation(
         provider=provider,
         max_concurrent_requests=max_concurrent_requests,
     )
-
-
-def _default_prompt(
-    *,
-    frames_per_sheet: int,
-    columns: int,
-) -> str:
-    if frames_per_sheet <= 0:
-        raise ValueError("frames_per_sheet must be > 0")
-    if columns <= 0:
-        raise ValueError("columns must be > 0")
-    rows = math.ceil(frames_per_sheet / columns)
-    return _DEFAULT_SUBTASK_ANNOTATION_PROMPT_TEMPLATE.replace(
-        "{columns_count}",
-        str(columns),
-    ).replace("{rows_count}", str(rows))
 
 
 def contact_sheet_prompt_manifest(
@@ -260,7 +240,7 @@ def _parse_subtask_annotation_result(text: str) -> _SubtaskAnnotationResult:
 async def _subtask_annotation_content(
     *,
     video: VideoFile,
-    prompt: str,
+    tasks: list[str],
     sample_sec: float,
     frame_width: int,
     frames_per_sheet: int,
@@ -276,7 +256,12 @@ async def _subtask_annotation_content(
         columns=columns,
         quality=quality,
     )
-    text = prompt
+    first_sheet = sheets[0]
+    text = _DEFAULT_SUBTASK_ANNOTATION_PROMPT_TEMPLATE.replace(
+        "{columns_count}",
+        str(first_sheet.columns),
+    ).replace("{rows_count}", str(first_sheet.rows))
+    text = _prompt_with_instruction(text, tasks)
     if include_contact_sheet_manifest:
         text = f"{text}\n\n{contact_sheet_prompt_manifest(sheets)}"
     return [

--- a/src/refiner/robotics/subtask_annotation.py
+++ b/src/refiner/robotics/subtask_annotation.py
@@ -30,13 +30,13 @@ if TYPE_CHECKING:
     )
     from refiner.video import VideoFile
 
-_DEFAULT_SUBTASK_ANNOTATION_PROMPT = """Reconstruct the sequence of manipulation events in this robot video from timestamped contact sheets.
+_DEFAULT_SUBTASK_ANNOTATION_PROMPT_TEMPLATE = """Reconstruct the sequence of manipulation events in this robot video from timestamped contact sheets.
 
 Return only JSON with this shape:
 {"segments":[{"start_sec":0.0,"end_sec":1.0,"subtask":"short action description"}]}
 
 How to read the images:
-- Each image is a contact sheet with 5 columns and 4 rows.
+- Each image is a contact sheet with {columns_count} columns and {rows_count} rows.
 - Time runs left-to-right within each row, then continues on the next row.
 - Each tile has a visible timestamp in its top-left corner, such as 012.50s.
 - Use the visible timestamp printed inside the tile, not the tile index, when choosing start_sec and end_sec.
@@ -101,7 +101,7 @@ def subtask_annotation(
     *,
     provider: SubtaskAnnotationProvider,
     video_key: str | None = None,
-    prompt: str = _DEFAULT_SUBTASK_ANNOTATION_PROMPT,
+    prompt: str | None = None,
     output_column: str = "predicted_subtasks",
     sample_sec: float = 0.5,
     frame_width: int = 224,
@@ -133,9 +133,14 @@ def subtask_annotation(
 
         selected_video_key = _resolve_video_key(row, video_key)
         video = row.videos[selected_video_key]
+        resolved_prompt = _resolve_prompt(
+            prompt,
+            frames_per_sheet=frames_per_sheet,
+            columns=columns,
+        )
         content = await _subtask_annotation_content(
             video=video,
-            prompt=_prompt_with_instruction(prompt, row.tasks),
+            prompt=_prompt_with_instruction(resolved_prompt, row.tasks),
             sample_sec=sample_sec,
             frame_width=frame_width,
             frames_per_sheet=frames_per_sheet,
@@ -174,6 +179,25 @@ def subtask_annotation(
         provider=provider,
         max_concurrent_requests=max_concurrent_requests,
     )
+
+
+def _resolve_prompt(
+    prompt: str | None,
+    *,
+    frames_per_sheet: int,
+    columns: int,
+) -> str:
+    if prompt is not None:
+        return prompt
+    if frames_per_sheet <= 0:
+        raise ValueError("frames_per_sheet must be > 0")
+    if columns <= 0:
+        raise ValueError("columns must be > 0")
+    rows = math.ceil(frames_per_sheet / columns)
+    return _DEFAULT_SUBTASK_ANNOTATION_PROMPT_TEMPLATE.replace(
+        "{columns_count}",
+        str(columns),
+    ).replace("{rows_count}", str(rows))
 
 
 def contact_sheet_prompt_manifest(

--- a/tests/robotics/test_subtask_annotation.py
+++ b/tests/robotics/test_subtask_annotation.py
@@ -257,6 +257,41 @@ def test_subtask_annotation_can_include_contact_sheet_manifest(
     )
 
 
+def test_subtask_annotation_prompt_uses_configured_contact_sheet_layout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    def _fake_generate_text(**kwargs):
+        return kwargs["fn"]
+
+    monkeypatch.setattr(inference_module, "generate_text", _fake_generate_text)
+
+    row = _lerobot_row(tmp_path)
+    block = mdr.robotics.subtask_annotation(
+        provider=mdr.inference.GoogleEndpointProvider(model="gemini-flash-latest"),
+        video_key="observation.images.main",
+        frames_per_sheet=6,
+        columns=4,
+    )
+    request = {}
+
+    async def _fake_request(**kwargs):
+        request.update(kwargs)
+        return InferenceResponse(
+            text='{"segments":[]}',
+            finish_reason="stop",
+            usage={},
+            response={},
+            object=subtask_annotation_module._SubtaskAnnotationResult(segments=[]),
+        )
+
+    asyncio.run(cast(Any, block)(row, _fake_request))
+
+    prompt = request["messages"][0]["content"][0]["text"]
+    assert "Each image is a contact sheet with 4 columns and 2 rows." in prompt
+    assert "5 columns and 4 rows" not in prompt
+
+
 def test_subtask_annotation_keeps_short_segments_by_default(
     tmp_path,
     monkeypatch,

--- a/tests/robotics/test_subtask_annotation.py
+++ b/tests/robotics/test_subtask_annotation.py
@@ -202,6 +202,14 @@ def test_subtask_annotation_block_updates_row(tmp_path, monkeypatch) -> None:
     assert message["role"] == "user"
     assert "Episode instruction: open the drawer" in message["content"][0]["text"]
     assert (
+        "Each image is a contact sheet with 5 columns and 4 rows."
+        in (message["content"][0]["text"])
+    )
+    assert (
+        "Use the visible timestamp printed inside the tile"
+        in (message["content"][0]["text"])
+    )
+    assert (
         "Actions may continue across contact sheet boundaries"
         not in message["content"][0]["text"]
     )


### PR DESCRIPTION
## Summary

- Update the default subtask annotation prompt with explicit 5x4 contact-sheet layout instructions.

- Tell the model to use printed tile timestamps instead of inferring time from tile index.

- Document the default sampling/layout behavior and keep short segments by default.


## Validation

- uv run pytest tests/robotics/test_subtask_annotation.py

- uv run ruff check --force-exclude src/refiner/robotics/subtask_annotation.py tests/robotics/test_subtask_annotation.py docs/episode-operations/subtask-annotation.md
