### PR TITLE
[codex] Use canonical Robometer model by default

### DIFF
--- a/docs/episode-operations/reward-scoring.md
+++ b/docs/episode-operations/reward-scoring.md
@@ -13,6 +13,7 @@ pipeline = (
     mdr.read_lerobot("hf://datasets/acme/demos")
     .map_async(
         mdr.robotics.reward_score(
+            model="robometer/Robometer-4B",
             video_key="observation.images.top",
             task=lambda row: "; ".join(row.tasks),
             max_frames=8,
@@ -51,4 +52,3 @@ mdr.robotics.reward_score(task=lambda row: row.task or "; ".join(row.tasks))
 
 `reward_score` uses pooling inference through a VLLM provider. See
 [Pooling](../inference/pooling.md) and [Providers and VLLM](../inference/providers-and-vllm.md).
-

--- a/docs/examples/score-rewards.md
+++ b/docs/examples/score-rewards.md
@@ -12,6 +12,7 @@ pipeline = (
     mdr.read_lerobot("hf://datasets/acme/raw-demos")
     .map_async(
         mdr.robotics.reward_score(
+            model="robometer/Robometer-4B",
             video_key="observation.images.top",
             task=lambda row: "; ".join(row.tasks),
             max_frames=8,
@@ -23,4 +24,3 @@ pipeline = (
 ```
 
 See [Reward Scoring](../episode-operations/reward-scoring.md).
-

--- a/src/refiner/robotics/reward.py
+++ b/src/refiner/robotics/reward.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 else:
     GeneratePoolingFn = Callable[[Mapping[str, Any]], Any]
 
-_DEFAULT_ROBOMETER_MODEL = "aliangdw/Robometer-4B"
+_DEFAULT_ROBOMETER_MODEL = "robometer/Robometer-4B"
 _PROGRESS_TOKEN = "<|prog_token|>"
 
 

--- a/tests/robotics/test_reward.py
+++ b/tests/robotics/test_reward.py
@@ -74,7 +74,6 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
         frames=[],
     )
     score = mdr.robotics.reward_score(
-        model="aliangdw/Robometer-4B",
         video_key="observation.images.main",
         max_frames=2,
     )
@@ -83,7 +82,7 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
     result = asyncio.run(score(row))
 
     assert services[0].config == {
-        "model_name_or_path": "aliangdw/Robometer-4B",
+        "model_name_or_path": "robometer/Robometer-4B",
         "config": "throughput",
     }
     assert "robometer_progress" not in result
@@ -97,7 +96,7 @@ def test_reward_score_builds_robometer_pooling_request(monkeypatch) -> None:
         "max_frames": 2,
     }
     assert seen["payload"] == {
-        "model": "aliangdw/Robometer-4B",
+        "model": "robometer/Robometer-4B",
         "task": "token_classify",
         "use_activation": False,
         "chat_template_kwargs": {


### PR DESCRIPTION
## Summary

Updates Refiner's default Robometer reward model to the canonical `robometer/Robometer-4B` repository.

Also updates the reward-scoring examples to show the canonical model explicitly.

## Validation

- `.venv/bin/python -m pytest tests/robotics/test_reward.py`
- pre-commit hooks during commit:
  - ruff
  - ruff format
  - ty
