### PR TITLE
Limit Robometer pooling backpressure

### DIFF
--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -91,7 +91,8 @@ class AsyncWindow(Generic[T]):
         while self._futures and (
             return_when == ALL_COMPLETED or len(self._futures) >= self.max_in_flight
         ):
-            done, _ = wait(self._futures, return_when=return_when)
+            wait_mode = FIRST_COMPLETED if return_when == ALL_COMPLETED else return_when
+            done, _ = wait(self._futures, return_when=wait_mode)
             self._collect_done(done)
 
     def _store_result(self, idx: int, value: T) -> None:

--- a/src/refiner/inference/internal/runtime.py
+++ b/src/refiner/inference/internal/runtime.py
@@ -119,7 +119,6 @@ def inference_map(
                     base_url=binding.endpoint,
                     api_key=binding.api_key,
                 )
-            _register_metrics()
             return client
 
     async def _request(row: Row, payload: Mapping[str, Any]) -> Any:
@@ -130,18 +129,22 @@ def inference_map(
         }
         if not isinstance(provider, GoogleEndpointProvider):
             request_payload = {"model": provider.model, **request_payload}
-        resolved_client = await _client()
+        _register_metrics()
         waiting_requests += 1
         await semaphore.acquire()
         waiting_requests -= 1
-        running_requests += 1
+        request_running = False
         try:
+            resolved_client = await _client()
+            running_requests += 1
+            request_running = True
             response = await call(resolved_client, request_payload)
         except Exception:
             row.log_throughput("failed_requests", 1, unit="requests")
             raise
         finally:
-            running_requests -= 1
+            if request_running:
+                running_requests -= 1
             semaphore.release()
         row.log_throughput("successful_requests", 1, unit="requests")
         if record is not None:

--- a/src/refiner/robotics/reward.py
+++ b/src/refiner/robotics/reward.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import io
 import math
+import time
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -17,6 +18,7 @@ else:
     GeneratePoolingFn = Callable[[Mapping[str, Any]], Any]
 
 _DEFAULT_ROBOMETER_MODEL = "aliangdw/Robometer-4B"
+_DEFAULT_MAX_CONCURRENT_REQUESTS = 4
 _PROGRESS_TOKEN = "<|prog_token|>"
 
 
@@ -31,7 +33,7 @@ def reward_score(
     max_frames: int = 8,
     output_column: str = "reward_score",
     success_column: str = "robometer_success",
-    max_concurrent_requests: int = 256,
+    max_concurrent_requests: int = _DEFAULT_MAX_CONCURRENT_REQUESTS,
 ) -> Callable[[Row], Any]:
     """Return an async map function that scores LeRobot episodes with Robometer."""
 
