### PR TITLE
Add lazy video frame sequences

### DIFF
--- a/docs/episode-data/frames-and-videos.md
+++ b/docs/episode-data/frames-and-videos.md
@@ -48,8 +48,8 @@ for key, video in row.videos.items():
     print(key, video)
 ```
 
-Video sources may be path-backed files, bytes, or in-memory frame arrays. They
-share the same core operations:
+Video sources may be path-backed files, bytes, in-memory frame arrays, or frame
+sequences. They share the same core operations:
 
 | Operation | Purpose |
 | --- | --- |
@@ -77,4 +77,3 @@ whether to remux or transcode the selected time range.
 - [Files and Videos Reader](../reading-data/files-and-videos.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)
 - [Motion Trimming](../episode-operations/motion-trimming.md)
-

--- a/docs/reading-data/mcap.md
+++ b/docs/reading-data/mcap.md
@@ -49,7 +49,7 @@ Each row includes:
 | `file_path` | Source MCAP file path. |
 | `episode_index` | Episode number within the file. |
 | `records` | `Tabular` records table. |
-| `videos` | Mapping of selected video names to `VideoFrameArray` values, when `videos` is set. |
+| `videos` | Mapping of selected video names to video source values, when `videos` is set. |
 | `fps` | Explicit fps, or inferred fps when possible. |
 
 ## Episode Splitting
@@ -233,7 +233,7 @@ mdr.read_mcap("run.mcap", sync_primary="state", fps=30)
 If `fps` is omitted and `sync_primary` is set, the reader infers fps from the
 median gap between sync-primary timestamps. If neither explicit fps nor inferred fps is
 available, the row has no `fps` column. Selected videos still need an fps value,
-so video frame arrays fall back to `30` when no better value is available. Near
+so video sources fall back to `30` when no better value is available. Near
 integer inferred rates are normalized, so nanosecond-rounded `30 fps` timelines
 do not become `30.0000003`.
 
@@ -250,7 +250,7 @@ mdr.read_mcap(
 )
 ```
 
