### PR TITLE
[codex] Validate LeRobot episode frame counts

### DIFF
--- a/docs/reading-data/lerobot.md
+++ b/docs/reading-data/lerobot.md
@@ -50,6 +50,13 @@ pipeline = mdr.read_lerobot(
 The reader merges metadata and remaps task indices so row tasks stay consistent.
 For a full recipe, see [Merge LeRobot Datasets](../examples/merge-lerobot-datasets.md).
 
+## Malformed Episodes
+
+`read_lerobot` validates that each episode's declared frame count matches the
+frames loaded from its frame parquet. Mismatches raise by default. To drop those
+episodes instead, pass `skip_malformed_rows=True`; the reader logs the first
+skipped row and records `malformed_lerobot_rows_skipped`.
+
 ## Inspecting Rows
 
 ```python

--- a/docs/reading-data/lerobot.md
+++ b/docs/reading-data/lerobot.md
@@ -55,7 +55,7 @@ For a full recipe, see [Merge LeRobot Datasets](../examples/merge-lerobot-datase
 `read_lerobot` validates that each episode's declared frame count matches the
 frames loaded from its frame parquet. Mismatches raise by default. To drop those
 episodes instead, pass `skip_malformed_rows=True`; the reader logs the first
-skipped row and records `malformed_lerobot_rows_skipped`.
+skipped episode and records `malformed_lerobot_episodes_skipped`.
 
 ## Inspecting Rows
 

--- a/docs/reading-data/lerobot.md
+++ b/docs/reading-data/lerobot.md
@@ -54,8 +54,8 @@ For a full recipe, see [Merge LeRobot Datasets](../examples/merge-lerobot-datase
 
 `read_lerobot` validates that each episode's declared frame count matches the
 frames loaded from its frame parquet. Mismatches raise by default. To drop those
-episodes instead, pass `skip_malformed_rows=True`; the reader logs the first
-skipped episode and records `malformed_lerobot_episodes_skipped`.
+episodes instead, pass `skip_malformed_rows=True`; the reader warns once and
+records `malformed_lerobot_episodes_skipped`.
 
 ## Inspecting Rows
 

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1300,6 +1300,7 @@ def read_lerobot(
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
     split_row_groups: bool = True,
+    skip_malformed_rows: bool = False,
 ) -> RefinerPipeline:
     """Create a pipeline with an episode-granular LeRobot reader source.
 
@@ -1307,7 +1308,9 @@ def read_lerobot(
     `num_shards` and `target_shard_bytes` affect only episode parquet shard
     planning. `split_row_groups` controls whether those planned spans are
     refined to row ranges inside an episode parquet file. Media loading stays
-    unchanged.
+    unchanged. By default, malformed episode rows whose declared frame count
+    does not match loaded frames raise an error; `skip_malformed_rows=True`
+    skips them with a warning and metric.
     """
     return RefinerPipeline(
         source=LeRobotEpisodeReader(
@@ -1317,6 +1320,7 @@ def read_lerobot(
             target_shard_bytes=target_shard_bytes,
             num_shards=num_shards,
             split_row_groups=split_row_groups,
+            skip_malformed_rows=skip_malformed_rows,
         )
     )
 

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from functools import cached_property
 from typing import Any
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -114,83 +115,79 @@ class LeRobotEpisodeReader(ParquetReader):
                     metadata=metadata_for_source,
                     remap=remap,
                 )
-                if batch.num_rows > 0:
-                    if self.skip_malformed_rows:
-                        keep: list[bool] = []
-                        first_error: str | None = None
-                        for row_idx in range(batch.num_rows):
-                            chunk = self._episode_value(
-                                batch, row_idx, "data/chunk_index"
+                if batch.num_rows <= 0:
+                    continue
+
+                if self.skip_malformed_rows:
+                    index_by_file = {
+                        key: table.column("index")
+                        .combine_chunks()
+                        .to_numpy(zero_copy_only=False)
+                        for key, table in frame_tables.items()
+                    }
+                    keep: list[bool] = []
+                    first_error: str | None = None
+                    for row in batch.table.select(
+                        [
+                            "episode_index",
+                            "length",
+                            "data/chunk_index",
+                            "data/file_index",
+                            "dataset_from_index",
+                            "dataset_to_index",
+                        ]
+                    ).to_pylist():
+                        chunk = row["data/chunk_index"]
+                        file_idx = row["data/file_index"]
+                        from_idx = int(row["dataset_from_index"])
+                        to_idx = int(row["dataset_to_index"])
+                        indexes = index_by_file[(chunk, file_idx)]
+                        actual = int(
+                            np.searchsorted(indexes, to_idx)
+                            - np.searchsorted(indexes, from_idx)
+                        )
+                        expected = int(row["length"])
+                        keep.append(actual == expected)
+                        if actual != expected and first_error is None:
+                            first_error = (
+                                f"episode {int(row['episode_index'])} expected {expected} "
+                                f"frames from chunk {chunk!r} file {file_idx!r} "
+                                f"index range [{from_idx}, {to_idx}), got {actual}"
                             )
-                            file_idx = self._episode_value(
-                                batch, row_idx, "data/file_index"
+                    skipped = keep.count(False)
+                    if skipped:
+                        if not self._warned_malformed_row:
+                            logger.warning(
+                                "Skipping malformed LeRobot row: {}", first_error
                             )
-                            from_idx = int(
-                                self._episode_value(
-                                    batch, row_idx, "dataset_from_index"
-                                )
+                            self._warned_malformed_row = True
+                        log_throughput(
+                            "malformed_lerobot_rows_skipped",
+                            skipped,
+                            shard_id=shard.id,
+                            unit="rows",
+                        )
+                        batch = batch.with_table(
+                            batch.table.filter(pa.array(keep, type=pa.bool_()))
+                        )
+                        if batch.num_rows == 0:
+                            continue
+
+                yield LeRobotTabular(
+                    batch,
+                    metadata_by_row=(metadata_for_source,) * batch.num_rows,
+                    frames_by_row=tuple(
+                        Tabular(
+                            self._slice_episode_frame_table(
+                                row_idx=row_idx,
+                                tabular=batch,
+                                frame_tables=frame_tables,
                             )
-                            to_idx = int(
-                                self._episode_value(batch, row_idx, "dataset_to_index")
-                            )
-                            table = frame_tables[(chunk, file_idx)].filter(
-                                (
-                                    pc.field("index")
-                                    >= pa.scalar(from_idx, type=pa.int64())
-                                )
-                                & (
-                                    pc.field("index")
-                                    < pa.scalar(to_idx, type=pa.int64())
-                                )
-                            )
-                            expected = int(
-                                self._episode_value(batch, row_idx, "length")
-                            )
-                            actual = table.num_rows
-                            keep.append(actual == expected)
-                            if actual != expected and first_error is None:
-                                episode_index = int(
-                                    self._episode_value(batch, row_idx, "episode_index")
-                                )
-                                first_error = (
-                                    f"episode {episode_index} expected {expected} "
-                                    f"frames from chunk {chunk!r} file {file_idx!r} "
-                                    f"index range [{from_idx}, {to_idx}), got {actual}"
-                                )
-                        skipped = keep.count(False)
-                        if skipped:
-                            if not self._warned_malformed_row:
-                                logger.warning(
-                                    "Skipping malformed LeRobot row: {}", first_error
-                                )
-                                self._warned_malformed_row = True
-                            log_throughput(
-                                "malformed_lerobot_rows_skipped",
-                                skipped,
-                                shard_id=shard.id,
-                                unit="rows",
-                            )
-                            batch = batch.with_table(
-                                batch.table.filter(pa.array(keep, type=pa.bool_()))
-                            )
-                            if batch.num_rows == 0:
-                                continue
-                    yield LeRobotTabular(
-                        batch,
-                        metadata_by_row=(metadata_for_source,) * batch.num_rows,
-                        frames_by_row=tuple(
-                            Tabular(
-                                self._slice_episode_frame_table(
-                                    row_idx=row_idx,
-                                    tabular=batch,
-                                    frame_tables=frame_tables,
-                                    validate_frame_count=not self.skip_malformed_rows,
-                                )
-                            )
-                            for row_idx in range(batch.num_rows)
-                        ),
-                        roots_by_row=(root,) * batch.num_rows,
-                    )
+                        )
+                        for row_idx in range(batch.num_rows)
+                    ),
+                    roots_by_row=(root,) * batch.num_rows,
+                )
 
     @staticmethod
     def _resolve_roots(
@@ -325,7 +322,6 @@ class LeRobotEpisodeReader(ParquetReader):
         row_idx: int,
         tabular: Tabular,
         frame_tables: Mapping[tuple[Any, Any], pa.Table],
-        validate_frame_count: bool = True,
     ) -> pa.Table:
         """Extract one episode's frame rows from the preloaded shared tables."""
         chunk = self._episode_value(tabular, row_idx, "data/chunk_index")
@@ -338,7 +334,7 @@ class LeRobotEpisodeReader(ParquetReader):
         )
         episode_index = int(self._episode_value(tabular, row_idx, "episode_index"))
         expected = int(self._episode_value(tabular, row_idx, "length"))
-        if validate_frame_count and table.num_rows != expected:
+        if table.num_rows != expected:
             raise ValueError(
                 f"episode {episode_index} expected {expected} frames from "
                 f"chunk {chunk!r} file {file_idx!r} index range [{from_idx}, {to_idx}), "

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -115,46 +115,81 @@ class LeRobotEpisodeReader(ParquetReader):
                     remap=remap,
                 )
                 if batch.num_rows > 0:
-                    row_indices: list[int] = []
-                    frames_by_row: list[Tabular] = []
-                    skipped = 0
-                    for row_idx in range(batch.num_rows):
-                        try:
-                            frames_by_row.append(
-                                Tabular(
-                                    self._slice_episode_frame_table(
-                                        row_idx=row_idx,
-                                        tabular=batch,
-                                        frame_tables=frame_tables,
-                                    )
+                    if self.skip_malformed_rows:
+                        keep: list[bool] = []
+                        first_error: str | None = None
+                        for row_idx in range(batch.num_rows):
+                            chunk = self._episode_value(
+                                batch, row_idx, "data/chunk_index"
+                            )
+                            file_idx = self._episode_value(
+                                batch, row_idx, "data/file_index"
+                            )
+                            from_idx = int(
+                                self._episode_value(
+                                    batch, row_idx, "dataset_from_index"
                                 )
                             )
-                            row_indices.append(row_idx)
-                        except ValueError as err:
-                            if not self.skip_malformed_rows:
-                                raise
-                            skipped += 1
+                            to_idx = int(
+                                self._episode_value(batch, row_idx, "dataset_to_index")
+                            )
+                            table = frame_tables[(chunk, file_idx)].filter(
+                                (
+                                    pc.field("index")
+                                    >= pa.scalar(from_idx, type=pa.int64())
+                                )
+                                & (
+                                    pc.field("index")
+                                    < pa.scalar(to_idx, type=pa.int64())
+                                )
+                            )
+                            expected = int(
+                                self._episode_value(batch, row_idx, "length")
+                            )
+                            actual = table.num_rows
+                            keep.append(actual == expected)
+                            if actual != expected and first_error is None:
+                                episode_index = int(
+                                    self._episode_value(batch, row_idx, "episode_index")
+                                )
+                                first_error = (
+                                    f"episode {episode_index} expected {expected} "
+                                    f"frames from chunk {chunk!r} file {file_idx!r} "
+                                    f"index range [{from_idx}, {to_idx}), got {actual}"
+                                )
+                        skipped = keep.count(False)
+                        if skipped:
                             if not self._warned_malformed_row:
                                 logger.warning(
-                                    "Skipping malformed LeRobot row: {}", err
+                                    "Skipping malformed LeRobot row: {}", first_error
                                 )
                                 self._warned_malformed_row = True
-                    if skipped:
-                        log_throughput(
-                            "malformed_lerobot_rows_skipped",
-                            skipped,
-                            shard_id=shard.id,
-                            unit="rows",
-                        )
-                    if not row_indices:
-                        continue
+                            log_throughput(
+                                "malformed_lerobot_rows_skipped",
+                                skipped,
+                                shard_id=shard.id,
+                                unit="rows",
+                            )
+                            batch = batch.with_table(
+                                batch.table.filter(pa.array(keep, type=pa.bool_()))
+                            )
+                            if batch.num_rows == 0:
+                                continue
                     yield LeRobotTabular(
-                        Tabular(
-                            batch.table.take(pa.array(row_indices, type=pa.int64()))
+                        batch,
+                        metadata_by_row=(metadata_for_source,) * batch.num_rows,
+                        frames_by_row=tuple(
+                            Tabular(
+                                self._slice_episode_frame_table(
+                                    row_idx=row_idx,
+                                    tabular=batch,
+                                    frame_tables=frame_tables,
+                                    validate_frame_count=not self.skip_malformed_rows,
+                                )
+                            )
+                            for row_idx in range(batch.num_rows)
                         ),
-                        metadata_by_row=(metadata_for_source,) * len(row_indices),
-                        frames_by_row=tuple(frames_by_row),
-                        roots_by_row=(root,) * len(row_indices),
+                        roots_by_row=(root,) * batch.num_rows,
                     )
 
     @staticmethod
@@ -290,6 +325,7 @@ class LeRobotEpisodeReader(ParquetReader):
         row_idx: int,
         tabular: Tabular,
         frame_tables: Mapping[tuple[Any, Any], pa.Table],
+        validate_frame_count: bool = True,
     ) -> pa.Table:
         """Extract one episode's frame rows from the preloaded shared tables."""
         chunk = self._episode_value(tabular, row_idx, "data/chunk_index")
@@ -302,7 +338,7 @@ class LeRobotEpisodeReader(ParquetReader):
         )
         episode_index = int(self._episode_value(tabular, row_idx, "episode_index"))
         expected = int(self._episode_value(tabular, row_idx, "length"))
-        if table.num_rows != expected:
+        if validate_frame_count and table.num_rows != expected:
             raise ValueError(
                 f"episode {episode_index} expected {expected} frames from "
                 f"chunk {chunk!r} file {file_idx!r} index range [{from_idx}, {to_idx}), "

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -124,7 +124,7 @@ class LeRobotEpisodeReader(ParquetReader):
                     for row_idx, actual in enumerate(frame_counts)
                 ]
                 skipped = keep.count(False)
-                if skipped:
+                if skipped and not self.skip_malformed_rows:
                     row_idx = keep.index(False)
                     expected = int(lengths[row_idx].as_py())
                     actual = frame_counts[row_idx]
@@ -135,10 +135,11 @@ class LeRobotEpisodeReader(ParquetReader):
                         f"episode {episode_index} expected {expected} "
                         f"frames, got {actual}"
                     )
-                    if not self.skip_malformed_rows:
-                        raise ValueError(error)
+                    raise ValueError(error)
+
+                if skipped:
                     if not self._warned_malformed_row:
-                        logger.warning("Skipping malformed LeRobot row: {}", error)
+                        logger.warning("Skipping malformed LeRobot episodes")
                         self._warned_malformed_row = True
                     log_throughput(
                         "malformed_lerobot_episodes_skipped",

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -27,6 +27,8 @@ from refiner.robotics.lerobot_format import (
     merge_metadata,
     remap_task_index_table,
 )
+from refiner.worker.context import logger
+from refiner.worker.metrics.api import log_throughput
 
 _DEFAULT_EPISODES_GLOB_ROOT = "meta/episodes"
 _INFO_JSON = "meta/info.json"
@@ -54,6 +56,7 @@ class LeRobotEpisodeReader(ParquetReader):
         num_shards: int | None = None,
         arrow_batch_size: int = 65536,
         split_row_groups: bool = True,
+        skip_malformed_rows: bool = False,
     ) -> None:
         """Create a LeRobot episode reader over one or more dataset roots.
 
@@ -66,6 +69,8 @@ class LeRobotEpisodeReader(ParquetReader):
             storage_options=storage_options,
         )
         self._last_frame_table: tuple[tuple[int, Any, Any], pa.Table] | None = None
+        self.skip_malformed_rows = skip_malformed_rows
+        self._warned_malformed_row = False
 
         super().__init__(
             inputs=tuple(
@@ -110,20 +115,46 @@ class LeRobotEpisodeReader(ParquetReader):
                     remap=remap,
                 )
                 if batch.num_rows > 0:
-                    yield LeRobotTabular(
-                        batch,
-                        metadata_by_row=(metadata_for_source,) * batch.num_rows,
-                        frames_by_row=tuple(
-                            Tabular(
-                                self._slice_episode_frame_table(
-                                    row_idx=row_idx,
-                                    tabular=batch,
-                                    frame_tables=frame_tables,
+                    row_indices: list[int] = []
+                    frames_by_row: list[Tabular] = []
+                    skipped = 0
+                    for row_idx in range(batch.num_rows):
+                        try:
+                            frames_by_row.append(
+                                Tabular(
+                                    self._slice_episode_frame_table(
+                                        row_idx=row_idx,
+                                        tabular=batch,
+                                        frame_tables=frame_tables,
+                                    )
                                 )
                             )
-                            for row_idx in range(batch.num_rows)
+                            row_indices.append(row_idx)
+                        except ValueError as err:
+                            if not self.skip_malformed_rows:
+                                raise
+                            skipped += 1
+                            if not self._warned_malformed_row:
+                                logger.warning(
+                                    "Skipping malformed LeRobot row: {}", err
+                                )
+                                self._warned_malformed_row = True
+                    if skipped:
+                        log_throughput(
+                            "malformed_lerobot_rows_skipped",
+                            skipped,
+                            shard_id=shard.id,
+                            unit="rows",
+                        )
+                    if not row_indices:
+                        continue
+                    yield LeRobotTabular(
+                        Tabular(
+                            batch.table.take(pa.array(row_indices, type=pa.int64()))
                         ),
-                        roots_by_row=(root,) * batch.num_rows,
+                        metadata_by_row=(metadata_for_source,) * len(row_indices),
+                        frames_by_row=tuple(frames_by_row),
+                        roots_by_row=(root,) * len(row_indices),
                     )
 
     @staticmethod
@@ -270,6 +301,13 @@ class LeRobotEpisodeReader(ParquetReader):
             & (pc.field("index") < pa.scalar(to_idx, type=pa.int64()))
         )
         episode_index = int(self._episode_value(tabular, row_idx, "episode_index"))
+        expected = int(self._episode_value(tabular, row_idx, "length"))
+        if table.num_rows != expected:
+            raise ValueError(
+                f"episode {episode_index} expected {expected} frames from "
+                f"chunk {chunk!r} file {file_idx!r} index range [{from_idx}, {to_idx}), "
+                f"got {table.num_rows}"
+            )
         episode_index_column = pa.array(
             [episode_index] * table.num_rows, type=pa.int64()
         )

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator, Mapping, Sequence
 from functools import cached_property
 from typing import Any
 
-import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -108,7 +107,7 @@ class LeRobotEpisodeReader(ParquetReader):
                 root = self.roots[part.source_index]
                 metadata_for_source = metadata[part.source_index]
                 remap = remaps[part.source_index]
-                frame_tables, frame_counts = self._load_frame_tables(
+                frame_tables = self._load_frame_tables(
                     source_index=part.source_index,
                     tabular=batch,
                     root=root,
@@ -118,16 +117,24 @@ class LeRobotEpisodeReader(ParquetReader):
                 if batch.num_rows <= 0:
                     continue
 
+                frames_by_row = tuple(
+                    self._slice_episode_frame_table(
+                        row_idx=row_idx,
+                        tabular=batch,
+                        frame_tables=frame_tables,
+                    )
+                    for row_idx in range(batch.num_rows)
+                )
                 lengths = batch.columns[batch.index_by_name["length"]]
                 keep = [
-                    actual == int(lengths[row_idx].as_py())
-                    for row_idx, actual in enumerate(frame_counts)
+                    table.num_rows == int(lengths[row_idx].as_py())
+                    for row_idx, table in enumerate(frames_by_row)
                 ]
                 skipped = keep.count(False)
                 if skipped and not self.skip_malformed_rows:
                     row_idx = keep.index(False)
                     expected = int(lengths[row_idx].as_py())
-                    actual = frame_counts[row_idx]
+                    actual = frames_by_row[row_idx].num_rows
                     episode_index = int(
                         self._episode_value(batch, row_idx, "episode_index")
                     )
@@ -150,22 +157,18 @@ class LeRobotEpisodeReader(ParquetReader):
                     batch = batch.with_table(
                         batch.table.filter(pa.array(keep, type=pa.bool_()))
                     )
+                    frames_by_row = tuple(
+                        table
+                        for table, should_keep in zip(frames_by_row, keep, strict=True)
+                        if should_keep
+                    )
                     if batch.num_rows == 0:
                         continue
 
                 yield LeRobotTabular(
                     batch,
                     metadata_by_row=(metadata_for_source,) * batch.num_rows,
-                    frames_by_row=tuple(
-                        Tabular(
-                            self._slice_episode_frame_table(
-                                row_idx=row_idx,
-                                tabular=batch,
-                                frame_tables=frame_tables,
-                            )
-                        )
-                        for row_idx in range(batch.num_rows)
-                    ),
+                    frames_by_row=tuple(Tabular(table) for table in frames_by_row),
                     roots_by_row=(root,) * batch.num_rows,
                 )
 
@@ -225,8 +228,8 @@ class LeRobotEpisodeReader(ParquetReader):
         root: DataFolder,
         metadata: LeRobotMetadata,
         remap: Mapping[int, int],
-    ) -> tuple[dict[tuple[Any, Any], pa.Table], list[int]]:
-        """Load reduced frame tables and per-episode frame counts.
+    ) -> dict[tuple[Any, Any], pa.Table]:
+        """Load one reduced frame table per referenced `(chunk, file)` pair.
 
         Each table is narrowed to the enclosing dataset-index span needed by
         the current episode batch and task indices are remapped once at the
@@ -277,25 +280,7 @@ class LeRobotEpisodeReader(ParquetReader):
             )
             table = remap_task_index_table(table, remap)
             tables[(chunk, file_idx)] = table
-
-        index_by_file = {
-            key: table.column("index").combine_chunks().to_numpy(zero_copy_only=False)
-            for key, table in tables.items()
-        }
-        frame_counts = []
-        chunks = tabular.columns[tabular.index_by_name["data/chunk_index"]]
-        files = tabular.columns[tabular.index_by_name["data/file_index"]]
-        from_indices = tabular.columns[tabular.index_by_name["dataset_from_index"]]
-        to_indices = tabular.columns[tabular.index_by_name["dataset_to_index"]]
-        for row_idx in range(tabular.num_rows):
-            indexes = index_by_file[(chunks[row_idx].as_py(), files[row_idx].as_py())]
-            frame_counts.append(
-                int(
-                    np.searchsorted(indexes, int(to_indices[row_idx].as_py()))
-                    - np.searchsorted(indexes, int(from_indices[row_idx].as_py()))
-                )
-            )
-        return tables, frame_counts
+        return tables
 
     def _get_frame_file_table(
         self,

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -153,10 +153,10 @@ class LeRobotEpisodeReader(ParquetReader):
                         logger.warning("Skipping malformed LeRobot row: {}", error)
                         self._warned_malformed_row = True
                     log_throughput(
-                        "malformed_lerobot_rows_skipped",
+                        "malformed_lerobot_episodes_skipped",
                         skipped,
                         shard_id=shard.id,
-                        unit="rows",
+                        unit="episodes",
                     )
                     batch = batch.with_table(
                         batch.table.filter(pa.array(keep, type=pa.bool_()))

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -118,30 +118,22 @@ class LeRobotEpisodeReader(ParquetReader):
                 if batch.num_rows <= 0:
                     continue
 
-                keep = []
-                for row_idx, actual in enumerate(frame_counts):
-                    expected = int(self._episode_value(batch, row_idx, "length"))
-                    keep.append(actual == expected)
+                lengths = batch.columns[batch.index_by_name["length"]]
+                keep = [
+                    actual == int(lengths[row_idx].as_py())
+                    for row_idx, actual in enumerate(frame_counts)
+                ]
                 skipped = keep.count(False)
                 if skipped:
                     row_idx = keep.index(False)
-                    chunk = self._episode_value(batch, row_idx, "data/chunk_index")
-                    file_idx = self._episode_value(batch, row_idx, "data/file_index")
-                    from_idx = int(
-                        self._episode_value(batch, row_idx, "dataset_from_index")
-                    )
-                    to_idx = int(
-                        self._episode_value(batch, row_idx, "dataset_to_index")
-                    )
-                    expected = int(self._episode_value(batch, row_idx, "length"))
+                    expected = int(lengths[row_idx].as_py())
                     actual = frame_counts[row_idx]
                     episode_index = int(
                         self._episode_value(batch, row_idx, "episode_index")
                     )
                     error = (
                         f"episode {episode_index} expected {expected} "
-                        f"frames from chunk {chunk!r} file {file_idx!r} "
-                        f"index range [{from_idx}, {to_idx}), got {actual}"
+                        f"frames, got {actual}"
                     )
                     if not self.skip_malformed_rows:
                         raise ValueError(error)

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -118,32 +118,28 @@ class LeRobotEpisodeReader(ParquetReader):
                 if batch.num_rows <= 0:
                     continue
 
-                episode_rows = batch.table.select(
-                    [
-                        "episode_index",
-                        "length",
-                        "data/chunk_index",
-                        "data/file_index",
-                        "dataset_from_index",
-                        "dataset_to_index",
-                    ]
-                ).to_pylist()
-                keep = [
-                    actual == int(row["length"])
-                    for row, actual in zip(episode_rows, frame_counts, strict=True)
-                ]
+                keep = []
+                for row_idx, actual in enumerate(frame_counts):
+                    expected = int(self._episode_value(batch, row_idx, "length"))
+                    keep.append(actual == expected)
                 skipped = keep.count(False)
                 if skipped:
                     row_idx = keep.index(False)
-                    row = episode_rows[row_idx]
-                    chunk = row["data/chunk_index"]
-                    file_idx = row["data/file_index"]
-                    from_idx = int(row["dataset_from_index"])
-                    to_idx = int(row["dataset_to_index"])
-                    expected = int(row["length"])
+                    chunk = self._episode_value(batch, row_idx, "data/chunk_index")
+                    file_idx = self._episode_value(batch, row_idx, "data/file_index")
+                    from_idx = int(
+                        self._episode_value(batch, row_idx, "dataset_from_index")
+                    )
+                    to_idx = int(
+                        self._episode_value(batch, row_idx, "dataset_to_index")
+                    )
+                    expected = int(self._episode_value(batch, row_idx, "length"))
                     actual = frame_counts[row_idx]
+                    episode_index = int(
+                        self._episode_value(batch, row_idx, "episode_index")
+                    )
                     error = (
-                        f"episode {int(row['episode_index'])} expected {expected} "
+                        f"episode {episode_index} expected {expected} "
                         f"frames from chunk {chunk!r} file {file_idx!r} "
                         f"index range [{from_idx}, {to_idx}), got {actual}"
                     )
@@ -262,11 +258,15 @@ class LeRobotEpisodeReader(ParquetReader):
         )
 
         tables: dict[tuple[Any, Any], pa.Table] = {}
-        for row in request_ranges.to_pylist():
-            chunk = row["data/chunk_index"]
-            file_idx = row["data/file_index"]
-            from_idx = int(row["dataset_from_index_min"])
-            to_idx = int(row["dataset_to_index_max"])
+        range_chunks = request_ranges.column("data/chunk_index")
+        range_files = request_ranges.column("data/file_index")
+        range_from_indices = request_ranges.column("dataset_from_index_min")
+        range_to_indices = request_ranges.column("dataset_to_index_max")
+        for row_idx in range(request_ranges.num_rows):
+            chunk = range_chunks[row_idx].as_py()
+            file_idx = range_files[row_idx].as_py()
+            from_idx = int(range_from_indices[row_idx].as_py())
+            to_idx = int(range_to_indices[row_idx].as_py())
             table = self._get_frame_file_table(
                 source_index=source_index,
                 root=root,
@@ -290,19 +290,16 @@ class LeRobotEpisodeReader(ParquetReader):
             for key, table in tables.items()
         }
         frame_counts = []
-        for row in tabular.table.select(
-            [
-                "data/chunk_index",
-                "data/file_index",
-                "dataset_from_index",
-                "dataset_to_index",
-            ]
-        ).to_pylist():
-            indexes = index_by_file[(row["data/chunk_index"], row["data/file_index"])]
+        chunks = tabular.columns[tabular.index_by_name["data/chunk_index"]]
+        files = tabular.columns[tabular.index_by_name["data/file_index"]]
+        from_indices = tabular.columns[tabular.index_by_name["dataset_from_index"]]
+        to_indices = tabular.columns[tabular.index_by_name["dataset_to_index"]]
+        for row_idx in range(tabular.num_rows):
+            indexes = index_by_file[(chunks[row_idx].as_py(), files[row_idx].as_py())]
             frame_counts.append(
                 int(
-                    np.searchsorted(indexes, int(row["dataset_to_index"]))
-                    - np.searchsorted(indexes, int(row["dataset_from_index"]))
+                    np.searchsorted(indexes, int(to_indices[row_idx].as_py()))
+                    - np.searchsorted(indexes, int(from_indices[row_idx].as_py()))
                 )
             )
         return tables, frame_counts

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -108,7 +108,7 @@ class LeRobotEpisodeReader(ParquetReader):
                 root = self.roots[part.source_index]
                 metadata_for_source = metadata[part.source_index]
                 remap = remaps[part.source_index]
-                frame_tables = self._load_frame_tables(
+                frame_tables, frame_counts = self._load_frame_tables(
                     source_index=part.source_index,
                     tabular=batch,
                     root=root,
@@ -118,60 +118,51 @@ class LeRobotEpisodeReader(ParquetReader):
                 if batch.num_rows <= 0:
                     continue
 
-                if self.skip_malformed_rows:
-                    index_by_file = {
-                        key: table.column("index")
-                        .combine_chunks()
-                        .to_numpy(zero_copy_only=False)
-                        for key, table in frame_tables.items()
-                    }
-                    keep: list[bool] = []
-                    first_error: str | None = None
-                    for row in batch.table.select(
-                        [
-                            "episode_index",
-                            "length",
-                            "data/chunk_index",
-                            "data/file_index",
-                            "dataset_from_index",
-                            "dataset_to_index",
-                        ]
-                    ).to_pylist():
-                        chunk = row["data/chunk_index"]
-                        file_idx = row["data/file_index"]
-                        from_idx = int(row["dataset_from_index"])
-                        to_idx = int(row["dataset_to_index"])
-                        indexes = index_by_file[(chunk, file_idx)]
-                        actual = int(
-                            np.searchsorted(indexes, to_idx)
-                            - np.searchsorted(indexes, from_idx)
-                        )
-                        expected = int(row["length"])
-                        keep.append(actual == expected)
-                        if actual != expected and first_error is None:
-                            first_error = (
-                                f"episode {int(row['episode_index'])} expected {expected} "
-                                f"frames from chunk {chunk!r} file {file_idx!r} "
-                                f"index range [{from_idx}, {to_idx}), got {actual}"
-                            )
-                    skipped = keep.count(False)
-                    if skipped:
-                        if not self._warned_malformed_row:
-                            logger.warning(
-                                "Skipping malformed LeRobot row: {}", first_error
-                            )
-                            self._warned_malformed_row = True
-                        log_throughput(
-                            "malformed_lerobot_rows_skipped",
-                            skipped,
-                            shard_id=shard.id,
-                            unit="rows",
-                        )
-                        batch = batch.with_table(
-                            batch.table.filter(pa.array(keep, type=pa.bool_()))
-                        )
-                        if batch.num_rows == 0:
-                            continue
+                episode_rows = batch.table.select(
+                    [
+                        "episode_index",
+                        "length",
+                        "data/chunk_index",
+                        "data/file_index",
+                        "dataset_from_index",
+                        "dataset_to_index",
+                    ]
+                ).to_pylist()
+                keep = [
+                    actual == int(row["length"])
+                    for row, actual in zip(episode_rows, frame_counts, strict=True)
+                ]
+                skipped = keep.count(False)
+                if skipped:
+                    row_idx = keep.index(False)
+                    row = episode_rows[row_idx]
+                    chunk = row["data/chunk_index"]
+                    file_idx = row["data/file_index"]
+                    from_idx = int(row["dataset_from_index"])
+                    to_idx = int(row["dataset_to_index"])
+                    expected = int(row["length"])
+                    actual = frame_counts[row_idx]
+                    error = (
+                        f"episode {int(row['episode_index'])} expected {expected} "
+                        f"frames from chunk {chunk!r} file {file_idx!r} "
+                        f"index range [{from_idx}, {to_idx}), got {actual}"
+                    )
+                    if not self.skip_malformed_rows:
+                        raise ValueError(error)
+                    if not self._warned_malformed_row:
+                        logger.warning("Skipping malformed LeRobot row: {}", error)
+                        self._warned_malformed_row = True
+                    log_throughput(
+                        "malformed_lerobot_rows_skipped",
+                        skipped,
+                        shard_id=shard.id,
+                        unit="rows",
+                    )
+                    batch = batch.with_table(
+                        batch.table.filter(pa.array(keep, type=pa.bool_()))
+                    )
+                    if batch.num_rows == 0:
+                        continue
 
                 yield LeRobotTabular(
                     batch,
@@ -245,8 +236,8 @@ class LeRobotEpisodeReader(ParquetReader):
         root: DataFolder,
         metadata: LeRobotMetadata,
         remap: Mapping[int, int],
-    ) -> dict[tuple[Any, Any], pa.Table]:
-        """Load one reduced frame table per referenced `(chunk, file)` pair.
+    ) -> tuple[dict[tuple[Any, Any], pa.Table], list[int]]:
+        """Load reduced frame tables and per-episode frame counts.
 
         Each table is narrowed to the enclosing dataset-index span needed by
         the current episode batch and task indices are remapped once at the
@@ -293,7 +284,28 @@ class LeRobotEpisodeReader(ParquetReader):
             )
             table = remap_task_index_table(table, remap)
             tables[(chunk, file_idx)] = table
-        return tables
+
+        index_by_file = {
+            key: table.column("index").combine_chunks().to_numpy(zero_copy_only=False)
+            for key, table in tables.items()
+        }
+        frame_counts = []
+        for row in tabular.table.select(
+            [
+                "data/chunk_index",
+                "data/file_index",
+                "dataset_from_index",
+                "dataset_to_index",
+            ]
+        ).to_pylist():
+            indexes = index_by_file[(row["data/chunk_index"], row["data/file_index"])]
+            frame_counts.append(
+                int(
+                    np.searchsorted(indexes, int(row["dataset_to_index"]))
+                    - np.searchsorted(indexes, int(row["dataset_from_index"]))
+                )
+            )
+        return tables, frame_counts
 
     def _get_frame_file_table(
         self,
@@ -333,13 +345,6 @@ class LeRobotEpisodeReader(ParquetReader):
             & (pc.field("index") < pa.scalar(to_idx, type=pa.int64()))
         )
         episode_index = int(self._episode_value(tabular, row_idx, "episode_index"))
-        expected = int(self._episode_value(tabular, row_idx, "length"))
-        if table.num_rows != expected:
-            raise ValueError(
-                f"episode {episode_index} expected {expected} frames from "
-                f"chunk {chunk!r} file {file_idx!r} index range [{from_idx}, {to_idx}), "
-                f"got {table.num_rows}"
-            )
         episode_index_column = pa.array(
             [episode_index] * table.num_rows, type=pa.int64()
         )

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -15,6 +15,8 @@ from refiner.pipeline.data.row import DictRow
 from refiner.video import VideoFile
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
+from refiner.worker.context import set_active_run_context
+from refiner.worker.metrics.emitter import UserMetricsEmitter
 from refiner.robotics.lerobot_format import (
     LeRobotInfo,
     LeRobotFeatureInfo,
@@ -25,6 +27,36 @@ from refiner.robotics.lerobot_format import (
     LeRobotVideoInfo,
     remap_task_index_table,
 )
+
+
+class _RecordingEmitter(UserMetricsEmitter):
+    def __init__(self) -> None:
+        self.counters: list[dict[str, object]] = []
+
+    def emit_user_counter(self, **kwargs) -> None:
+        self.counters.append(kwargs)
+
+
+class _Runtime:
+    def claim(self, previous=None):
+        del previous
+        return None
+
+    def heartbeat(self, shards):
+        del shards
+
+    def complete(self, shard):
+        del shard
+
+    def fail(self, shard, error=None):
+        del shard, error
+
+    def finalized_workers(self, *, stage_index=None):
+        del stage_index
+        return []
+
+    def shutdown(self) -> None:
+        return None
 
 
 def _write_parquet(path: Path, rows: list[dict]) -> None:
@@ -89,6 +121,7 @@ def _build_sample_dataset(
         [
             {
                 "episode_index": 0,
+                "length": 2,
                 "dataset_from_index": 0,
                 "dataset_to_index": 2,
                 "data/chunk_index": 0,
@@ -104,6 +137,7 @@ def _build_sample_dataset(
             },
             {
                 "episode_index": 1,
+                "length": 2,
                 "dataset_from_index": 2,
                 "dataset_to_index": 4,
                 "data/chunk_index": 0,
@@ -186,6 +220,90 @@ def test_lerobot_reader_emits_episode_rows(tmp_path: Path) -> None:
     assert video.uri.endswith("/videos/observation.images.main/chunk-000/file-000.mp4")
     assert video.from_timestamp_s == 0.0
     assert video.to_timestamp_s == 1.0
+
+
+def test_lerobot_reader_raises_on_malformed_frame_count(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+    _write_parquet(
+        root / "data" / "chunk-000" / "file-000.parquet",
+        [
+            {
+                "index": 0,
+                "episode_index": 0,
+                "frame_index": 0,
+                "timestamp": 0.0,
+                "task_index": 0,
+            },
+            {
+                "index": 1,
+                "episode_index": 0,
+                "frame_index": 1,
+                "timestamp": 0.1,
+                "task_index": 0,
+            },
+        ],
+    )
+
+    reader = LeRobotEpisodeReader(str(root))
+
+    with pytest.raises(ValueError, match="episode 1 expected 2 frames"):
+        _episode_rows(reader)
+
+
+def test_lerobot_reader_can_skip_malformed_rows(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+    _write_parquet(
+        root / "data" / "chunk-000" / "file-000.parquet",
+        [
+            {
+                "index": 0,
+                "episode_index": 0,
+                "frame_index": 0,
+                "timestamp": 0.0,
+                "task_index": 0,
+            },
+            {
+                "index": 1,
+                "episode_index": 0,
+                "frame_index": 1,
+                "timestamp": 0.1,
+                "task_index": 0,
+            },
+        ],
+    )
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "refiner.pipeline.sources.readers.lerobot.logger.warning",
+        lambda message, *args: warnings.append(message.format(*args)),
+    )
+
+    reader = LeRobotEpisodeReader(str(root), skip_malformed_rows=True)
+    emitter = _RecordingEmitter()
+    with set_active_run_context(
+        job_id="job-1",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=_Runtime(),
+        user_metrics_emitter=emitter,
+    ):
+        rows = [
+            row
+            for shard in reader.list_shards()
+            for unit in reader.iter_shard_units(shard)
+            for row in cast(Tabular, unit).to_rows()
+        ]
+
+    assert [int(row["episode_index"]) for row in rows] == [0]
+    assert len(warnings) == 1
+    assert "episode 1 expected 2 frames" in warnings[0]
+    assert [
+        counter["value"]
+        for counter in emitter.counters
+        if counter["label"] == "malformed_lerobot_rows_skipped"
+    ] == [1.0]
 
 
 def test_lerobot_row_uses_absolute_video_uri_directly() -> None:

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -255,12 +255,7 @@ def test_lerobot_reader_can_skip_malformed_rows(tmp_path: Path, monkeypatch) -> 
     )
 
     reader = LeRobotEpisodeReader(str(root), skip_malformed_rows=True)
-    rows = [
-        row
-        for shard in reader.list_shards()
-        for unit in reader.read_shard(shard)
-        for row in cast(Tabular, unit).to_rows()
-    ]
+    rows = _episode_rows(reader)
 
     assert [int(row["episode_index"]) for row in rows] == [0]
     assert len(warnings) == 1

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -264,7 +264,7 @@ def test_lerobot_reader_can_skip_malformed_rows(tmp_path: Path, monkeypatch) -> 
 
     assert [int(row["episode_index"]) for row in rows] == [0]
     assert len(warnings) == 1
-    assert "episode 1 expected 2 frames" in warnings[0]
+    assert warnings[0] == "Skipping malformed LeRobot episodes"
     assert [(label, value, unit) for label, value, _, unit in metrics] == [
         ("malformed_lerobot_episodes_skipped", 1, "episodes")
     ]

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -3,23 +3,20 @@ from __future__ import annotations
 import json
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+from typing import cast
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from typing import cast
 
 import refiner as mdr
 from refiner.io import DataFolder
 from refiner.pipeline.data.row import DictRow
-from refiner.video import VideoFile
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
-from refiner.worker.context import set_active_run_context
-from refiner.worker.metrics.emitter import UserMetricsEmitter
 from refiner.robotics.lerobot_format import (
-    LeRobotInfo,
     LeRobotFeatureInfo,
+    LeRobotInfo,
     LeRobotMetadata,
     LeRobotRow,
     LeRobotStatsFile,
@@ -27,36 +24,7 @@ from refiner.robotics.lerobot_format import (
     LeRobotVideoInfo,
     remap_task_index_table,
 )
-
-
-class _RecordingEmitter(UserMetricsEmitter):
-    def __init__(self) -> None:
-        self.counters: list[dict[str, object]] = []
-
-    def emit_user_counter(self, **kwargs) -> None:
-        self.counters.append(kwargs)
-
-
-class _Runtime:
-    def claim(self, previous=None):
-        del previous
-        return None
-
-    def heartbeat(self, shards):
-        del shards
-
-    def complete(self, shard):
-        del shard
-
-    def fail(self, shard, error=None):
-        del shard, error
-
-    def finalized_workers(self, *, stage_index=None):
-        del stage_index
-        return []
-
-    def shutdown(self) -> None:
-        return None
+from refiner.video import VideoFile
 
 
 def _write_parquet(path: Path, rows: list[dict]) -> None:
@@ -278,32 +246,28 @@ def test_lerobot_reader_can_skip_malformed_rows(tmp_path: Path, monkeypatch) -> 
         "refiner.pipeline.sources.readers.lerobot.logger.warning",
         lambda message, *args: warnings.append(message.format(*args)),
     )
+    metrics: list[tuple[str, int | float, str, str | None]] = []
+    monkeypatch.setattr(
+        "refiner.pipeline.sources.readers.lerobot.log_throughput",
+        lambda label, value, shard_id, *, unit=None, step_index=None: metrics.append(
+            (label, value, shard_id, unit)
+        ),
+    )
 
     reader = LeRobotEpisodeReader(str(root), skip_malformed_rows=True)
-    emitter = _RecordingEmitter()
-    with set_active_run_context(
-        job_id="job-1",
-        stage_index=0,
-        worker_id="worker-1",
-        worker_name=None,
-        runtime_lifecycle=_Runtime(),
-        user_metrics_emitter=emitter,
-    ):
-        rows = [
-            row
-            for shard in reader.list_shards()
-            for unit in reader.iter_shard_units(shard)
-            for row in cast(Tabular, unit).to_rows()
-        ]
+    rows = [
+        row
+        for shard in reader.list_shards()
+        for unit in reader.read_shard(shard)
+        for row in cast(Tabular, unit).to_rows()
+    ]
 
     assert [int(row["episode_index"]) for row in rows] == [0]
     assert len(warnings) == 1
     assert "episode 1 expected 2 frames" in warnings[0]
-    assert [
-        counter["value"]
-        for counter in emitter.counters
-        if counter["label"] == "malformed_lerobot_rows_skipped"
-    ] == [1.0]
+    assert [(label, value, unit) for label, value, _, unit in metrics] == [
+        ("malformed_lerobot_rows_skipped", 1, "rows")
+    ]
 
 
 def test_lerobot_row_uses_absolute_video_uri_directly() -> None:

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -266,7 +266,7 @@ def test_lerobot_reader_can_skip_malformed_rows(tmp_path: Path, monkeypatch) -> 
     assert len(warnings) == 1
     assert "episode 1 expected 2 frames" in warnings[0]
     assert [(label, value, unit) for label, value, _, unit in metrics] == [
-        ("malformed_lerobot_rows_skipped", 1, "rows")
+        ("malformed_lerobot_episodes_skipped", 1, "episodes")
     ]
 
 

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -3,20 +3,21 @@ from __future__ import annotations
 import json
 from dataclasses import FrozenInstanceError
 from pathlib import Path
-from typing import cast
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from typing import cast
 
 import refiner as mdr
 from refiner.io import DataFolder
 from refiner.pipeline.data.row import DictRow
+from refiner.video import VideoFile
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.robotics.lerobot_format import (
-    LeRobotFeatureInfo,
     LeRobotInfo,
+    LeRobotFeatureInfo,
     LeRobotMetadata,
     LeRobotRow,
     LeRobotStatsFile,
@@ -24,7 +25,6 @@ from refiner.robotics.lerobot_format import (
     LeRobotVideoInfo,
     remap_task_index_table,
 )
-from refiner.video import VideoFile
 
 
 def _write_parquet(path: Path, rows: list[dict]) -> None:


### PR DESCRIPTION
## Summary
- validate that each LeRobot episode row loads exactly its declared `length` frames
- keep the default behavior strict by raising on malformed rows
- add `skip_malformed_rows=True` to drop malformed rows with one warning and a `malformed_lerobot_episodes_skipped` metric
- document the malformed episode policy and cover both strict and skip modes in reader tests

## Issue
Some LeRobot datasets can have episode metadata whose frame file pointer does not line up with the actual frame parquet. `lerobot/libero` has early rows whose `data/file_index` points at `file-000`, while the frame indices for later episodes are in subsequent files. The old reader silently returned zero-frame episodes after filtering the wrong frame file.

Closes #193.

## Validation
- `uv run ruff check src/refiner/pipeline/sources/readers/lerobot.py src/refiner/pipeline/pipeline.py tests/readers/test_lerobot_reader.py`
- `uv run ruff format --check src/refiner/pipeline/sources/readers/lerobot.py src/refiner/pipeline/pipeline.py tests/readers/test_lerobot_reader.py`
- `uv run ty check src/refiner/pipeline/sources/readers/lerobot.py src/refiner/pipeline/pipeline.py tests/readers/test_lerobot_reader.py`
- `uv run pytest tests/readers/test_lerobot_reader.py tests/readers/test_parquet_reader.py`
- live smoke: `mdr.read_lerobot("hf://datasets/lerobot/libero").take(5)` now raises on episode 3 with the expected/actual frame count mismatch
- commit hooks: `ruff`, `ruff format`, `ty`
