### PR TITLE
[codex] add subtask annotation example

### DIFF
--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -9,21 +9,19 @@ description: "Use vision-language models to annotate temporal subtask segments"
 vision-language model to return temporal subtask segments.
 
 ```python
-provider = mdr.inference.VLLMProvider(model="Qwen/Qwen2.5-VL-7B-Instruct")
-
 pipeline = (
     mdr.read_lerobot("hf://datasets/acme/demos")
     .map_async(
         mdr.robotics.subtask_annotation(
-            provider=provider,
             video_key="observation.images.top",
             output_column="predicted_subtasks",
-            sample_sec=0.5,
         ),
-        max_in_flight=64,
     )
 )
 ```
+
+`subtask_annotation` uses Gemini 3.5 Flash through `GoogleEndpointProvider`,
+so you need to provide `GOOGLE_GENERATIVE_AI_API_KEY`.
 
 ## Output Shape
 
@@ -38,8 +36,8 @@ The output column contains a list of segments:
 
 ## Contact Sheets
 
-Contact sheets reduce video into timestamped image grids. This is often cheaper
-and easier for VLMs than sending the full video.
+Contact sheets reduce video into timestamped image grids. We found this to be
+the most efficient way to give VLMs temporal context for subtask annotation.
 
 | Parameter | Meaning |
 | --- | --- |
@@ -47,6 +45,7 @@ and easier for VLMs than sending the full video.
 | `frame_width` | Width of each sampled frame in the sheet. |
 | `frames_per_sheet` | Number of frames per sheet image. |
 | `columns` | Contact sheet grid columns. |
+| `quality` | JPEG quality for generated sheet images, from `1` to `100`. Defaults to `84`. |
 | `include_contact_sheet_manifest` | Add textual sheet descriptions to the prompt. |
 | `min_segment_duration_sec` | Minimum returned segment duration. Defaults to `0.0`, so valid short segments are kept. |
 

--- a/docs/examples/annotate-subtasks.md
+++ b/docs/examples/annotate-subtasks.md
@@ -5,27 +5,47 @@ description: "Add VLM-generated temporal subtask annotations to episodes"
 
 # Annotate Subtasks
 
+This example reads a LeRobot dataset, runs temporal subtask annotation on the
+episode video, writes the predicted segments into a new `predicted_subtasks`
+column, and saves the result back in LeRobot format.
+
 ```python
 import refiner as mdr
 
-provider = mdr.inference.VLLMProvider(
-    model="Qwen/Qwen2.5-VL-7B-Instruct",
-)
+INPUT_DATASET = "hf://datasets/lerobot/berkeley_cable_routing"
+OUTPUT_ROOT = "hf://buckets/macrodata/test_bucket"
+VIDEO_KEY = "observation.images.top_image"
+
 
 pipeline = (
-    mdr.read_lerobot("hf://datasets/acme/raw-demos")
+    mdr.read_lerobot(INPUT_DATASET)
     .map_async(
         mdr.robotics.subtask_annotation(
-            provider=provider,
-            video_key="observation.images.top",
+            video_key=VIDEO_KEY,
             output_column="predicted_subtasks",
         ),
-        max_in_flight=64,
     )
-    .write_lerobot("hf://buckets/acme-robotics/demos-with-subtasks")
+    .write_lerobot(f"{OUTPUT_ROOT}/berkeley-cable-routing-subtasks")
+)
+
+pipeline.launch_cloud(
+    name="berkeley-subtask-annotation",
+    num_workers=4,
+    cpus_per_worker=1,
+    mem_mb_per_worker=2048,
+    secrets=[
+        mdr.Secrets.env(keys=["HF_TOKEN"]),
+        {"GOOGLE_GENERATIVE_AI_API_KEY": None},
+    ],
 )
 ```
 
+`HF_TOKEN` is passed through from the default Macrodata Cloud environment so the
+workers can read and write Hugging Face datasets and buckets without embedding
+the token in the script. `GOOGLE_GENERATIVE_AI_API_KEY` is declared as a secret
+that must be supplied by the launch environment because `subtask_annotation`
+uses Gemini 3.5 Flash through `GoogleEndpointProvider`.
+
 Use [Subtask Annotation](../episode-operations/subtask-annotation.md) for
-parameter details and [Providers and VLLM](../inference/providers-and-vllm.md)
-for model setup.
+parameter details. `subtask_annotation` uses Gemini 3.5 Flash through
+`GoogleEndpointProvider`, so you need to provide `GOOGLE_GENERATIVE_AI_API_KEY`.