-Each selected video becomes a `VideoFrameArray` under the row's `videos` column.
+Each selected video becomes a frame sequence under the row's `videos` column.
 When you later call `to_robot_rows`, map those values into semantic video keys:
 
 ```python

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -938,7 +938,7 @@ def read_mcap(
 
     Each emitted row represents one episode and contains a `records` `Tabular`
     table. When `videos` is set, rows also include a `videos` mapping of
-    selected names to `VideoFrameArray` values. Set `sync_primary` to align
+    selected names to video source values. Set `sync_primary` to align
     records and videos to a field, topic, or video timeline; otherwise selected
     fields are emitted sparsely at their original MCAP log timestamps.
 

--- a/src/refiner/pipeline/sources/readers/mcap.py
+++ b/src/refiner/pipeline/sources/readers/mcap.py
@@ -31,7 +31,7 @@ from refiner.robotics.synchronization import (
     sparse_frame_table,
 )
 from refiner.utils import check_required_dependencies
-from refiner.video import VideoFrameArray, decode_raw_h264_frames
+from refiner.video import VideoFrameSequence, decode_raw_h264_frames
 
 _RESERVED_FRAME_COLUMNS = frozenset({"frame_index", "timestamp"})
 _ROW_COLUMNS = frozenset({"records", "episode_index", "videos", "fps"})
@@ -763,8 +763,8 @@ def _video_map(
     sync_primary: tuple[str, str | None] | None,
     sync_method: SyncMethod,
     fps: float,
-) -> dict[str, VideoFrameArray]:
-    out: dict[str, VideoFrameArray] = {}
+) -> dict[str, VideoFrameSequence]:
+    out: dict[str, VideoFrameSequence] = {}
     sync_primary_timestamps = (
         [event[0] for event in sync_primary_events]
         if sync_primary_events is not None
@@ -772,50 +772,75 @@ def _video_map(
     )
     for name, source in videos.items():
         events = topic_events.get(source[0], ())
+        frame_events = None
+        aligned_frame_events = None
+        predecoded = False
         if sync_primary is not None and source == sync_primary:
             source_events = sync_primary_events or ()
             h264_events = _h264_frame_events(source_events, source[1])
-            frames = (
-                [event[1] for event in h264_events]
-                if h264_events is not None
-                else [
-                    _frame_from_value(source_value(event[1], source[1]))
-                    for event in source_events
-                ]
-            )
+            if h264_events is not None:
+                frame_events = h264_events
+                predecoded = True
+            else:
+                frame_events = source_events
+            frame_count = len(frame_events)
+
         elif sync_primary_timestamps is not None:
             video_sync_method: SyncMethod = (
                 "nearest" if sync_method == "interpolate" else sync_method
             )
             h264_events = _h264_frame_events(events, source[1])
-            frames = []
-            for aligned in align_values(
-                h264_events if h264_events is not None else events,
+            predecoded = h264_events is not None
+            aligned_events = align_values(
+                h264_events if h264_events is not None else tuple(events),
                 sync_primary_timestamps,
                 None if h264_events is not None else source[1],
                 method=video_sync_method,
-            ):
-                if aligned is None:
-                    raise ValueError(
-                        f"MCAP video {name!r} has no aligned frame for a sync_primary row"
-                    )
-                frames.append(
-                    aligned.value
-                    if h264_events is not None
-                    else _frame_from_value(aligned.value)
+            )
+            if any(aligned is None for aligned in aligned_events):
+                raise ValueError(
+                    f"MCAP video {name!r} has no aligned frame for a sync_primary row"
                 )
+            aligned_frame_events = [
+                aligned for aligned in aligned_events if aligned is not None
+            ]
+            frame_count = len(sync_primary_timestamps)
+
         else:
             h264_events = _h264_frame_events(events, source[1])
-            frames = (
-                [event[1] for event in h264_events]
-                if h264_events is not None
-                else [
-                    _frame_from_value(source_value(event[1], source[1]))
-                    for event in sorted(events, key=lambda event: event[0])
-                ]
-            )
-        if frames:
-            out[name] = VideoFrameArray(np.stack(frames), fps=fps)
+            sorted_events = tuple(sorted(events, key=lambda event: event[0]))
+            if h264_events is not None:
+                frame_events = h264_events
+                predecoded = True
+            else:
+                frame_events = sorted_events
+            frame_count = len(frame_events)
+
+        if frame_count:
+
+            def frames(
+                frame_events=frame_events,
+                aligned_frame_events=aligned_frame_events,
+                field_path=source[1],
+                predecoded=predecoded,
+            ):
+                if aligned_frame_events is not None:
+                    for aligned in aligned_frame_events:
+                        yield (
+                            aligned.value
+                            if predecoded
+                            else _frame_from_value(aligned.value)
+                        )
+                    return
+                assert frame_events is not None
+                for _timestamp_ns, value in frame_events:
+                    yield (
+                        value
+                        if predecoded
+                        else _frame_from_value(source_value(value, field_path))
+                    )
+
+            out[name] = VideoFrameSequence(frames, fps=fps, frame_count=frame_count)
     return out
 
 

--- a/src/refiner/video/__init__.py
+++ b/src/refiner/video/__init__.py
@@ -26,6 +26,7 @@ from refiner.video.types import (
     VideoBytes,
     VideoFile,
     VideoFrameArray,
+    VideoFrameSequence,
     VideoSource,
     video_from_storage_value,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "VideoFile",
     "VideoBytes",
     "VideoFrameArray",
+    "VideoFrameSequence",
     "VideoSource",
     "video_from_storage_value",
     "VideoPtsAlignment",

--- a/src/refiner/video/decode.py
+++ b/src/refiner/video/decode.py
@@ -55,11 +55,11 @@ async def export_clip(
     transcode_config: VideoTranscodeConfig | None = None,
 ) -> bytes:
     from refiner.video.transcode import TranscodeWriter, VideoTranscodeConfig
-    from refiner.video.types import VideoFrameArray
+    from refiner.video.types import VideoFrameArray, VideoFrameSequence
 
     output_file = _NonClosingBytesIO()
     config = transcode_config or VideoTranscodeConfig()
-    if isinstance(video, VideoFrameArray):
+    if isinstance(video, VideoFrameArray | VideoFrameSequence):
         writer = TranscodeWriter.open_file(
             output_file=output_file,
             config=config,

--- a/src/refiner/video/types.py
+++ b/src/refiner/video/types.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 import io
 import math
-from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from dataclasses import dataclass, field
 from fractions import Fraction
-from typing import IO, TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import IO, TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 import numpy as np
 
@@ -213,6 +220,164 @@ class VideoBytes:
 
 
 @dataclass(frozen=True, slots=True, eq=False)
+class VideoFrameSequence:
+    """Video source backed by an iterable of RGB frame arrays."""
+
+    frames: Callable[[], Iterable[Any]] | Iterable[Any] = field(
+        repr=False, compare=False
+    )
+    fps: float = 30.0
+    frame_count: int | None = None
+    from_timestamp_s: float | None = None
+    to_timestamp_s: float | None = None
+
+    def __post_init__(self) -> None:
+        fps = float(self.fps)
+        if not math.isfinite(fps) or fps <= 0:
+            raise ValueError("fps must be > 0")
+        if self.frame_count is not None and self.frame_count < 0:
+            raise ValueError("frame_count must be >= 0")
+        source = self.frames
+        if not callable(source) and iter(source) is source:
+            raise ValueError(
+                "frames must be repeatable; pass a callable that returns a fresh iterator"
+            )
+        object.__setattr__(self, "fps", fps)
+
+    @property
+    def duration_s(self) -> float | None:
+        if self.frame_count is None:
+            return None
+        return self.frame_count / float(self.fps)
+
+    def iter_frame_arrays(self) -> Iterator[np.ndarray]:
+        start_idx = (
+            0
+            if self.from_timestamp_s is None
+            else max(0, int(math.floor(float(self.from_timestamp_s) * self.fps)))
+        )
+        if self.to_timestamp_s is not None:
+            end_idx = max(
+                start_idx, int(math.ceil(float(self.to_timestamp_s) * self.fps))
+            )
+        elif self.frame_count is not None:
+            end_idx = start_idx + self.frame_count
+        else:
+            end_idx = None
+        source = self.frames
+        frames = (
+            cast(Callable[[], Iterable[Any]], source)() if callable(source) else source
+        )
+        for index, frame in enumerate(frames):
+            if index < start_idx:
+                continue
+            if end_idx is not None and index >= end_idx:
+                break
+            array = np.asarray(frame)
+            if array.ndim != 3 or int(array.shape[2]) != 3:
+                raise ValueError(
+                    "video frames must have shape [height, width, channels=3]"
+                )
+            if array.dtype != np.uint8:
+                array = np.clip(array, 0, 255).astype(np.uint8)
+            if not array.flags.c_contiguous:
+                array = np.ascontiguousarray(array)
+            yield array
+
+    async def iter_numpy_frames(self) -> AsyncIterator[np.ndarray]:
+        for frame in self.iter_frame_arrays():
+            yield frame
+
+    def clipped(
+        self,
+        *,
+        from_timestamp_s: float | None = None,
+        to_timestamp_s: float | None = None,
+    ) -> "VideoFrameSequence":
+        next_from, next_to = _compose_clip_bounds(
+            current_from=self.from_timestamp_s,
+            current_to=self.to_timestamp_s,
+            from_timestamp_s=from_timestamp_s,
+            to_timestamp_s=to_timestamp_s,
+        )
+        frame_count = self.frame_count
+        if frame_count is not None:
+            next_from_s = float(next_from or 0.0)
+            view_from = float(self.from_timestamp_s or 0.0)
+            view_to = (
+                float(self.to_timestamp_s)
+                if self.to_timestamp_s is not None
+                else view_from + frame_count / float(self.fps)
+            )
+            if next_from_s > view_to or (
+                next_to is not None and next_to > view_to + 1e-6
+            ):
+                raise ValueError("clip bounds are beyond the current video view")
+            effective_to = view_to if next_to is None else next_to
+            start_idx = max(0, int(math.floor(next_from_s * self.fps)))
+            end_idx = max(start_idx, int(math.ceil(float(effective_to) * self.fps)))
+            frame_count = end_idx - start_idx
+        return VideoFrameSequence(
+            self.frames,
+            fps=self.fps,
+            frame_count=frame_count,
+            from_timestamp_s=next_from,
+            to_timestamp_s=next_to,
+        )
+
+    async def iter_frames(self) -> AsyncIterator[DecodedVideoFrame]:
+        import av
+        from refiner.video.decode import DecodedVideoFrame
+
+        start_idx = (
+            0
+            if self.from_timestamp_s is None
+            else max(0, int(math.floor(float(self.from_timestamp_s) * self.fps)))
+        )
+        rate = Fraction(self.fps).limit_denominator(100000)
+        for offset, frame_array in enumerate(self.iter_frame_arrays()):
+            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            frame.pts = start_idx + offset
+            frame.time_base = Fraction(rate.denominator, rate.numerator)
+            yield DecodedVideoFrame(
+                index=offset,
+                pts=offset,
+                timestamp_s=offset / float(self.fps),
+                width=int(frame.width),
+                height=int(frame.height),
+                frame=frame,
+            )
+
+    def iter_frame_windows(
+        self,
+        *,
+        offsets: Sequence[int],
+        stride: int = 1,
+        drop_incomplete: bool = True,
+    ) -> AsyncIterator[DecodedFrameWindow]:
+        from refiner.video.decode import iter_frame_windows
+
+        return iter_frame_windows(
+            self,
+            offsets=offsets,
+            stride=stride,
+            drop_incomplete=drop_incomplete,
+        )
+
+    async def write_to(
+        self,
+        writer: VideoStreamWriter,
+        *,
+        frame_observer: FrameObserver | None = None,
+        force_transcode: bool = False,
+    ) -> WrittenVideo:
+        return await writer.write_frame_array_video(
+            self,
+            frame_observer=frame_observer,
+        )
+
+
+@dataclass(frozen=True, slots=True, eq=False)
 class VideoFrameArray:
     frames: Any = field(repr=False, compare=False)
     fps: float = 30.0
@@ -349,6 +514,7 @@ __all__ = [
     "VideoBytes",
     "VideoFile",
     "VideoFrameArray",
+    "VideoFrameSequence",
     "VideoSource",
     "video_from_storage_value",
 ]

--- a/src/refiner/video/writer.py
+++ b/src/refiner/video/writer.py
@@ -21,7 +21,12 @@ from refiner.video.transcode import (
     TranscodeWriter,
     VideoTranscodeConfig,
 )
-from refiner.video.types import VideoBytes, VideoFile, VideoFrameArray
+from refiner.video.types import (
+    VideoBytes,
+    VideoFile,
+    VideoFrameArray,
+    VideoFrameSequence,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,7 +81,7 @@ class VideoStreamWriter:
 
     async def write_frame_array_video(
         self,
-        video: VideoFrameArray,
+        video: VideoFrameArray | VideoFrameSequence,
         *,
         frame_observer: FrameObserver | None = None,
     ) -> WrittenVideo:
@@ -117,7 +122,7 @@ class VideoStreamWriter:
 
     async def _commit_frame_arrays(
         self,
-        video: VideoFrameArray,
+        video: VideoFrameArray | VideoFrameSequence,
         *,
         frame_observer: FrameObserver | None,
     ) -> WrittenVideo:
@@ -134,7 +139,7 @@ class VideoStreamWriter:
 
     def _commit_frame_arrays_sync(
         self,
-        video: VideoFrameArray,
+        video: VideoFrameArray | VideoFrameSequence,
         *,
         frame_observer: FrameObserver | None,
     ) -> WrittenVideo:

--- a/tests/readers/test_mcap_reader.py
+++ b/tests/readers/test_mcap_reader.py
@@ -15,7 +15,7 @@ from refiner.pipeline.sources.readers.mcap import _frame_from_value, _ros_image_
 from refiner.pipeline.sources.readers import mcap as mcap_reader
 from refiner.pipeline.sources.readers import McapReader
 from refiner.robotics.row import RoboticsRow
-from refiner.video import VideoFrameArray
+from refiner.video import VideoFrameSequence
 
 mcap_writer = pytest.importorskip("mcap.writer")
 
@@ -894,7 +894,7 @@ def test_mcap_reader_builds_video_frame_arrays_for_robot_rows(tmp_path: Path) ->
     assert robot_row.fps == 12
     assert robot_row.states.to_pylist() == [[1, 2], [3, 4], [5, 6]]
     video = robot_row.videos["observation.images.front"]
-    assert isinstance(video, VideoFrameArray)
+    assert isinstance(video, VideoFrameSequence)
     assert video.frame_count == 3
     assert video.fps == 12
     assert [frame[0, 0].tolist() for frame in video.iter_frame_arrays()] == [
@@ -919,6 +919,7 @@ def test_mcap_reader_decodes_h264_video_messages(tmp_path: Path) -> None:
     assert row["records"].column("timestamp").to_pylist() == [0.0, 0.5]
     assert row["records"].column("state").to_pylist() == [[1], [2]]
     video = row["videos"]["front"]
+    assert isinstance(video, VideoFrameSequence)
     assert video.frame_count == 2
     red, green = [frame[0, 0] for frame in video.iter_frame_arrays()]
     assert red[0] > 200 and red[1] < 20 and red[2] < 20
@@ -932,6 +933,7 @@ def test_mcap_reader_omits_video_topics_from_default_fields(tmp_path: Path) -> N
     row = read_mcap(str(path), videos={"front": "/image.frame"}).materialize()[0]
 
     assert "/image.frame" not in row["records"].table.column_names
+    assert isinstance(row["videos"]["front"], VideoFrameSequence)
     assert row["videos"]["front"].frame_count == 2
 
 

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -2025,6 +2025,57 @@ def test_write_zarr_materializes_frame_array_videos(tmp_path: Path) -> None:
     np.testing.assert_allclose(row["action"], [[0.0], [0.1]])
 
 
+def test_write_zarr_streams_frame_sequence_videos(tmp_path: Path) -> None:
+    output = tmp_path / "video-sequence.zarr"
+    frames = np.arange(2 * 4 * 4 * 3, dtype=np.uint8).reshape(2, 4, 4, 3)
+    calls = 0
+
+    def iter_frames():
+        nonlocal calls
+        calls += 1
+        yield from frames
+
+    rows = list(
+        mdr.from_items(
+            [
+                {
+                    "episode_id": "episode-1",
+                    "video": mdr.video.VideoFrameSequence(
+                        iter_frames, fps=10, frame_count=2
+                    ),
+                    "action": [[0.0], [0.1]],
+                }
+            ]
+        ).to_robot_rows(
+            episode_id_key="episode_id",
+            action_key="action",
+            state_key=None,
+            timestamp_key=None,
+            video_keys={"observation.images.front": "video"},
+            fps=10,
+        )
+    )
+
+    ZarrSink(
+        str(output),
+        arrays={
+            "data/action": "action",
+            "data/rgb": "observation.images.front",
+        },
+        reduce_to_single_store=False,
+    ).write_block(rows)
+
+    zarr_store = next(output.glob("*.zarr"))
+    row = mdr.read_zarr(
+        zarr_store,
+        arrays={"action": "data/action", "rgb": "data/rgb"},
+        file_path_column=None,
+    ).take(1)[0]
+    np.testing.assert_array_equal(row["rgb"], frames)
+    np.testing.assert_allclose(row["action"], [[0.0], [0.1]])
+    assert calls == 1
+
+
 def test_write_zarr_defaults_include_robotics_videos(tmp_path: Path) -> None:
     output = tmp_path / "default-video.zarr"
     frames = np.arange(2 * 4 * 4 * 3, dtype=np.uint8).reshape(2, 4, 4, 3)

--- a/tests/test_video_decode.py
+++ b/tests/test_video_decode.py
@@ -93,6 +93,50 @@ def test_video_frame_array_iter_frames() -> None:
     assert [int(frame[0, 0, 0]) for frame in arrays] == [0, 1, 2]
 
 
+def test_video_frame_sequence_iterates_without_stacking() -> None:
+    calls = 0
+
+    def frames():
+        nonlocal calls
+        for value in range(3):
+            calls += 1
+            yield np.full((4, 4, 3), value, dtype=np.uint8)
+
+    video = mdr.video.VideoFrameSequence(frames, fps=5, frame_count=3)
+
+    decoded = asyncio.run(_collect_frames(video))
+    arrays = list(video.iter_frame_arrays())
+
+    assert video.frame_count == 3
+    assert [frame.index for frame in decoded] == [0, 1, 2]
+    assert [frame.timestamp_s for frame in decoded] == [0.0, 0.2, 0.4]
+    assert [int(frame[0, 0, 0]) for frame in arrays] == [0, 1, 2]
+    assert calls == 6
+
+
+def test_video_frame_sequence_rejects_one_shot_iterators() -> None:
+    frames = (np.full((4, 4, 3), value, dtype=np.uint8) for value in range(3))
+
+    with pytest.raises(ValueError, match="frames must be repeatable"):
+        mdr.video.VideoFrameSequence(frames, fps=5, frame_count=3)
+
+
+def test_video_frame_sequence_clips_frame_count() -> None:
+    video = mdr.video.VideoFrameSequence(
+        lambda: (np.full((4, 4, 3), value, dtype=np.uint8) for value in range(5)),
+        fps=2,
+        frame_count=5,
+    )
+
+    clipped = video.clipped(from_timestamp_s=0.5, to_timestamp_s=1.5)
+    decoded = asyncio.run(_collect_frames(clipped))
+
+    assert clipped.frame_count == 2
+    assert [int(frame[0, 0, 0]) for frame in clipped.iter_frame_arrays()] == [1, 2]
+    assert [frame.index for frame in decoded] == [0, 1]
+    assert [frame.timestamp_s for frame in decoded] == [0.0, 0.5]
+
+
 def test_video_frame_array_preserves_fractional_fps() -> None:
     frames = np.stack([np.full((4, 4, 3), value, dtype=np.uint8) for value in range(3)])
     video = mdr.video.VideoFrameArray(frames, fps=29.97)
@@ -107,6 +151,27 @@ def test_video_stream_writer_accepts_video_frame_array(tmp_path) -> None:
     video = mdr.video.VideoFrameArray(
         np.stack([np.full((8, 8, 3), value, dtype=np.uint8) for value in range(4)]),
         fps=29.97,
+    )
+    writer = VideoStreamWriter(
+        folder=DataFolder.resolve(tmp_path),
+        stream_key="camera",
+        transcode_config=VideoTranscodeConfig(),
+        video_bytes_limit=1024 * 1024,
+        output_rel_template="videos/{stream_key}/file-{file_index:03d}.mp4",
+    )
+
+    written = asyncio.run(video.write_to(writer))
+    writer.close()
+
+    assert written.segment.fps == 29.97
+    assert written.segment.to_timestamp == pytest.approx(4 / 29.97)
+
+
+def test_video_stream_writer_accepts_video_frame_sequence(tmp_path) -> None:
+    video = mdr.video.VideoFrameSequence(
+        lambda: (np.full((8, 8, 3), value, dtype=np.uint8) for value in range(4)),
+        fps=29.97,
+        frame_count=4,
     )
     writer = VideoStreamWriter(
         folder=DataFolder.resolve(tmp_path),


### PR DESCRIPTION
## Summary
- add VideoFrameSequence as a VideoSource backed by iterable RGB frames
- switch MCAP video outputs from eager VideoFrameArray stacking to lazy frame sequences
- keep writer/export/Zarr paths working with frame sequences and update MCAP docs

## Tests
- uv run ruff check src/refiner/video/types.py src/refiner/video/writer.py src/refiner/video/decode.py src/refiner/video/__init__.py src/refiner/pipeline/sources/readers/mcap.py src/refiner/pipeline/pipeline.py tests/test_video_decode.py tests/readers/test_mcap_reader.py tests/readers/test_zarr_reader.py
- uv run ty check src/refiner/video/types.py src/refiner/video/writer.py src/refiner/video/decode.py src/refiner/pipeline/sources/readers/mcap.py src/refiner/pipeline/pipeline.py tests/test_video_decode.py tests/readers/test_mcap_reader.py tests/readers/test_zarr_reader.py
- uv run pytest tests/test_video_decode.py tests/readers/test_mcap_reader.py tests/readers/test_zarr_reader.py