### PR TITLE
Add cloud extra dependencies

### DIFF
--- a/docs/platform/manifests.md
+++ b/docs/platform/manifests.md
@@ -36,6 +36,48 @@ macrodata jobs manifest job_123 --json
 Use `--deps` to show dependencies and `--code` to show captured script text.
 Use `--json` for an agent, notebook, or CI job.
 
+## Dependency Entries
+
+Cloud launch normally captures installed packages from the submitting Python
+environment. Those entries appear as package/version pairs in the manifest:
+
+```text
+pandas==2.3.3
+pyarrow==23.0.1
+```
+
+`launch_cloud(extra_dependencies=[...])` merges additional pip requirement
+strings into that list. Extra dependencies take precedence over captured
+packages with the same normalized package name:
+
+```python
+pipeline.launch_cloud(
+    name="gpu-run",
+    extra_dependencies=[
+        "torch==2.6.0",
+        "transformers>=4.55",
+        "ego-vision[models,detection]==0.1.6",
+    ],
+)
+```
+
+Exact pins are shown as package/version pairs. Versionless requirements and
+ranges are shown as the submitted install string:
+
+```text
+torch==2.6.0
+transformers>=4.55
+ego-vision[detection,models]==0.1.6
+```
+
+Environment markers are not preserved. Do not include markers in
+`extra_dependencies`; list the package as it should install on Macrodata Cloud.
+For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
+
+If `sync_local_dependencies=False`, the manifest skips locally detected
+packages. Explicit `extra_dependencies` still appear and install in the cloud
+runtime.
+
 ## What To Look For
 
 | Field | Why it matters |

--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -80,12 +80,44 @@ Common launch settings:
 | `cpus_per_worker` | CPU allocation per worker. |
 | `mem_mb_per_worker` | Memory allocation per worker. |
 | `gpu` | GPU type/count per worker. |
+| `sync_local_dependencies` | Include detected packages from the submitting environment. Defaults to `True`. |
+| `extra_dependencies` | Additional pip requirement strings to install on workers. These override captured packages with the same package name. |
 | `secrets` | Secret values or workspace secret references passed to workers. |
 | `env` | Non-secret environment variables. |
 | `continue_from_job` | Reuse compatible outputs from a prior cloud job. |
 
 See [Cloud Launcher](../running-pipelines/cloud-launcher.md) and
 [Resources, GPUs, and Services](../running-pipelines/resources-gpus-and-services.md).
