### PR TITLE
[codex] add video frame count method

### DIFF
--- a/docs/episode-data/frames-and-videos.md
+++ b/docs/episode-data/frames-and-videos.md
@@ -53,10 +53,25 @@ sequences. They share the same core operations:
 
 | Operation | Purpose |
 | --- | --- |
+| `get_frame_count()` | Return the exact frame count when it is known or reported by the encoded container. |
 | `clipped(...)` | Create a time-bounded view. |
 | `iter_frames()` | Decode video frames lazily. |
 | `iter_numpy_frames()` | Decode RGB arrays lazily. |
 | `write_to(...)` | Let a writer copy/remux/transcode media. |
+
+## Video Frame Counts
+
+```python
+async def add_frame_count(row):
+    video = row.videos["observation.images.top"]
+    return row.update(video_frame_count=await video.get_frame_count())
+```
+
+`get_frame_count()` is explicit because path-backed and bytes-backed videos may
+need to open the encoded container. In-memory frame arrays return their exact
+length. Frame sequences return their provided count, or count the repeatable
+sequence when no count was provided. Encoded videos use container metadata and
+raise an error when the container does not report an exact frame count.
 
 ## Clip A Video View
 

--- a/src/refiner/pipeline/utils/cache/decoder_cache.py
+++ b/src/refiner/pipeline/utils/cache/decoder_cache.py
@@ -18,6 +18,7 @@ class VideoSourceProbe:
     width: int
     height: int
     fps: float | None
+    frame_count: int | None
     time_base: Fraction
     codec: str | None
     pix_fmt: str | None
