### PR TITLE
[codex] Filter nested frame task labels

### DIFF
--- a/src/refiner/robotics/row.py
+++ b/src/refiner/robotics/row.py
@@ -303,9 +303,14 @@ class _RoboticsRowView(Row, RoboticsRow):
                 field = self._spec.task_key[len(nested_frames_key) + 1 :]
                 table = self._nested_frame_table()
                 if table is not None and field in table.names:
-                    value = table.column(field).unique().to_pylist()
-        if hasattr(value, "as_py"):
-            value = value.as_py()
+                    value = [
+                        task
+                        for task in table.column(field).unique().to_pylist()
+                        if isinstance(task, str) and task.strip()
+                    ]
+        as_py = getattr(cast(Any, value), "as_py", None)
+        if callable(as_py):
+            value = as_py()
         if isinstance(value, bytes):
             value = value.decode("utf-8")
         if isinstance(value, str):

--- a/tests/robotics/test_robotics_row.py
+++ b/tests/robotics/test_robotics_row.py
@@ -257,10 +257,20 @@ def test_to_robot_rows_reads_nested_episode_task() -> None:
         {
             "steps": [
                 {
+                    "language_instruction": None,
+                    "action": [0.0],
+                    "observation": {"state": [1.0]},
+                },
+                {
+                    "language_instruction": "",
+                    "action": [0.0],
+                    "observation": {"state": [1.0]},
+                },
+                {
                     "language_instruction": "pick up the cup",
                     "action": [0.0],
                     "observation": {"state": [1.0]},
-                }
+                },
             ]
         }
     )


### PR DESCRIPTION
## Summary
- filter nested-frame `task_key` extraction to non-empty string labels before exposing `row.tasks`
- keep direct `tasks` sequence values unchanged for normal episode-level task fields
- add a regression case where early nested frames have missing/empty instructions before the valid task

## Context
When `task_key` points inside `nested_frames_key`, Refiner synthesizes episode-level `row.tasks` from frame values. After #187, that path used raw Arrow `unique()` values, so `None` or empty strings from frames without instructions could become `row.tasks` entries. That could make `row.task` return `None` even when a later frame has a valid task, and writer code could later try to encode a non-string task.

## Validation
- `uv run pytest tests/robotics/test_robotics_row.py`
- `uv run ruff check src/refiner/robotics/row.py tests/robotics/test_robotics_row.py`
- `uv run ty check src/refiner/robotics/row.py`