+
+### Dependency Overrides
+
+Most cloud launches use the locally captured package list. Use
+`extra_dependencies` when the worker needs a package that is not installed
+locally, or when a cloud run should pin a different version:
+
+```python
+pipeline.launch_cloud(
+    name="hand-tracking-smoke",
+    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
+    extra_dependencies=[
+        "ego-vision[models,detection]==0.1.6",
+        "opencv-python-headless",
+        "torch",
+    ],
+)
+```
+
+Entries are pip requirement strings. Exact pins, versionless requirements,
+ranges, and extras are supported. Extra dependencies are merged into the
+dependency manifest by package name and take precedence over locally captured
+packages with the same name.
+
+Environment markers are not preserved. Do not include markers in
+`extra_dependencies`; list the package as it should install on Macrodata Cloud.
+For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
+
+Set `sync_local_dependencies=False` to skip local package capture while still
+installing explicitly listed `extra_dependencies`.
 
 ## What Gets Submitted
 

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -14,6 +14,7 @@ pipeline.launch_cloud(
     num_workers=8,
     cpus_per_worker=4,
     mem_mb_per_worker=8192,
+    extra_dependencies=["torch", "ego-vision[models,detection]==0.1.6"],
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -31,6 +32,58 @@ A cloud submission includes:
 
 You can inspect submitted metadata through the platform and CLI. See
 [Manifests](../platform/manifests.md) and [CLI Jobs](../cli/jobs-logs-and-metrics.md).
+
+## Runtime Dependencies
+
+By default, cloud launch captures packages from the local Python environment and
+adds them to the job manifest. Workers install the submitted dependency list
+before running the pipeline.
+
+Use `extra_dependencies` when a cloud worker needs packages that are not present
+locally, or when the cloud package should override the locally captured version:
+
+```python
+pipeline.launch_cloud(
+    name="egocentric-smoke",
+    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
+    extra_dependencies=[
+        "ego-vision[models,detection]==0.1.6",
+        "opencv-python-headless",
+        "torch",
+    ],
+)
+```
+
+Each entry is a pip requirement string. Versionless requirements, exact pins,
+ranges, and extras are accepted:
+
+```python
+extra_dependencies=[
+    "torch",
+    "transformers>=4.55",
+    "ego-vision[models,detection]==0.1.6",
+]
+```
+
+Environment markers are not preserved. Do not include markers in
+`extra_dependencies`; list the package as it should install on Macrodata Cloud.
+For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
+
+Extra dependencies take precedence over captured local packages with the same
+package name. For example, if the local environment has `torch==2.4.0` but
+`extra_dependencies` includes `torch==2.6.0`, the submitted manifest keeps the
+explicit `torch==2.6.0` pin.
+
+Set `sync_local_dependencies=False` to skip local environment capture. Extra
+dependencies still install:
+
+```python
+pipeline.launch_cloud(
+    name="minimal-runtime",
+    sync_local_dependencies=False,
+    extra_dependencies=["torch", "macrodata-refiner[hf]"],
+)
+```
 
 ## Secrets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "loguru",
     "numpy",
     "orjson",
+    "packaging",
     "pyarrow",
     "msgspec>=0.20.0",
     "pydantic>=2.0.0",

--- a/src/refiner/cli/jobs/manifest.py
+++ b/src/refiner/cli/jobs/manifest.py
@@ -32,9 +32,9 @@ def _requirements_text(value: Any) -> str | None:
     lines: list[str] = []
     for dependency in value:
         if isinstance(dependency, dict):
-            lines.append(
-                f"{_safe_text(dependency.get('name'))}=={_safe_text(dependency.get('version'))}"
-            )
+            name = _safe_text(dependency.get("name"))
+            version = dependency.get("version")
+            lines.append(f"{name}=={_safe_text(version)}" if version else name)
     return "\n".join(lines)
 
 

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -14,7 +14,6 @@ from refiner.pipeline.planning import (
     plan_pipeline_stages,
 )
 from refiner.pipeline.resources import GPU
-from refiner.platform.manifest import build_run_manifest
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
@@ -96,11 +95,6 @@ class BaseLauncher(ABC):
             ),
             gpu=compute.gpu if compute.gpu is not None else getattr(self, "gpu", None),
         )
-
-    def _run_manifest(
-        self, *, secret_values: tuple[str, ...] = ()
-    ) -> dict[str, object]:
-        return build_run_manifest(secret_values=secret_values)
 
     @abstractmethod
     def launch(self):

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import os
 import re
 import sys
@@ -27,7 +28,7 @@ from refiner.platform.client import (
     StagePayload,
 )
 from refiner.platform.client.serialize import PreparedPipelinePayload
-from refiner.platform.manifest import refiner_ref_exists_on_remote
+from refiner.platform.manifest import build_run_manifest, refiner_ref_exists_on_remote
 from refiner.launchers.secrets import SecretInput, resolve_env_mapping
 from refiner.launchers.secrets import normalize_secret_sources, resolve_secret_sources
 from refiner.pipeline.resources import GPU
@@ -100,7 +101,11 @@ class CloudLauncher(BaseLauncher):
         cpus_per_worker: Optional requested CPU cores per worker.
         mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
         gpu: Optional GPU runtime request for cloud scheduling.
