### PR TITLE
Fail fast on runtime service startup failures

### DIFF
--- a/src/refiner/execution/asyncio/window.py
+++ b/src/refiner/execution/asyncio/window.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import heapq
 from collections.abc import Coroutine
-from concurrent.futures import ALL_COMPLETED, FIRST_COMPLETED, Future, wait
+from concurrent.futures import (
+    ALL_COMPLETED,
+    FIRST_COMPLETED,
+    FIRST_EXCEPTION,
+    Future,
+    wait,
+)
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
@@ -65,8 +71,8 @@ class AsyncWindow(Generic[T]):
         return self._take_ready()
 
     def drain(self) -> list[T]:
-        """Wait for all in-flight work, then return every available result."""
-        self._wait_until(return_when=ALL_COMPLETED)
+        """Wait for in-flight work, failing fast if any future raises."""
+        self._wait_until(return_when=FIRST_EXCEPTION)
         return self._take_ready()
 
     def cancel_pending(self) -> None:
@@ -83,13 +89,18 @@ class AsyncWindow(Generic[T]):
             return
         self._futures.difference_update(done)
         for future in done:
-            idx, value = future.result()
+            try:
+                idx, value = future.result()
+            except BaseException:
+                self.cancel_pending()
+                raise
             self._store_result(idx, value)
 
     def _wait_until(self, *, return_when: str) -> None:
         """Block until the requested completion condition and collect results."""
         while self._futures and (
-            return_when == ALL_COMPLETED or len(self._futures) >= self.max_in_flight
+            return_when in {ALL_COMPLETED, FIRST_EXCEPTION}
+            or len(self._futures) >= self.max_in_flight
         ):
             done, _ = wait(self._futures, return_when=return_when)
             self._collect_done(done)

--- a/tests/execution/test_async_window.py
+++ b/tests/execution/test_async_window.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import asyncio
 import time
 
+import pytest
+
 from refiner.execution.asyncio.window import AsyncWindow
 
 
 async def _delayed_value(value: int, delay_s: float) -> int:
     await asyncio.sleep(delay_s)
     return value
+
+
+async def _delayed_failure(delay_s: float) -> int:
+    await asyncio.sleep(delay_s)
+    raise RuntimeError("request failed")
 
 
 def test_async_window_submit_blocking_enforces_max_in_flight() -> None:
@@ -31,8 +38,12 @@ def test_async_window_take_completed_returns_ready_results_without_blocking() ->
     assert window.submit_blocking(_delayed_value(1, 0.03)) is None
     assert window.submit_blocking(_delayed_value(2, 0.0)) is None
 
-    time.sleep(0.05)
-    polled = window.take_completed()
+    deadline = time.perf_counter() + 1.0
+    polled: list[int] = []
+    while time.perf_counter() < deadline and len(polled) < 2:
+        polled.extend(window.take_completed())
+        if len(polled) < 2:
+            time.sleep(0.01)
 
     assert sorted(polled) == [1, 2]
     assert window.drain() == []
@@ -46,6 +57,21 @@ def test_async_window_ready_results_preserve_order() -> None:
 
     assert window.take_completed() == []
     assert window.drain() == [1, 2]
+
+
+def test_async_window_drain_fails_fast_and_cancels_pending() -> None:
+    window = AsyncWindow[int](max_in_flight=2, preserve_order=True)
+
+    assert window.submit_blocking(_delayed_failure(0.03)) is None
+    assert window.submit_blocking(_delayed_value(2, 1.0)) is None
+
+    start = time.perf_counter()
+    with pytest.raises(RuntimeError, match="request failed"):
+        window.drain()
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5
+    assert len(window) == 0
 
 
 def test_async_window_cancel_pending_clears_window() -> None:


### PR DESCRIPTION
## Purpose

Avoid delayed worker failure when async inference requests fail.

## Changes

- Make `AsyncWindow.drain()` fail fast on the first failed future and cancel pending in-flight work.
- Add regression coverage for async window fail-fast cancellation.

## Test Evidence

- `uv run pytest tests/execution/test_async_window.py tests/services/test_manager.py` -> 13 passed
- `uv run pytest tests/execution tests/services tests/worker` -> 37 passed
- `uv run ruff check --force-exclude src/refiner/execution/asyncio/window.py src/refiner/services/manager.py tests/execution/test_async_window.py tests/services/test_manager.py` -> passed
- commit hook: `ruff`, `ruff format`, `ty` -> passed