### PR TITLE
[codex] Use canonical Robometer model by default

### DIFF
--- a/tests/robotics/test_reward.py
+++ b/tests/robotics/test_reward.py
@@ -136,3 +136,16 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
             }
         ],
     }
+
+
+def test_robometer_sample_indexes_match_official_rounding() -> None:
+    assert reward_module._sample_indexes(32, max_frames=8) == (
+        0,
+        4,
+        9,
+        13,
+        18,
+        22,
+        27,
+        31,
+    )


### PR DESCRIPTION
## Summary

Updates Refiner's default Robometer reward model to the canonical `robometer/Robometer-4B` repo and adds a focused regression test for Robometer frame sampling parity.

The sampling test locks the 32-frame / 8-sample case used in the Soar parity check to the official round-sampled indexes:

```text
0, 4, 9, 13, 18, 22, 27, 31
```

This catches the old floor-sampling behavior that selected frame 26 instead of 27 and caused the large late-trajectory reward mismatch.

## Validation

- `.venv/bin/python -m pytest tests/robotics/test_reward.py`
- pre-commit hooks during commit:
  - ruff
  - ruff format
  - ty
