### PR TITLE
Use headless ego vision in egocentric tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ wheels/
 notebooks/
 thoughts/
 .worktrees/
+artifacts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ hf = [
 egocentric = [
     "macrodata-refiner[hf]",
     "macrodata-refiner[video]",
-    "ego-vision[models]>=0.1.5",
+    "ego-vision[models]>=0.1.6",
     "opencv-python-headless",
 ]
 text = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ hf = [
 egocentric = [
     "macrodata-refiner[hf]",
     "macrodata-refiner[video]",
-    "ego-vision[models]>=0.1.2",
+    "ego-vision[models]>=0.1.4",
+    "opencv-python-headless",
 ]
 text = [
     "warcio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ hf = [
 egocentric = [
     "macrodata-refiner[hf]",
     "macrodata-refiner[video]",
-    "ego-vision[models]>=0.1.4",
+    "ego-vision[models]>=0.1.5",
     "opencv-python-headless",
 ]
 text = [

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -84,10 +84,21 @@ def _collect_dependencies() -> list[dict[str, str]]:
             continue
         dependencies_by_name[dist_name] = dist_version
 
+    _prefer_headless_opencv(dependencies_by_name)
     return [
         {"name": name, "version": dependencies_by_name[name]}
         for name in sorted(dependencies_by_name, key=lambda item: item.lower())
     ]
+
+
+def _prefer_headless_opencv(dependencies_by_name: dict[str, str]) -> None:
+    normalized_names = {name.lower(): name for name in dependencies_by_name}
+    if "opencv-python-headless" not in normalized_names:
+        return
+    for gui_dist_name in ("opencv-python", "opencv-contrib-python"):
+        existing_name = normalized_names.get(gui_dist_name)
+        if existing_name is not None:
+            dependencies_by_name.pop(existing_name, None)
 
 
 def _resolve_installed_version() -> str | None:

--- a/src/refiner/robotics/egocentric.py
+++ b/src/refiner/robotics/egocentric.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from refiner.execution.asyncio.runtime import submit
@@ -16,6 +16,7 @@ def track_hands(
     video_key: str = "video",
     output_key: str = "hand_tracking",
     config: Any | None = None,
+    config_factory: Callable[[Any], Any] | None = None,
 ) -> BatchFn:
     """Return a ``batch_map`` function for ego-vision hand tracking.
 
@@ -27,6 +28,8 @@ def track_hands(
         raise ValueError("video_key cannot be empty")
     if not output_key:
         raise ValueError("output_key cannot be empty")
+    if config is not None and config_factory is not None:
+        raise ValueError("config and config_factory are mutually exclusive")
 
     pipeline = None
     episode_input = None
@@ -35,11 +38,12 @@ def track_hands(
         "robotics.egocentric:track_hands",
         video_key=video_key,
         output_key=output_key,
+        has_config_factory=config_factory is not None,
     )
     def _track(rows: list[Row]) -> Iterable[Row]:
         nonlocal episode_input, pipeline
         if pipeline is None:
-            pipeline, episode_input = _load_egovision(config)
+            pipeline, episode_input = _load_egovision(config, config_factory)
 
         episodes = []
         for row in rows:
@@ -62,7 +66,10 @@ def track_hands(
     return _track
 
 
-def _load_egovision(config: Any | None) -> tuple[Any, Any]:
+def _load_egovision(
+    config: Any | None,
+    config_factory: Callable[[Any], Any] | None,
+) -> tuple[Any, Any]:
     try:
         egovision = importlib.import_module("egovision")
     except ImportError as exc:
@@ -71,7 +78,9 @@ def _load_egovision(config: Any | None) -> tuple[Any, Any]:
             "`pip install macrodata-refiner[egocentric]`."
         ) from exc
 
-    if config is None:
+    if config_factory is not None:
+        config = config_factory(egovision)
+    elif config is None:
         config = egovision.HandTrackingConfig(
             hand_reconstruction=egovision.HaworReconstructionConfig(),
         )

--- a/tests/platform/test_manifest.py
+++ b/tests/platform/test_manifest.py
@@ -121,6 +121,33 @@ def test_build_run_manifest_environment_does_not_include_rundir_by_default(
     assert "rundir" not in manifest["environment"]
 
 
+def test_build_run_manifest_prefers_headless_opencv(monkeypatch) -> None:
+    class _Dist:
+        def __init__(self, name: str, version: str) -> None:
+            self.metadata = {"Name": name}
+            self.version = version
+
+    monkeypatch.setattr(sys, "argv", ["-c"])
+    monkeypatch.setattr(
+        "refiner.platform.manifest.importlib_metadata.distributions",
+        lambda: [
+            _Dist("opencv-python", "4.13.0.92"),
+            _Dist("opencv-python-headless", "4.13.0.92"),
+            _Dist("ultralytics", "8.4.53"),
+        ],
+    )
+
+    manifest = build_run_manifest()
+
+    dependencies = {
+        dependency["name"]: dependency["version"]
+        for dependency in manifest["dependencies"]
+    }
+    assert "opencv-python" not in dependencies
+    assert dependencies["opencv-python-headless"] == "4.13.0.92"
+    assert dependencies["ultralytics"] == "8.4.53"
+
+
 def test_refiner_ref_exists_on_remote_returns_true_on_success(monkeypatch) -> None:
     monkeypatch.setattr(
         "refiner.platform.manifest.urllib_request.urlopen",

--- a/tests/robotics/test_egocentric.py
+++ b/tests/robotics/test_egocentric.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 import refiner as mdr
 from refiner.pipeline.data import datatype
@@ -94,6 +95,73 @@ def test_track_hands_is_available_from_robotics_namespace() -> None:
     )
 
     assert pipeline.pipeline_steps[-1].op_name == "batch_map"
+
+
+def test_track_hands_accepts_config_factory(monkeypatch) -> None:
+    seen: dict[str, Any] = {}
+
+    class EpisodeInput:
+        def __init__(self, *, frames):
+            self.frames = list(frames)
+
+    class HandTrackingConfig:
+        def __init__(self, *, device=None, hand_reconstruction=None):
+            self.device = device
+            self.hand_reconstruction = hand_reconstruction
+
+    class HaworReconstructionConfig:
+        pass
+
+    class Result:
+        def to_dict(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    class HandTrackingPipeline:
+        def __init__(self, config):
+            seen["device"] = config.device
+
+        def predict_episodes(self, episodes):
+            seen["frame_counts"] = [len(episode.frames) for episode in episodes]
+            return [Result() for _ in episodes]
+
+    fake_egovision = ModuleType("egovision")
+    setattr(fake_egovision, "EpisodeInput", EpisodeInput)
+    setattr(fake_egovision, "HandTrackingConfig", HandTrackingConfig)
+    setattr(fake_egovision, "HandTrackingPipeline", HandTrackingPipeline)
+    setattr(fake_egovision, "HaworReconstructionConfig", HaworReconstructionConfig)
+    monkeypatch.setitem(sys.modules, "egovision", fake_egovision)
+
+    def config_factory(egovision):
+        seen["factory_module"] = egovision.__name__
+        return egovision.HandTrackingConfig(
+            device="cuda",
+            hand_reconstruction=egovision.HaworReconstructionConfig(),
+        )
+
+    frames = np.zeros((2, 4, 5, 3), dtype=np.uint8)
+    row = _robot_row_converter(video_keys={"video": "video"})(
+        DictRow({"video": VideoFrameArray(frames, fps=10)})
+    )
+
+    out = list(track_hands(config_factory=config_factory)([row]))
+
+    assert seen == {
+        "factory_module": "egovision",
+        "device": "cuda",
+        "frame_counts": [2],
+    }
+    assert out[0]["hand_tracking"] == {"ok": True}
+
+
+def test_track_hands_rejects_config_and_config_factory() -> None:
+    def config_factory(egovision):
+        return egovision.HandTrackingConfig()
+
+    with pytest.raises(
+        ValueError,
+        match="config and config_factory are mutually exclusive",
+    ):
+        track_hands(config=object(), config_factory=config_factory)
 
 
 def test_track_hands_runs_from_parquet_robotics_rows(tmp_path, monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -873,15 +873,15 @@ wheels = [
 
 [[package]]
 name = "ego-vision"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/c9/e97b241e10e38cf80183b88daf74c189f2bc55e16b5a10a1774d12af4e54/ego_vision-0.1.5.tar.gz", hash = "sha256:e29ec512ac64b369857b27dca243e667c8ae10f93409fcb9daaa1983739703db", size = 102000, upload-time = "2026-05-29T12:25:45.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/57/498daad4e14989d4d48e7f7b4a0d7e71312314442337a77069892e23310d/ego_vision-0.1.6.tar.gz", hash = "sha256:f95418151b9b18a440677193540c7c18c96ff27e3ef5fe25286bd8a7dabc6703", size = 101607, upload-time = "2026-05-29T13:02:54.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/6b/54cea562a86bf6132b7862135b08f09b4ab4626e7f81c5df2ace27c0a7d6/ego_vision-0.1.5-py3-none-any.whl", hash = "sha256:867275cfff20c41af6e92dd6d7f7bfe63671533a176a4e12993029563ef8c5d9", size = 121623, upload-time = "2026-05-29T12:25:43.406Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/45/0dd482d11fd55bcbbf8900f8e767af8c8a8eca6d4292dd77130ec910bf14/ego_vision-0.1.6-py3-none-any.whl", hash = "sha256:6ef0f9778fd835bfb73af1f8851c3b69ad13fc3ce8a42e793c5547ad174655a9", size = 121168, upload-time = "2026-05-29T13:02:53.432Z" },
 ]
 
 [package.optional-dependencies]
@@ -1659,7 +1659,7 @@ requires-dist = [
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
     { name = "datasets", marker = "extra == 'hf'", specifier = ">=3.0.0" },
-    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.5" },
+    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.6" },
     { name = "fsspec", extras = ["http"] },
     { name = "h5py", marker = "extra == 'hdf5'" },
     { name = "hf", marker = "extra == 'hf'", specifier = ">=1.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -873,15 +873,15 @@ wheels = [
 
 [[package]]
 name = "ego-vision"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/96/3bd96590b386f4a232cfd9dae6a154a48fa427dfaa3c7b2bdcaa23c3b254/ego_vision-0.1.4.tar.gz", hash = "sha256:3ddda978b18a7aee9874446f2db4cbb7a5e505d5f3b59410d260d43753b4eec7", size = 102005, upload-time = "2026-05-29T11:18:11.3Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/c9/e97b241e10e38cf80183b88daf74c189f2bc55e16b5a10a1774d12af4e54/ego_vision-0.1.5.tar.gz", hash = "sha256:e29ec512ac64b369857b27dca243e667c8ae10f93409fcb9daaa1983739703db", size = 102000, upload-time = "2026-05-29T12:25:45.234Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/1f/62346980eb1263afd2680057567a89735b7f6f1540cb90295c2ea55dfdbd/ego_vision-0.1.4-py3-none-any.whl", hash = "sha256:eeecf8c2c6bfcf170331c747890aeb379d6713d171ff80c265c0f583820df982", size = 121614, upload-time = "2026-05-29T11:18:10.011Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6b/54cea562a86bf6132b7862135b08f09b4ab4626e7f81c5df2ace27c0a7d6/ego_vision-0.1.5-py3-none-any.whl", hash = "sha256:867275cfff20c41af6e92dd6d7f7bfe63671533a176a4e12993029563ef8c5d9", size = 121623, upload-time = "2026-05-29T12:25:43.406Z" },
 ]
 
 [package.optional-dependencies]
@@ -1659,7 +1659,7 @@ requires-dist = [
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
     { name = "datasets", marker = "extra == 'hf'", specifier = ">=3.0.0" },
-    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.4" },
+    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.5" },
     { name = "fsspec", extras = ["http"] },
     { name = "h5py", marker = "extra == 'hdf5'" },
     { name = "hf", marker = "extra == 'hf'", specifier = ">=1.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -873,15 +873,15 @@ wheels = [
 
 [[package]]
 name = "ego-vision"
-version = "0.1.2"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/3c/b0c07d9211561377050e027e2a966dc327e15278945ee635fb78acedd2d7/ego_vision-0.1.2.tar.gz", hash = "sha256:a22638eeb38a12563fde3872f2c5a57fa2a0a0d6779715955fe2c74b16915b3b", size = 101692, upload-time = "2026-05-29T07:29:49.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/96/3bd96590b386f4a232cfd9dae6a154a48fa427dfaa3c7b2bdcaa23c3b254/ego_vision-0.1.4.tar.gz", hash = "sha256:3ddda978b18a7aee9874446f2db4cbb7a5e505d5f3b59410d260d43753b4eec7", size = 102005, upload-time = "2026-05-29T11:18:11.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/38/fef39d4c125f6a2b80a29026fda24e43feecc3cd7d381561f8357b0925ed/ego_vision-0.1.2-py3-none-any.whl", hash = "sha256:0995d71cf1622113a249709d501ea4ecb59fc2c4dd18070ba9cea59d49b7b7a0", size = 121278, upload-time = "2026-05-29T07:29:47.731Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1f/62346980eb1263afd2680057567a89735b7f6f1540cb90295c2ea55dfdbd/ego_vision-0.1.4-py3-none-any.whl", hash = "sha256:eeecf8c2c6bfcf170331c747890aeb379d6713d171ff80c265c0f583820df982", size = 121614, upload-time = "2026-05-29T11:18:10.011Z" },
 ]
 
 [package.optional-dependencies]
@@ -891,7 +891,7 @@ models = [
     { name = "joblib" },
     { name = "lap" },
     { name = "natsort" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "safetensors" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1606,6 +1606,7 @@ egocentric = [
     { name = "ego-vision", extra = ["models"] },
     { name = "hf" },
     { name = "huggingface-hub" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
 ]
 hdf5 = [
@@ -1658,7 +1659,7 @@ requires-dist = [
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
     { name = "datasets", marker = "extra == 'hf'", specifier = ">=3.0.0" },
-    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.2" },
+    { name = "ego-vision", extras = ["models"], marker = "extra == 'egocentric'", specifier = ">=0.1.4" },
     { name = "fsspec", extras = ["http"] },
     { name = "h5py", marker = "extra == 'hdf5'" },
     { name = "hf", marker = "extra == 'hf'", specifier = ">=1.7.1" },
@@ -1677,6 +1678,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "numcodecs", marker = "extra == 'zarr'", specifier = "<0.16" },
     { name = "numpy" },
+    { name = "opencv-python-headless", marker = "extra == 'egocentric'" },
     { name = "orjson" },
     { name = "pillow", marker = "extra == 'video'" },
     { name = "pyarrow" },
@@ -2508,6 +2510,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
     { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
     { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- require ego-vision[models]>=0.1.4 for the egocentric extra
- add opencv-python-headless to the egocentric dependency set for headless cloud workers
- add a config_factory hook so cloud workers can build ego-vision configs after importing ego-vision in the worker runtime

## Tests
- uv run ruff check --force-exclude .
- uv run ruff format --force-exclude --check .
- uv run ty check
- uv run pytest tests/robotics/test_egocentric.py tests/test_optional_dependencies.py