@@ -85,11 +86,13 @@ def _probe_video_source(
         return None
 
     stream_fps = stream.average_rate or stream.base_rate
+    frame_count = int(stream.frames) if stream.frames else None
     codec_obj = getattr(getattr(stream, "codec_context", None), "codec", None)
     return VideoSourceProbe(
         width=int(stream.width),
         height=int(stream.height),
         fps=float(stream_fps) if stream_fps is not None else None,
+        frame_count=frame_count,
         time_base=Fraction(cast(Any, stream.time_base)),
         codec=str(
             getattr(codec_obj, "canonical_name", None)

--- a/src/refiner/video/types.py
+++ b/src/refiner/video/types.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class VideoSource(Protocol):
+    async def get_frame_count(self) -> int: ...
+
     def clipped(
         self,
         *,
@@ -94,6 +96,21 @@ class VideoFile:
     def open(self) -> IO[bytes]:
         return self.data_file.open(mode="rb")
 
+    async def get_frame_count(self) -> int:
+        from refiner.video.remux import prepare_video_source
+
+        prepared = await prepare_video_source(video=self)
+        try:
+            if self.from_timestamp_s is not None or self.to_timestamp_s is not None:
+                raise ValueError(
+                    "encoded video frame count is unavailable for clipped videos"
+                )
+            if prepared.probe is None or prepared.probe.frame_count is None:
+                raise ValueError(f"Video frame count is unavailable for {self.uri!r}")
+            return prepared.probe.frame_count
+        finally:
+            prepared.close()
+
     def clipped(
         self,
         *,
@@ -160,6 +177,22 @@ class VideoBytes:
 
     def open(self) -> IO[bytes]:
         return io.BytesIO(self.data)
+
+    async def get_frame_count(self) -> int:
+        from refiner.video.remux import prepare_video_source
+
+        prepared = await prepare_video_source(video=self)
+        try:
+            if self.from_timestamp_s is not None or self.to_timestamp_s is not None:
+                raise ValueError(
+                    "encoded video frame count is unavailable for clipped videos"
+                )
+            if prepared.probe is None or prepared.probe.frame_count is None:
+                source = self.uri or type(self).__name__
+                raise ValueError(f"Video frame count is unavailable for {source!r}")
+            return prepared.probe.frame_count
+        finally:
+            prepared.close()
 
     def clipped(
         self,
@@ -249,6 +282,11 @@ class VideoFrameSequence:
         if self.frame_count is None:
             return None
         return self.frame_count / float(self.fps)
+
+    async def get_frame_count(self) -> int:
+        if self.frame_count is not None:
+            return self.frame_count
+        return sum(1 for _ in self.iter_frame_arrays())
 
     def iter_frame_arrays(self) -> Iterator[np.ndarray]:
         start_idx = (
@@ -408,6 +446,9 @@ class VideoFrameArray:
     @property
     def duration_s(self) -> float:
         return self.frame_count / float(self.fps)
+
+    async def get_frame_count(self) -> int:
+        return self.frame_count
 
     def iter_frame_arrays(self) -> Iterator[np.ndarray]:
         yield from self._array

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -34,6 +34,9 @@ class _FinalizedWorkersRuntime:
 
 
 class _EmptyVideoSource:
+    async def get_frame_count(self):
+        return 0
+
     def clipped(self, **_kwargs):
         return self
 

--- a/tests/test_video_decode.py
+++ b/tests/test_video_decode.py
@@ -68,6 +68,35 @@ def test_iter_frames_respects_clip_bounds(tmp_path) -> None:
     assert [frame.timestamp_s for frame in frames] == [0.2, 0.4, 0.6]
 
 
+def test_video_file_get_frame_count_uses_container_metadata(tmp_path) -> None:
+    path = tmp_path / "video.mp4"
+    _write_video(path, num_frames=5, fps=5)
+    video = mdr.video.VideoFile(DataFile.resolve(path))
+
+    assert asyncio.run(video.get_frame_count()) == 5
+
+
+def test_video_bytes_get_frame_count_uses_container_metadata(tmp_path) -> None:
+    path = tmp_path / "video.mp4"
+    _write_video(path, num_frames=4, fps=5)
+    video = mdr.video.VideoBytes(path.read_bytes(), uri=str(path))
+
+    assert asyncio.run(video.get_frame_count()) == 4
+
+
+def test_clipped_encoded_video_get_frame_count_raises(tmp_path) -> None:
+    path = tmp_path / "video.mp4"
+    _write_video(path, num_frames=5, fps=5)
+    video = mdr.video.VideoFile(
+        DataFile.resolve(path),
+        from_timestamp_s=0.0,
+        to_timestamp_s=0.4,
+    )
+
+    with pytest.raises(ValueError, match="clipped videos"):
+        asyncio.run(video.get_frame_count())
+
+
 def test_video_frame_array_clip_returns_frame_view() -> None:
     frames = np.stack([np.full((4, 4, 3), value, dtype=np.uint8) for value in range(6)])
     video = mdr.video.VideoFrameArray(frames, fps=10)
@@ -79,6 +108,13 @@ def test_video_frame_array_clip_returns_frame_view() -> None:
     assert len(clipped_frames) == 3
     assert clipped_frames[0].shape == (4, 4, 3)
     assert [int(frame[0, 0, 0]) for frame in clipped_frames] == [2, 3, 4]
+
+
+def test_video_frame_array_get_frame_count() -> None:
+    frames = np.stack([np.full((4, 4, 3), value, dtype=np.uint8) for value in range(6)])
+    video = mdr.video.VideoFrameArray(frames, fps=10)
+
+    assert asyncio.run(video.get_frame_count()) == 6
 
 
 def test_video_frame_array_iter_frames() -> None:
@@ -112,6 +148,21 @@ def test_video_frame_sequence_iterates_without_stacking() -> None:
     assert [frame.timestamp_s for frame in decoded] == [0.0, 0.2, 0.4]
     assert [int(frame[0, 0, 0]) for frame in arrays] == [0, 1, 2]
     assert calls == 6
+
+
+def test_video_frame_sequence_get_frame_count_counts_unknown_sequence() -> None:
+    calls = 0
+
+    def frames():
+        nonlocal calls
+        for value in range(3):
+            calls += 1
+            yield np.full((4, 4, 3), value, dtype=np.uint8)
+
+    video = mdr.video.VideoFrameSequence(frames, fps=5)
+
+    assert asyncio.run(video.get_frame_count()) == 3
+    assert calls == 3
 
 
 def test_video_frame_sequence_rejects_one_shot_iterators() -> None:


### PR DESCRIPTION
## Purpose

Add an explicit async `VideoSource.get_frame_count()` API so callers can request a video frame count without making `row.num_frames` or a property hide IO.

## Changes

- Adds `get_frame_count()` to the `VideoSource` protocol and concrete video sources.
- Extends `VideoSourceProbe` with `frame_count` from PyAV stream metadata.
- Uses strict encoded-video behavior: `VideoFile` and `VideoBytes` return container-reported frame counts and raise when unavailable or clipped.
- Documents frame count behavior for video sources.
- Adds focused tests for path-backed, bytes-backed, array-backed, and sequence-backed videos.

## Validation

- `uv run pytest tests/test_video_decode.py tests/readers/test_zarr_reader.py tests/pipeline/test_lerobot_sink.py tests/pipeline/test_sinks.py`
- `uv run ruff check --force-exclude src/refiner/video/types.py src/refiner/pipeline/utils/cache/decoder_cache.py tests/test_video_decode.py tests/readers/test_zarr_reader.py`
- `uv run ty check`