### PR TITLE
[codex] Make robotics tasks plural canonical

### DIFF
--- a/docs/episode-data/converting-to-robot-rows.md
+++ b/docs/episode-data/converting-to-robot-rows.md
@@ -40,7 +40,7 @@ adds semantic properties such as `row.actions`, `row.states`, and `row.videos`.
 | Option | Use it for |
 | --- | --- |
 | `episode_id_key` | Source column or slash path for episode identity. |
-| `task_key` | Source column or slash path containing task text. |
+| `task_key` | Source column or slash path containing task text. Strings become `row.tasks = [task]`; string sequences are preserved. |
 | `fps` or `fps_key` | Literal fps or source column for fps. |
 | `robot_type` or `robot_type_key` | Literal robot type or source column. |
 | `timestamp_key` | Frame-aligned timestamp column. If missing and `fps` is known, timestamps are generated from frame indices. |

--- a/docs/episode-data/metadata-tasks-and-stats.md
+++ b/docs/episode-data/metadata-tasks-and-stats.md
@@ -30,6 +30,8 @@ print(row.tasks)
 print(row.task)
 ```
 
+`row.task` is a convenience alias for the first item in `row.tasks`.
+
 When reading multiple LeRobot roots, Refiner merges task tables and remaps
 indices so task text stays stable.
 
@@ -66,4 +68,3 @@ See [Writing LeRobot](../writing-data/lerobot.md).
 - [LeRobot Reader](../reading-data/lerobot.md)
 - [LeRobot Writer](../writing-data/lerobot.md)
 - [Motion Trimming](../episode-operations/motion-trimming.md)
-

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -255,11 +255,11 @@ class RefinerPipeline:
         while ``.filter(col("episode_id") == "ep-1")`` requires a physical
         ``episode_id`` column.
 
-        ``episode_id_key`` and ``task_key`` may use slash paths. For nested frame
-        rows, ``task_key`` may point inside ``nested_frames_key``; the first
-        non-empty frame value is used as the episode task. If ``timestamp_key`` is
-        requested but absent and ``fps`` is known, timestamps are generated from
-        frame indices.
+        ``episode_id_key`` and ``task_key`` may use slash paths. ``task_key`` values
+        are exposed as ``row.tasks``; strings become single-item task lists, and
+        sequences of strings are preserved. For nested frame rows, ``task_key`` may
+        point inside ``nested_frames_key``. If ``timestamp_key`` is requested but
+        absent and ``fps`` is known, timestamps are generated from frame indices.
         """
         from refiner.robotics.row import _robot_row_converter
 

--- a/src/refiner/pipeline/sinks/lerobot.py
+++ b/src/refiner/pipeline/sinks/lerobot.py
@@ -272,6 +272,7 @@ class LeRobotWriterSink(BaseSink):
         """Write one LeRobot episode into staged shard-local outputs."""
         is_lerobot_row = isinstance(row, LeRobotRow)
         is_generic_robotics_row = not is_lerobot_row and isinstance(row, RoboticsRow)
+        generic_tasks: list[str] = []
         if isinstance(row, LeRobotRow):
             metadata = _metadata_with_lerobot_fps(row.metadata)
             frames = (
@@ -281,31 +282,78 @@ class LeRobotWriterSink(BaseSink):
             )
         elif is_generic_robotics_row:
             robotics_row = cast(RoboticsRow, row)
-            task_index = None
-            if robotics_row.task is not None:
-                task_index = state.generic_task_to_index.get(robotics_row.task)
-                if task_index is None:
-                    digest = hashlib.blake2b(
-                        robotics_row.task.encode("utf-8"),
-                        digest_size=8,
-                    ).digest()
-                    task_index = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+            generic_tasks = robotics_row.tasks
+            frames = robotics_row.to_frame_table()
+            task_indices = (
+                sorted(
+                    {
+                        int(task_index)
+                        for task_index in (
+                            frames.table.column("task_index").unique().to_pylist()
+                        )
+                        if task_index is not None
+                    }
+                )
+                if "task_index" in frames.table.column_names
+                else []
+            )
+            if task_indices and generic_tasks:
+                if len(task_indices) != len(generic_tasks):
+                    raise ValueError(
+                        "LeRobot writer requires one task label per frame task_index"
+                    )
+                for task_index, task in zip(task_indices, generic_tasks, strict=True):
+                    existing_index = state.generic_task_to_index.get(task)
+                    if existing_index is not None and existing_index != task_index:
+                        raise ValueError(
+                            "LeRobot writer encountered mismatched task_index values "
+                            f"for task {task!r}"
+                        )
                     existing_task = next(
                         (
-                            task
-                            for task, index in state.generic_task_to_index.items()
-                            if index == task_index
+                            existing_task
+                            for existing_task, existing_task_index in (
+                                state.generic_task_to_index.items()
+                            )
+                            if existing_task_index == task_index
+                            and existing_task != task
                         ),
                         None,
                     )
                     if existing_task is not None:
                         raise ValueError(
                             "LeRobot writer encountered colliding task_index values "
-                            f"for {existing_task!r} and {robotics_row.task!r}"
+                            f"for {existing_task!r} and {task!r}"
                         )
-                    state.generic_task_to_index[robotics_row.task] = task_index
-            frames = robotics_row.to_frame_table()
-            if task_index is not None:
+                    state.generic_task_to_index[task] = task_index
+            else:
+                for task in generic_tasks:
+                    task_index = state.generic_task_to_index.get(task)
+                    if task_index is not None:
+                        continue
+                    digest = hashlib.blake2b(
+                        task.encode("utf-8"),
+                        digest_size=8,
+                    ).digest()
+                    task_index = int.from_bytes(digest, "big") & ((1 << 63) - 1)
+                    existing_task = next(
+                        (
+                            existing_task
+                            for existing_task, existing_task_index in (
+                                state.generic_task_to_index.items()
+                            )
+                            if existing_task_index == task_index
+                        ),
+                        None,
+                    )
+                    if existing_task is not None:
+                        raise ValueError(
+                            "LeRobot writer encountered colliding task_index values "
+                            f"for {existing_task!r} and {task!r}"
+                        )
+                    state.generic_task_to_index[task] = task_index
+            if not task_indices and len(generic_tasks) == 1:
+                task_index = state.generic_task_to_index.get(generic_tasks[0])
                 frames = frames.with_table(
                     set_or_append_column(
                         frames.table,
@@ -313,8 +361,6 @@ class LeRobotWriterSink(BaseSink):
                         pa.array([task_index] * frames.num_rows, type=pa.int64()),
                     )
                 )
-            elif "task_index" in frames.table.column_names:
-                frames = frames.with_table(frames.table.drop(["task_index"]))
 
             metadata = LeRobotMetadata(
                 info=LeRobotInfo(
@@ -380,8 +426,8 @@ class LeRobotWriterSink(BaseSink):
                         pa.array([episode_index] * frames.num_rows, type=pa.int64()),
                     )
                 )
-            if robotics_row.task is not None:
-                base_values.setdefault("task", robotics_row.task)
+            if generic_tasks:
+                base_values.setdefault("tasks", generic_tasks)
             base_row = DictRow(base_values, shard_id=row.shard_id)
             video_inputs = list(robotics_row.videos.items())
             source_stats_by_key = {key: None for key, _ in video_inputs}
@@ -451,13 +497,26 @@ class LeRobotWriterSink(BaseSink):
             task_indices = sorted(
                 {
                     int(task_index)
-                    for task_index in frames.table.column("task_index").to_pylist()
+                    for task_index in (
+                        frames.table.column("task_index").unique().to_pylist()
+                    )
                     if task_index is not None
                 }
             )
-            episode_row_patch["tasks"] = [
-                metadata.tasks.index_to_task[task_index] for task_index in task_indices
+            missing_task_indices = [
+                task_index
+                for task_index in task_indices
+                if task_index not in metadata.tasks.index_to_task
             ]
+            if not missing_task_indices:
+                episode_row_patch["tasks"] = [
+                    metadata.tasks.index_to_task[task_index]
+                    for task_index in task_indices
+                ]
+            elif not is_generic_robotics_row:
+                raise KeyError(missing_task_indices[0])
+        elif generic_tasks:
+            episode_row_patch["tasks"] = generic_tasks
 
         # video work
         video_tasks = [

--- a/src/refiner/robotics/lerobot_format/row.py
+++ b/src/refiner/robotics/lerobot_format/row.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pyarrow as pa
 
@@ -180,12 +180,18 @@ class LeRobotRow(Row, RoboticsRow):
 
     @property
     def tasks(self) -> list[str]:
-        return list(self._row.get("tasks", []))
+        value = self._row.get("tasks")
+        if value is None:
+            value = self._row.get("task")
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+            return cast(list[str], list(value))
+        return []
 
     @property
     def task(self) -> str | None:
-        task = self._row.get("task")
-        return task if isinstance(task, str) else None
+        return next(iter(self.tasks), None)
 
     @property
     def num_frames(self) -> int:
@@ -374,6 +380,12 @@ class LeRobotRow(Row, RoboticsRow):
     ) -> "LeRobotRow":
         merged = dict(patch or {})
         merged.update(kwargs)
+        if "task" in merged:
+            task = merged.pop("task")
+            merged["tasks"] = [task] if isinstance(task, str) and task.strip() else []
+        tasks = merged.get("tasks")
+        if isinstance(tasks, str):
+            merged["tasks"] = [tasks] if tasks.strip() else []
         metadata = merged.pop("metadata", self.metadata)
         frames = merged.pop("frames", self.frames)
         return LeRobotRow(

--- a/src/refiner/robotics/row.py
+++ b/src/refiner/robotics/row.py
@@ -99,6 +99,9 @@ class RoboticsRow(Protocol):
     def num_frames(self) -> int: ...
 
     @property
+    def tasks(self) -> list[str]: ...
+
+    @property
     def task(self) -> str | None: ...
 
     @property
@@ -183,6 +186,8 @@ class _RoboticsRowView(Row, RoboticsRow):
         hidden.update(
             source_key for source_key, _ in self._spec.video_source_map.values()
         )
+        if self._spec.task_key is not None:
+            hidden.add(self._spec.task_key)
         for key in tuple(hidden):
             if "/" in key and key not in self._row:
                 hidden.add(key.split("/", 1)[0])
@@ -279,10 +284,15 @@ class _RoboticsRowView(Row, RoboticsRow):
 
     @property
     def task(self) -> str | None:
+        return next(iter(self.tasks), None)
+
+    @property
+    def tasks(self) -> list[str]:
         if self._spec.task_key is None:
-            return None
-        value = _get_path(self._row, self._spec.task_key, default=None)
-        if value is None:
+            value = self._row.get("tasks", self._row.get("task"))
+        else:
+            value = _get_path(self._row, self._spec.task_key, default=None)
+        if value is None and self._spec.task_key is not None:
             nested_frames_key = _valid_nested_frames_key(
                 self._row,
                 self._spec.nested_frames_key,
@@ -293,15 +303,16 @@ class _RoboticsRowView(Row, RoboticsRow):
                 field = self._spec.task_key[len(nested_frames_key) + 1 :]
                 table = self._nested_frame_table()
                 if table is not None and field in table.names:
-                    value = next(
-                        (item for item in table.column(field).to_pylist() if item),
-                        None,
-                    )
+                    value = table.column(field).unique().to_pylist()
         if hasattr(value, "as_py"):
             value = value.as_py()
         if isinstance(value, bytes):
-            return value.decode("utf-8")
-        return value if isinstance(value, str) else None
+            value = value.decode("utf-8")
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+            return cast(list[str], list(value))
+        return []
 
     @property
     def fps(self) -> float | None:
@@ -517,7 +528,18 @@ class _RoboticsRowView(Row, RoboticsRow):
         /,
         **kwargs: Any,
     ) -> "_RoboticsRowView":
-        return self._replace(self._row.update(patch, **kwargs))
+        merged = dict(patch or {})
+        merged.update(kwargs)
+        if "task" in merged:
+            task = merged.pop("task")
+            merged["tasks"] = [task] if isinstance(task, str) and task.strip() else []
+        if "tasks" in merged and self._spec.task_key is not None:
+            value = merged.pop("tasks")
+            if isinstance(value, str):
+                value = [value] if value.strip() else []
+            row = self._row.update(_set_path(self._row, self._spec.task_key, value))
+            return self._replace(row.update(merged))
+        return self._replace(self._row.update(merged))
 
     def drop(self, *keys: str) -> "_RoboticsRowView":
         return self._replace(self._row.drop(*keys))

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -49,13 +49,14 @@ class _FakeRoboticsRow(Row, RoboticsRow):
         episode_id: str,
         frame_table: Tabular,
         task: str | None = None,
+        tasks: Sequence[str] | None = None,
         fps: float | None = None,
         robot_type: str | None = None,
         videos: Mapping[str, VideoSource] | None = None,
     ) -> None:
         self._data = {"episode_id": episode_id}
         self._frame_table = frame_table
-        self._task = task
+        self._tasks = list(tasks) if tasks is not None else ([task] if task else [])
         self._fps = fps
         self._robot_type = robot_type
         self._videos = dict(videos or {})
@@ -78,8 +79,12 @@ class _FakeRoboticsRow(Row, RoboticsRow):
         return self._frame_table.num_rows
 
     @property
+    def tasks(self) -> list[str]:
+        return self._tasks
+
+    @property
     def task(self) -> str | None:
-        return self._task
+        return next(iter(self.tasks), None)
 
     @property
     def fps(self) -> float | None:
@@ -544,7 +549,7 @@ def test_write_lerobot_is_deferred_and_roundtrips(tmp_path: Path) -> None:
     assert stats_json["observation.images.main"]["count"] == [expected_video_count]
 
     out_rows = mdr.read_lerobot(str(out_root)).materialize()
-    assert sorted(row["task"] for row in out_rows) == ["pick", "place"]
+    assert sorted(cast(LeRobotRow, row).task for row in out_rows) == ["pick", "place"]
 
 
 def test_write_lerobot_launch_local_runs_stage1_then_stage2(tmp_path: Path) -> None:
@@ -668,6 +673,41 @@ def test_write_lerobot_accepts_generic_robotics_rows(tmp_path: Path) -> None:
         "pick",
         "place",
     ]
+
+
+def test_write_lerobot_keeps_unassigned_generic_tasks(tmp_path: Path) -> None:
+    out_root = tmp_path / "generic-unassigned-tasks"
+    row = _FakeRoboticsRow(
+        episode_id="demo",
+        tasks=["pick", "place"],
+        fps=10,
+        robot_type="mockbot",
+        frame_table=Tabular.from_rows(
+            [
+                DictRow({"timestamp": 0.0, "observation.state": [1.0]}),
+                DictRow({"timestamp": 0.1, "observation.state": [2.0]}),
+            ]
+        ),
+    )
+    writer = LeRobotWriterSink(str(out_root))
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime()),
+    ):
+        writer.write_shard_block("shard-1", [row])
+        writer.on_shard_complete("shard-1")
+
+    data_file = next((out_root / "data").glob("chunk-*/file-000.parquet"))
+    episode_file = next((out_root / "meta").glob("chunk-*/episodes/file-000.parquet"))
+    frames = pq.read_table(data_file)
+    episodes = pq.read_table(episode_file)
+
+    assert "task_index" not in frames.column_names
+    assert episodes.column("tasks").to_pylist() == [["pick", "place"]]
 
 
 def test_write_lerobot_generates_missing_generic_episode_ids(tmp_path: Path) -> None:
@@ -1021,7 +1061,6 @@ def test_write_lerobot_preserves_stable_task_index_mapping(tmp_path: Path) -> No
         out_root / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
     )
     assert episodes.column("tasks").to_pylist() == [["pick"], ["place"]]
-    assert episodes.column("task").to_pylist() == ["pick", "place"]
 
 
 def test_write_lerobot_raises_on_unmapped_frame_task_index(tmp_path: Path) -> None:

--- a/tests/robotics/test_motion.py
+++ b/tests/robotics/test_motion.py
@@ -87,6 +87,18 @@ def test_motion_trim_rewrites_video_file_bounds() -> None:
     assert "observation.images.main" not in trimmed.stats
 
 
+def test_lerobot_row_task_uses_tasks() -> None:
+    row = _row(frames=[], from_ts=0.0, to_ts=0.0).update(
+        {
+            "tasks": ["pick", "place"],
+        }
+    )
+
+    assert row.task == "pick"
+    assert row.update({"tasks": "reset"}).tasks == ["reset"]
+    assert row.update({"task": "reset"}).tasks == ["reset"]
+
+
 def test_motion_trim_returns_empty_frames_when_no_motion() -> None:
     row = _row(
         frames=[

--- a/tests/robotics/test_robotics_row.py
+++ b/tests/robotics/test_robotics_row.py
@@ -54,6 +54,7 @@ def test_to_robot_rows_does_not_treat_video_uri_frames_as_frame_table() -> None:
     )
 
     assert robotics_row.episode_id == "episode-1"
+    assert robotics_row.tasks == ["pick the cup"]
     assert robotics_row.task == "pick the cup"
     assert robotics_row.num_frames == -1
     video = robotics_row.videos["observation.images.main"]
@@ -91,7 +92,7 @@ def test_robotics_row_repr_summarizes_episode() -> None:
     assert "robot_type='mockbot'" in text
     assert "videos=['observation.images.main']" in text
     assert "actions (row.actions): double[2, 1]" in text
-    assert "source_fields=['id', 'task', 'payload']" in text
+    assert "source_fields=['id', 'payload']" in text
 
 
 def test_to_robot_rows_exposes_stats_and_embedded_video_bytes() -> None:
@@ -256,7 +257,7 @@ def test_to_robot_rows_reads_nested_episode_task() -> None:
         {
             "steps": [
                 {
-                    "language_instruction": b"pick up the cup",
+                    "language_instruction": "pick up the cup",
                     "action": [0.0],
                     "observation": {"state": [1.0]},
                 }
@@ -270,7 +271,17 @@ def test_to_robot_rows_reads_nested_episode_task() -> None:
         task_key="steps/language_instruction",
     )
 
+    assert robotics_row.tasks == ["pick up the cup"]
     assert robotics_row.task == "pick up the cup"
+
+
+def test_to_robot_rows_normalizes_task_values() -> None:
+    row = DictRow({"task": ["pick", "place"]})
+    robotics_row = _robot_row(row, task_key="task")
+
+    assert robotics_row.tasks == ["pick", "place"]
+    assert robotics_row.task == "pick"
+    assert robotics_row.update({"task": "reset"}).tasks == ["reset"]
 
 
 def test_to_robot_rows_accepts_literal_fps_and_robot_type() -> None:


### PR DESCRIPTION
## Summary
- add canonical `row.tasks` support to generic `RoboticsRow` while keeping `row.task` as a first-task convenience alias
- normalize string task values into single-item task lists for generic robotics rows and LeRobot rows
- update generic `write_lerobot` task handling to preserve existing frame `task_index`, fill it only for single-task unassigned rows, and keep multi-task unassigned rows at episode metadata level

## Context
LeRobot v3 stores episode task labels as `tasks` and frame assignments as `task_index`. Refiner generic robotics rows only exposed singular `task`, which forced converted rows through single-task writer behavior and made multi-task episodes without frame assignments awkward. This makes `tasks` the canonical row API while retaining `task` for simple callers.

## Validation
- `uv run pytest tests/robotics/test_robotics_row.py tests/robotics/test_motion.py tests/robotics/test_subtask_annotation.py tests/pipeline/test_lerobot_sink.py::test_write_lerobot_is_deferred_and_roundtrips tests/pipeline/test_lerobot_sink.py::test_write_lerobot_accepts_generic_robotics_rows tests/pipeline/test_lerobot_sink.py::test_write_lerobot_keeps_unassigned_generic_tasks tests/pipeline/test_lerobot_sink.py::test_write_lerobot_generates_missing_generic_episode_ids tests/pipeline/test_lerobot_sink.py::test_write_lerobot_accepts_to_robot_rows_after_vectorized_filter tests/pipeline/test_lerobot_sink.py::test_write_lerobot_preserves_stable_task_index_mapping tests/pipeline/test_lerobot_sink.py::test_write_lerobot_raises_on_unmapped_frame_task_index`
- `uv run ruff check src/refiner/robotics/row.py src/refiner/robotics/lerobot_format/row.py src/refiner/pipeline/sinks/lerobot.py src/refiner/pipeline/pipeline.py tests/robotics/test_robotics_row.py tests/robotics/test_motion.py tests/pipeline/test_lerobot_sink.py tests/robotics/test_subtask_annotation.py`
- `uv run ty check src/refiner/robotics/row.py src/refiner/robotics/lerobot_format/row.py src/refiner/pipeline/sinks/lerobot.py src/refiner/pipeline/pipeline.py`

Note: the full `tests/pipeline/test_lerobot_sink.py` run was not used because the final hub merge test hung locally; the targeted writer tests above cover the changed task behavior.