@@ -57,15 +59,23 @@ def reward_score(
             raise TypeError("reward_score expects rows from read_lerobot(...)")
 
         selected_video_key = _resolve_video_key(row, video_key)
+        sample_t0 = time.perf_counter()
         frames = await _sample_video_frames(
             row,
             video_key=selected_video_key,
             max_frames=max_frames,
         )
+        row.log_histogram(
+            "robometer_video_sample_seconds",
+            time.perf_counter() - sample_t0,
+            unit="seconds",
+        )
+        row.log_histogram("robometer_sampled_frames", len(frames), unit="frames")
         task_text = _resolve_task_text(row, task)
         content: list[dict[str, Any]] = [
             {"type": "text", "text": _robometer_progress_prompt(task_text)}
         ]
+        encode_t0 = time.perf_counter()
         for frame in frames:
             content.append(
                 {
@@ -74,7 +84,13 @@ def reward_score(
                 }
             )
             content.append({"type": "text", "text": _PROGRESS_TOKEN})
+        row.log_histogram(
+            "robometer_frame_encode_seconds",
+            time.perf_counter() - encode_t0,
+            unit="seconds",
+        )
 
+        request_t0 = time.perf_counter()
         response = await generate_pooling_request(
             {
                 "task": "token_classify",
@@ -87,6 +103,11 @@ def reward_score(
                 "mm_processor_kwargs": {"do_resize": False},
                 "messages": [{"role": "user", "content": content}],
             }
+        )
+        row.log_histogram(
+            "robometer_request_seconds",
+            time.perf_counter() - request_t0,
+            unit="seconds",
         )
         token_logits = _extract_progress_token_logits(response, len(frames))
         progress = [expected_progress(row) for row in token_logits]

--- a/src/refiner/robotics/reward.py
+++ b/src/refiner/robotics/reward.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import asyncio
 import io
 import math
 import time
@@ -50,8 +51,16 @@ def reward_score(
     from refiner.inference.providers import VLLMProvider
 
     provider = VLLMProvider(model=model, config="throughput")
+    episode_semaphore = asyncio.Semaphore(max_concurrent_requests)
 
     async def _score_episode(
+        row: Row,
+        generate_pooling_request: GeneratePoolingFn,
+    ) -> MapResult:
+        async with episode_semaphore:
+            return await _score_episode_unbounded(row, generate_pooling_request)
+
+    async def _score_episode_unbounded(
         row: Row,
         generate_pooling_request: GeneratePoolingFn,
     ) -> MapResult:

--- a/tests/inference/test_metrics.py
+++ b/tests/inference/test_metrics.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
+from typing import Any, cast
 
 import pytest
 
@@ -8,8 +10,12 @@ import refiner as mdr
 from refiner.inference import (
     InferenceResponse,
     OpenAIEndpointProvider,
+    VLLMProvider,
+    generate_pooling,
 )
 from refiner.pipeline.data.row import DictRow
+from refiner.services import VLLMRuntimeServiceBinding
+from refiner.services.manager import ServiceManager
 from refiner.worker.context import set_active_run_context
 
 from ._helpers import (
@@ -165,3 +171,101 @@ def test_inference_generate_text_reports_failed_requests(monkeypatch) -> None:
     }
     assert counter_totals["failed_requests"] == 1
     assert "successful_requests" not in counter_totals
+
+
+def test_inference_request_limit_applies_before_vllm_service_ready(
+    monkeypatch,
+) -> None:
+    emitter = _MetricRecordingEmitter()
+
+    class _Runtime:
+        def claim(self, previous=None):
+            del previous
+            return None
+
+        def heartbeat(self, shards):
+            del shards
+
+        def complete(self, shard):
+            del shard
+
+        def fail(self, shard, error=None):
+            del shard, error
+
+        def finalized_workers(self, *, stage_index=None):
+            del stage_index
+            return []
+
+    async def _fake_pooling(self, payload):
+        del self, payload
+        return {"data": []}
+
+    async def _inference_fn(row, generate_pooling_request):
+        await generate_pooling_request({"task": "token_classify"})
+        return row
+
+    async def _invoke() -> None:
+        service_requested = asyncio.Event()
+        service_ready = asyncio.Event()
+        get_calls = 0
+        provider = VLLMProvider(model="test-model")
+        expected_service_name = provider.service_definition().name
+
+        class _ServiceManager:
+            async def get(self, name: str):
+                nonlocal get_calls
+                assert name == expected_service_name
+                get_calls += 1
+                service_requested.set()
+                await service_ready.wait()
+                return VLLMRuntimeServiceBinding(
+                    name=name,
+                    kind="llm",
+                    endpoint="http://127.0.0.1:8000",
+                )
+
+        infer = generate_pooling(
+            fn=_inference_fn,
+            provider=provider,
+            max_concurrent_requests=1,
+        )
+
+        with (
+            set_active_run_context(
+                job_id="job-1",
+                stage_index=0,
+                worker_id="worker-1",
+                worker_name=None,
+                runtime_lifecycle=_Runtime(),
+                service_manager=cast(ServiceManager, _ServiceManager()),
+                user_metrics_emitter=emitter,
+            ),
+        ):
+            first = asyncio.create_task(
+                cast(
+                    Coroutine[Any, Any, object],
+                    infer(DictRow({"id": 1}).with_shard_id("s")),
+                )
+            )
+            await asyncio.wait_for(service_requested.wait(), timeout=1.0)
+            second = asyncio.create_task(
+                cast(
+                    Coroutine[Any, Any, object],
+                    infer(DictRow({"id": 2}).with_shard_id("s")),
+                )
+            )
+            await asyncio.sleep(0)
+
+            gauges = {
+                item["label"]: item["callback"] for item in emitter.registered_gauges
+            }
+            assert get_calls == 1
+            assert gauges["waiting_requests"]() == 1
+            assert gauges["running_requests"]() == 0
+
+            service_ready.set()
+            await asyncio.gather(first, second)
+
+    monkeypatch.setattr(openai_provider._OpenAIEndpointClient, "pooling", _fake_pooling)
+
+    asyncio.run(_invoke())

--- a/tests/robotics/test_reward.py
+++ b/tests/robotics/test_reward.py
@@ -78,10 +78,12 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
         video_key="observation.images.main",
         max_frames=2,
     )
+    builtin = getattr(score, "__refiner_builtin_call__")
     services = collect_pipeline_services(mdr.from_items([{}]).map_async(score))
 
     result = asyncio.run(score(row))
 
+    assert builtin["args"]["max_concurrent_requests"] == 4
     assert services[0].config == {
         "model_name_or_path": "aliangdw/Robometer-4B",
         "config": "throughput",


### PR DESCRIPTION
## Summary
- lower Robometer reward_score default pooling concurrency to 4
- acquire inference request slots before resolving vLLM runtime service bindings so service-ready bursts are capped and visible as waiting_requests
- add Robometer timing histograms for video sampling, frame encoding, sampled frame count, and request duration

## Why this is not duplicating an existing PR
Checked open PRs for:
- robometer request concurrency
- reward_score max_concurrent_requests
- vllm pooling waiting_requests

No open PRs matched this fix.

## Profiling context
The stuck aloha_static_battery run has 49 async rows in flight, vLLM engine stats staying at running=0/waiting=0, and no request completions. Local profiling showed all 49 episodes are clips from the same MP4 and concurrent frame sampling serializes through the opened-video cache, taking ~66-72s before request work. The old max_concurrent_requests=256 can then burst large multimodal /pooling requests once service resolution completes, which appears to hang before vLLM engine scheduling.

Submitted patched cloud job 019e85f1-8cd4-7199-be74-b8e794357acb from this branch; its plan confirms async_map.max_in_flight=256 and max_concurrent_requests=4, but it is still pending with no worker because the earlier 256-profile job is still running.

## Tests
- uv run pytest tests/inference tests/robotics -q
- uv run ruff check src/refiner/inference/internal/runtime.py src/refiner/robotics/reward.py tests/inference/test_metrics.py tests/robotics/test_reward.py
- pre-commit via commit hook: ruff, ruff format, ty

AI assistance was used for this change.