--- a/examples/lerobot/subtask_annotation.py
+++ b/examples/lerobot/subtask_annotation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import refiner as mdr
+
+INPUT_DATASET = "hf://datasets/lerobot/berkeley_cable_routing"
+OUTPUT_ROOT = "hf://buckets/macrodata/test_bucket"
+VIDEO_KEY = "observation.images.top_image"
+
+
+run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+output = f"{OUTPUT_ROOT}/berkeley-cable-routing-subtasks-{run_id}"
+
+pipeline = (
+    mdr.read_lerobot(INPUT_DATASET)
+    .map_async(
+        mdr.robotics.subtask_annotation(
+            video_key=VIDEO_KEY,
+            output_column="predicted_subtasks",
+        ),
+    )
+    .write_lerobot(output)
+)
+
+pipeline.launch_cloud(
+    name="berkeley-subtask-annotation",
+    num_workers=4,
+    cpus_per_worker=1,
+    mem_mb_per_worker=2048,
+    secrets=[
+        mdr.Secrets.env(keys=["HF_TOKEN"]),
+        {"GOOGLE_GENERATIVE_AI_API_KEY": None},
+    ],
+    env={
+        "SUBTASK_ANNOTATION_INPUT_DATASET": INPUT_DATASET,
+        "SUBTASK_ANNOTATION_VIDEO_KEY": VIDEO_KEY,
+        "SUBTASK_ANNOTATION_OUTPUT": output,
+    },
+)

--- a/src/refiner/inference/providers/base.py
+++ b/src/refiner/inference/providers/base.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from refiner.services import VLLMServiceDefinition
+if TYPE_CHECKING:
+    from refiner.services import VLLMServiceDefinition
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,6 +113,8 @@ class VLLMProvider:
             raise ValueError("config must be 'throughput'")
 
     def service_definition(self) -> VLLMServiceDefinition:
+        from refiner.services import VLLMServiceDefinition
+
         return VLLMServiceDefinition(
             model_name_or_path=self.model,
             config=self.config,

--- a/src/refiner/robotics/subtask_annotation.py
+++ b/src/refiner/robotics/subtask_annotation.py
@@ -11,6 +11,7 @@ from typing import Any, TypeAlias, cast
 
 from pydantic import BaseModel
 
+from refiner.inference.providers import GoogleEndpointProvider
 from refiner.inference.types import Message, ProviderOptions
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.steps import MapResult
@@ -23,7 +24,6 @@ if TYPE_CHECKING:
     from refiner.inference.generate_text import GenerateTextFn
     from refiner.inference.providers import (
         AnthropicEndpointProvider,
-        GoogleEndpointProvider,
         OpenAIEndpointProvider,
         OpenAIResponsesProvider,
         VLLMProvider,
@@ -99,7 +99,9 @@ class TimestampedContactSheet:
 
 def subtask_annotation(
     *,
-    provider: SubtaskAnnotationProvider,
+    provider: SubtaskAnnotationProvider = GoogleEndpointProvider(
+        model="gemini-3.5-flash"
+    ),
     video_key: str | None = None,
     output_column: str = "predicted_subtasks",
     sample_sec: float = 0.5,

--- a/tests/robotics/test_subtask_annotation.py
+++ b/tests/robotics/test_subtask_annotation.py
@@ -163,6 +163,23 @@ def test_subtask_annotation_builds_generate_text_block(monkeypatch) -> None:
     assert callable(seen["fn"])
 
 
+def test_subtask_annotation_defaults_to_google_provider(monkeypatch) -> None:
+    seen = {}
+
+    def _fake_generate_text(**kwargs):
+        seen.update(kwargs)
+        return "annotation-block"
+
+    monkeypatch.setattr(inference_module, "generate_text", _fake_generate_text)
+
+    block = mdr.robotics.subtask_annotation()
+
+    assert block == "annotation-block"
+    assert isinstance(seen["provider"], mdr.inference.GoogleEndpointProvider)
+    assert seen["provider"].model == "gemini-3.5-flash"
+    assert callable(seen["fn"])
+
+
 def test_subtask_annotation_block_updates_row(tmp_path, monkeypatch) -> None:
     seen = {}
 


### PR DESCRIPTION
## Summary

- Make `robotics.subtask_annotation()` default to Gemini 3.5 Flash via `GoogleEndpointProvider`, while still allowing an explicit provider override.
- Add a LeRobot cloud example for subtask annotation that uses the default provider and Macrodata Cloud secrets.
- Update the subtask annotation docs/example to show the provider-free path and the required cloud secrets.

## Validation

- `uv run ruff check --force-exclude src/refiner/robotics/subtask_annotation.py tests/robotics/test_subtask_annotation.py examples/lerobot/subtask_annotation.py`
- `uv run pytest tests/robotics/test_subtask_annotation.py -q`
- `uv run pre-commit run --files src/refiner/robotics/subtask_annotation.py tests/robotics/test_subtask_annotation.py examples/lerobot/subtask_annotation.py docs/episode-operations/subtask-annotation.md docs/examples/annotate-subtasks.md`