-        sync_local_dependencies: Whether to sync submitting environment dependencies.
+        sync_local_dependencies: Whether to include packages detected from the
+            local environment in the cloud runtime.
+        extra_dependencies: Additional packages to install in the cloud runtime.
+            Entries are requirement strings. These take precedence over packages
+            detected from the local environment.
         secrets: Optional secret sources mounted into the cloud runtime.
         env: Optional plain environment variables mounted into the cloud runtime.
     """
@@ -115,6 +120,7 @@ class CloudLauncher(BaseLauncher):
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
+        extra_dependencies: Sequence[str] | None = None,
         secrets: SecretInput | None = None,
         env: dict[str, object | None] | None = None,
         continue_from_job: str | None = None,
@@ -135,6 +141,7 @@ class CloudLauncher(BaseLauncher):
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
         self.sync_local_dependencies = sync_local_dependencies
+        self.extra_dependencies = extra_dependencies
         self.secrets = normalize_secret_sources(secrets)
         self.env = env
         self.continue_from_job = normalized_continue_from_job
@@ -148,7 +155,11 @@ class CloudLauncher(BaseLauncher):
     def _resolve_cloud_manifest(
         self, *, secret_values: tuple[str, ...]
     ) -> dict[str, object]:
-        manifest = self._run_manifest(secret_values=secret_values)
+        manifest = build_run_manifest(
+            secret_values=secret_values,
+            capture_dependencies=self.sync_local_dependencies,
+            extra_dependencies=self.extra_dependencies,
+        )
         environment = manifest.get("environment")
         if environment is None:
             return manifest
@@ -299,7 +310,6 @@ class CloudLauncher(BaseLauncher):
                     for stage in stages
                 ],
                 manifest=manifest,
-                sync_local_dependencies=self.sync_local_dependencies,
                 secrets=resolved_secret_sources,
                 env=resolved_env,
                 continue_from_job=self.continue_from_job,

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -25,6 +25,7 @@ from refiner.pipeline.planning import PlannedStage
 from refiner.pipeline.resources import GPU
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
 from refiner.platform.client.api import MacrodataClient, request_json
+from refiner.platform.manifest import build_run_manifest
 from refiner.services.discovery import (
     collect_pipeline_services,
     runtime_service_specs_to_dicts,
@@ -200,7 +201,7 @@ class LocalLauncher(BaseLauncher):
 
         tracking_client = MacrodataClient(api_key=api_key)
         try:
-            manifest = self._run_manifest()
+            manifest = build_run_manifest()
             manifest_environment = cast(
                 dict[str, Any], manifest.setdefault("environment", {})
             )

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -520,6 +520,7 @@ class RefinerPipeline:
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         sync_local_dependencies: bool = True,
+        extra_dependencies: Sequence[str] | None = None,
         secrets: SecretInput | None = None,
         env: Mapping[str, object | None] | None = None,
         continue_from_job: str | None = None,
@@ -533,7 +534,12 @@ class RefinerPipeline:
             cpus_per_worker: Optional requested CPU cores per worker.
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
             gpu: Optional structured GPU request.
-            sync_local_dependencies: Sync submitting environment dependencies in cloud image.
+            sync_local_dependencies: Include packages detected from the local
+                environment in the cloud runtime.
+            extra_dependencies: Additional packages to install in the cloud runtime.
+                Entries are requirement strings such as `"torch"` or
+                `"ego-vision[models]==0.1.2"`. These take precedence over packages
+                detected from the local environment.
             secrets: Secret sources to mount inside the cloud image. A mapping keeps
                 the legacy behavior; `None` values are loaded from the submitting
                 environment. `Secrets.env(...)` references stored workspace secrets.
@@ -555,6 +561,7 @@ class RefinerPipeline:
             mem_mb_per_worker=mem_mb_per_worker,
             gpu=gpu,
             sync_local_dependencies=sync_local_dependencies,
+            extra_dependencies=extra_dependencies,
             secrets=secrets,
             env=dict(env) if env is not None else None,
             continue_from_job=continue_from_job,

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -286,7 +286,6 @@ class CloudRunCreateRequest:
     plan: dict[str, Any]
     stage_payloads: list[StagePayload]
     manifest: dict[str, Any] | None = None
-    sync_local_dependencies: bool = True
     secrets: list[dict[str, Any]] | None = None
     env: dict[str, str] | None = None
     continue_from_job: str | None = None
@@ -295,9 +294,7 @@ class CloudRunCreateRequest:
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "name": self.name,
-            "executor": {
-                "sync_local_dependencies": self.sync_local_dependencies,
-            },
+            "executor": {},
             "plan": self.plan,
             "stage_payloads": [payload.to_dict() for payload in self.stage_payloads],
         }

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -4,6 +4,7 @@ import hashlib
 import inspect
 import json
 import platform
+import re
 import subprocess
 import sys
 from urllib import error as urllib_error
@@ -13,7 +14,10 @@ from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 _REDACTION_PLACEHOLDER = "REDACTED_SECRET"
+_NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN = re.compile(r"[-_.]+")
 
 
 def _redact_captured_text(text: str, *, secret_values: Sequence[str]) -> str:
@@ -90,6 +94,49 @@ def _collect_dependencies() -> list[dict[str, str]]:
     ]
 
 
+def _dependency_key(name: str) -> str:
+    try:
+        package_name = Requirement(name).name
+    except InvalidRequirement:
+        package_name = name.split("[", 1)[0].strip()
+    return _NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN.sub("-", package_name).lower()
+
+
+def _merge_extra_dependencies(
+    dependencies: list[dict[str, str]],
+    extra_dependencies: Sequence[str] | None,
+) -> list[dict[str, str]]:
+    if not extra_dependencies:
+        return dependencies
+    if isinstance(extra_dependencies, str):
+        raise ValueError("extra_dependencies must be a sequence of requirement strings")
+
+    merged = {_dependency_key(dep["name"]): dict(dep) for dep in dependencies}
+    for dependency in extra_dependencies:
+        text = str(dependency).strip()
+        if not text:
+            raise ValueError("extra_dependencies contains an empty dependency name")
+        try:
+            requirement = Requirement(text)
+        except InvalidRequirement as err:
+            raise ValueError(
+                f"extra_dependencies contains invalid requirement {text!r}"
+            ) from err
+
+        specifiers = list(requirement.specifier)
+        if len(specifiers) == 1 and specifiers[0].operator == "==":
+            name = requirement.name
+            if requirement.extras:
+                name = f"{name}[{','.join(sorted(requirement.extras))}]"
+            merged[_dependency_key(requirement.name)] = {
+                "name": name,
+                "version": specifiers[0].version,
+            }
+        else:
+            merged[_dependency_key(requirement.name)] = {"name": text}
+    return list(merged.values())
+
+
 def _resolve_installed_version() -> str | None:
     try:
         version = importlib_metadata.version("macrodata-refiner").strip()
@@ -156,7 +203,12 @@ def refiner_ref_exists_on_remote(ref: str) -> bool:
         return False
 
 
-def build_run_manifest(*, secret_values: Sequence[str] = ()) -> dict[str, Any]:
+def build_run_manifest(
+    *,
+    secret_values: Sequence[str] = (),
+    capture_dependencies: bool = True,
+    extra_dependencies: Sequence[str] | None = None,
+) -> dict[str, Any]:
     script_path = _detect_script_path()
     path, text, sha256 = _read_script(script_path)
     refiner_version = _resolve_installed_version()
@@ -177,8 +229,13 @@ def build_run_manifest(*, secret_values: Sequence[str] = ()) -> dict[str, Any]:
             "refiner_ref": refiner_ref,
             "platform": f"{platform.system().lower()}-{platform.machine().lower()}",
         },
-        "dependencies": _collect_dependencies(),
     }
+    dependencies = _collect_dependencies() if capture_dependencies else []
+    if capture_dependencies or extra_dependencies:
+        manifest["dependencies"] = _merge_extra_dependencies(
+            dependencies,
+            extra_dependencies,
+        )
     return manifest
 
 

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -118,7 +118,7 @@ class _FakeClient:
                     "refiner_version": "0.1.0",
                     "platform": "linux",
                 },
-                "dependencies": [{"name": "pandas", "version": "2.0.0"}],
+                "dependencies": [{"name": "pandas"}],
                 "script": {
                     "path": "pipeline.py",
                     "sha256": "abc123",
@@ -2299,7 +2299,8 @@ def test_jobs_manifest_keeps_runtime_when_extra_sections_requested(
     assert rc == 0
     assert "Runtime" in out.out
     assert "Dependencies: 1 dependency" in out.out
-    assert "pandas==2.0.0" in out.out
+    assert "pandas" in out.out
+    assert "pandas==" not in out.out
     assert "Code" in out.out
     assert "Path: pipeline.py" in out.out
     assert "SHA256: abc123" in out.out
@@ -2351,7 +2352,7 @@ def test_jobs_manifest_json_respects_deps_and_code_flags(monkeypatch, capsys) ->
             manifest = cast(dict[str, Any], payload["manifest"])
             manifest["dependencies"] = [
                 {"name": "pandas", "version": "2.0.0"},
-                {"name": "pyarrow", "version": "17.0.0"},
+                {"name": "pyarrow"},
             ]
             manifest["script"] = {
                 "path": "pipeline.py",
@@ -2389,7 +2390,7 @@ def test_jobs_manifest_json_respects_deps_and_code_flags(monkeypatch, capsys) ->
 
     assert rc == 0
     assert '"dependencyCount": 2' in out.out
-    assert '"dependencies": "pandas==2.0.0\\npyarrow==17.0.0"' in out.out
+    assert '"dependencies": "pandas==2.0.0\\npyarrow"' in out.out
     assert '"text": "print(\'ok\')[31m\\nnext_line()"' in out.out
 
 

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -177,7 +177,7 @@ def _stub_cloud_submit(
         ],
     )
     monkeypatch.setattr(
-        "refiner.launchers.base.build_run_manifest",
+        "refiner.launchers.cloud.build_run_manifest",
         manifest if callable(manifest) else (lambda **_: manifest or {"version": 1}),
     )
     return captured
@@ -213,7 +213,6 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.name == "demo cloud"
-    assert request.sync_local_dependencies is True
     assert request.plan["stages"][0]["name"] == "stage_0"
     assert request.plan["stages"][0]["requested_num_workers"] == 3
     assert request.plan["stages"][0]["cpus_per_worker"] == 2
@@ -318,18 +317,32 @@ def test_gpu_rejects_unsupported_values() -> None:
         GPU(count=1, type="h100", cuda_version="13.0")  # type: ignore[arg-type]
 
 
-def test_pipeline_launch_cloud_can_disable_dependency_install(monkeypatch) -> None:
-    captured = _stub_cloud_submit(monkeypatch)
+def test_pipeline_launch_cloud_can_skip_local_dependency_capture(monkeypatch) -> None:
+    captured_manifest_kwargs = {}
+
+    def manifest(**kwargs):
+        captured_manifest_kwargs.update(kwargs)
+        if kwargs.get("capture_dependencies") is True:
+            return {"version": 1, "dependencies": [{"name": "local", "version": "1"}]}
+        return {"version": 1}
+
+    captured = _stub_cloud_submit(monkeypatch, manifest=manifest)
     monkeypatch.setattr(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
         lambda ref: True,
     )
 
     pipeline = read_jsonl("input.jsonl")
-    pipeline.launch_cloud(name="demo cloud", sync_local_dependencies=False)
+    pipeline.launch_cloud(
+        name="demo cloud",
+        sync_local_dependencies=False,
+        extra_dependencies=["torch"],
+    )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
-    assert request.sync_local_dependencies is False
+    assert request.manifest == {"version": 1}
+    assert captured_manifest_kwargs["capture_dependencies"] is False
+    assert captured_manifest_kwargs["extra_dependencies"] == ["torch"]
 
 
 def test_pipeline_launch_cloud_resolves_secrets(monkeypatch) -> None:
@@ -936,7 +949,7 @@ def test_pipeline_launch_cloud_submits_one_stage_payload_per_planned_stage(
         ],
     )
     monkeypatch.setattr(
-        "refiner.launchers.base.build_run_manifest",
+        "refiner.launchers.cloud.build_run_manifest",
         lambda **_: {"version": 1},
     )
     monkeypatch.setattr(
@@ -988,7 +1001,7 @@ def test_pipeline_launch_cloud_interactive_ref_fallback_accepts(monkeypatch) -> 
 def test_pipeline_launch_cloud_interactive_ref_fallback_rejects(monkeypatch) -> None:
     _stub_cloud_submit(monkeypatch, fail_on_submit=True)
     monkeypatch.setattr(
-        "refiner.launchers.base.build_run_manifest",
+        "refiner.launchers.cloud.build_run_manifest",
         lambda **_: {
             "version": 1,
             "environment": {"refiner_version": "0.2.0", "refiner_ref": "deadbeef"},
@@ -1035,7 +1048,7 @@ def test_pipeline_launch_cloud_noninteractive_ref_fallback_requires_override(
 ) -> None:
     _stub_cloud_submit(monkeypatch, fail_on_submit=True)
     monkeypatch.setattr(
-        "refiner.launchers.base.build_run_manifest",
+        "refiner.launchers.cloud.build_run_manifest",
         lambda **_: {
             "version": 1,
             "environment": {"refiner_version": "0.2.0", "refiner_ref": "deadbeef"},
@@ -1345,7 +1358,6 @@ def test_pipeline_launch_cloud_continue_from_job_posts_submit_request(
     )
     assert request.stage_payloads[0].runtime.num_workers == 3
     assert request.stage_payloads[0].runtime.cpus_per_worker == 2
-    assert request.sync_local_dependencies is True
 
 
 def test_pipeline_launch_cloud_continue_from_job_stage_posts_submit_request(

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -86,7 +86,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
     assert "http_client" in captured
     assert captured["timeout_s"] == 30.0
     json_payload = cast(dict[str, object], captured["json_payload"])
-    assert json_payload["executor"] == {"sync_local_dependencies": True}
+    assert json_payload["executor"] == {}
     stage_payloads = cast(list[dict[str, object]], json_payload["stage_payloads"])
     assert stage_payloads == [
         {
@@ -166,7 +166,6 @@ def test_cloud_client_cloud_submit_job_posts_continue_metadata(monkeypatch) -> N
                 )
             ],
             manifest={"version": 1},
-            sync_local_dependencies=False,
             unsafe_continue=True,
         )
     )
@@ -182,9 +181,7 @@ def test_cloud_client_cloud_submit_job_posts_continue_metadata(monkeypatch) -> N
     json_payload = cast(dict[str, object], captured["json_payload"])
     assert json_payload["name"] == "demo-cloud-job"
     assert json_payload["continue_from_job"] == "00000000-0000-1000-8000-000000000123:2"
-    assert json_payload["executor"] == {
-        "sync_local_dependencies": False,
-    }
+    assert json_payload["executor"] == {}
     assert json_payload["unsafe_continue"] is True
     assert json_payload["plan"] == {"stages": [{"name": "stage_0", "steps": []}]}
     assert json_payload["manifest"] == {"version": 1}

--- a/tests/platform/test_manifest.py
+++ b/tests/platform/test_manifest.py
@@ -7,6 +7,8 @@ from importlib import metadata as importlib_metadata
 from pathlib import Path
 from urllib import error as urllib_error
 
+import pytest
+
 from refiner.platform.manifest import build_run_manifest, refiner_ref_exists_on_remote
 
 
@@ -40,6 +42,122 @@ def test_build_run_manifest_captures_script_from_argv(
     assert manifest["environment"]["refiner_version"] == "0.2.0"
     assert manifest["environment"]["refiner_ref"] == "abc123def456"
     assert isinstance(manifest["dependencies"], list)
+
+
+def test_build_run_manifest_can_skip_dependency_capture(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_installed_version",
+        lambda: "0.2.0",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_direct_url_git_sha",
+        lambda: "abc123def456",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_local_repo_git_sha",
+        lambda: None,
+    )
+
+    manifest = build_run_manifest(capture_dependencies=False)
+
+    assert manifest["version"] == 1
+    assert "dependencies" not in manifest
+
+
+def test_build_run_manifest_merges_extra_dependencies(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_installed_version",
+        lambda: "0.2.0",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_direct_url_git_sha",
+        lambda: "abc123def456",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_local_repo_git_sha",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._collect_dependencies",
+        lambda: [
+            {"name": "cloudpickle", "version": "3.1.2"},
+            {"name": "ego-vision", "version": "0.1.1"},
+            {"name": "Requests", "version": "2.32.5"},
+            {"name": "torch", "version": "2.4.0"},
+        ],
+    )
+
+    manifest = build_run_manifest(
+        extra_dependencies=[
+            "torch==2.6.0",
+            "ego-vision[models]==0.1.2",
+            "new-package",
+            "transformers>=4.55",
+        ],
+    )
+
+    assert manifest["dependencies"] == [
+        {"name": "cloudpickle", "version": "3.1.2"},
+        {"name": "ego-vision[models]", "version": "0.1.2"},
+        {"name": "Requests", "version": "2.32.5"},
+        {"name": "torch", "version": "2.6.0"},
+        {"name": "new-package"},
+        {"name": "transformers>=4.55"},
+    ]
+
+
+def test_build_run_manifest_adds_extra_dependencies_without_capture(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_installed_version",
+        lambda: "0.2.0",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_direct_url_git_sha",
+        lambda: "abc123def456",
+    )
+    monkeypatch.setattr(
+        "refiner.platform.manifest._resolve_local_repo_git_sha",
+        lambda: None,
+    )
+
+    manifest = build_run_manifest(
+        capture_dependencies=False,
+        extra_dependencies=["torch==2.6.0"],
+    )
+
+    assert manifest["dependencies"] == [{"name": "torch", "version": "2.6.0"}]
+
+
+def test_build_run_manifest_rejects_invalid_extra_dependency(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+
+    with pytest.raises(
+        ValueError, match="extra_dependencies contains invalid requirement"
+    ):
+        build_run_manifest(extra_dependencies=["not a requirement"])
 
 
 def test_build_run_manifest_redacts_secret_values(monkeypatch, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1581,6 +1581,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
+    { name = "packaging" },
     { name = "pyarrow" },
     { name = "pydantic" },
 ]
@@ -1678,6 +1679,7 @@ requires-dist = [
     { name = "numcodecs", marker = "extra == 'zarr'", specifier = "<0.16" },
     { name = "numpy" },
     { name = "orjson" },
+    { name = "packaging" },
     { name = "pillow", marker = "extra == 'video'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- add launch_cloud(extra_dependencies=[...]) with pip requirement strings
- merge extra requirements into the submitted manifest, overriding captured local dependencies by package name
- stop sending the removed executor.sync_local_dependencies flag; sync_local_dependencies now only controls local dependency capture
- render versionless manifest dependencies cleanly in the CLI

## Tests
- uv run ruff check src/refiner/launchers/cloud.py src/refiner/pipeline/pipeline.py src/refiner/platform/client/models.py src/refiner/platform/manifest.py src/refiner/launchers/base.py src/refiner/launchers/local.py src/refiner/cli/jobs/manifest.py tests/launchers/test_cloud_launcher.py tests/launchers/test_local_launcher.py tests/platform/test_cloud_client.py tests/platform/test_manifest.py tests/cli/test_job_commands.py examples/egovision_refiner_smoke.py
- uv run ty check src/refiner/launchers/cloud.py src/refiner/pipeline/pipeline.py src/refiner/platform/client/models.py src/refiner/platform/manifest.py src/refiner/launchers/base.py src/refiner/launchers/local.py src/refiner/cli/jobs/manifest.py tests/launchers/test_cloud_launcher.py tests/launchers/test_local_launcher.py tests/platform/test_cloud_client.py tests/platform/test_manifest.py tests/cli/test_job_commands.py
- uv run pytest tests/launchers/test_cloud_launcher.py tests/launchers/test_local_launcher.py tests/platform/test_cloud_client.py tests/platform/test_manifest.py tests/cli/test_job_commands.py -q