### PR TITLE
[codex] fix async rows processed metric

### DIFF
--- a/src/refiner/execution/operators/row.py
+++ b/src/refiner/execution/operators/row.py
@@ -95,11 +95,16 @@ def execute_row_steps(
                 if window is None:
                     return
                 for row in inp.take_all():
-                    row.log_throughput("rows_processed", 1, unit="rows")
                     window.submit_blocking(_run_async_step(step=step, row=row))
-                out.extend(window.take_completed())
+                completed_rows = window.take_completed()
+                for row in completed_rows:
+                    row.log_throughput("rows_processed", 1, unit="rows")
+                out.extend(completed_rows)
                 if flush_all:
-                    out.extend(window.drain())
+                    drained_rows = window.drain()
+                    for row in drained_rows:
+                        row.log_throughput("rows_processed", 1, unit="rows")
+                    out.extend(drained_rows)
                 return
 
             if isinstance(step, FilterRowStep):


### PR DESCRIPTION
## Summary

Fix `map_async` step metrics so `rows_processed` increments only after an async row completes and leaves the async window.

## Root Cause

`execute_row_steps` emitted `rows_processed` before calling `window.submit_blocking(...)` for async row steps. That made the metric count rows accepted into the async window rather than rows whose async work completed, which was misleading when `in_flight` was high and no reward/model calls had finished yet.

## Changes

- Move async `rows_processed` emission to completed rows returned by `window.take_completed()` and `window.drain()`.
- Keep the PR diff limited to `src/refiner/execution/operators/row.py`.

## Validation

- `uv run pytest tests/execution/test_async_row.py tests/worker/test_runner.py`
- `uv run ruff check --force-exclude src/refiner/execution/operators/row.py`
- `uv run ty check src/refiner/execution/operators/row.py`