### PR TITLE
Bump refiner version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.2.2"
+version = "0.3.0"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1673,7 +1673,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
## Summary
- bump macrodata-refiner package version to 0.3.0
- update the uv lockfile package entry

## Validation
- uv run python -c 'import importlib.metadata; print(importlib.metadata.version("macrodata-refiner"))'