### PR TITLE
[codex] Propagate worker shutdown errors

### DIFF
--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -26,6 +26,10 @@ class WorkerRunStats:
     output_rows: int = 0
 
 
+class WorkerShutdownError(RuntimeError):
+    pass
+
+
 class Worker:
     def __init__(
         self,
@@ -272,6 +276,8 @@ class Worker:
                         )
                         if sink.counts_output_rows:
                             output_rows += written_output_rows
+                except WorkerShutdownError:
+                    raise
                 except Exception as e:
                     execution_error = e
                     failed_error = str(e).strip() or type(e).__name__

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -15,7 +15,7 @@ from refiner.execution.engine import iter_rows
 from refiner.pipeline.sinks import BaseSink
 from refiner.pipeline.data.shard import FilePart
 from refiner.services import RuntimeServiceSpec
-from refiner.worker.runner import Worker
+from refiner.worker.runner import Worker, WorkerShutdownError
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.worker.metrics.api import log_gauge
@@ -378,6 +378,31 @@ def test_worker_failure_uses_exception_type_when_message_is_empty() -> None:
 
     assert stats.failed == 1
     assert runtime_lifecycle.failed_errors == ["RuntimeError"]
+
+
+def test_worker_shutdown_error_propagates_without_failing_shard() -> None:
+    shard = _shard("shutdown", 0, 1)
+    runtime_lifecycle = _FakeRuntimeLifecycle([shard])
+    rows_by_shard = {shard.id: [DictRow({"x": 1})]}
+
+    def shutdown(row: Row) -> Row:
+        del row
+        raise WorkerShutdownError("worker is shutting down")
+
+    worker = Worker(
+        pipeline=RefinerPipeline(source=_FakeReader(rows_by_shard)).map(shutdown),
+        job_id="job",
+        stage_index=0,
+        worker_id=runtime_lifecycle.worker_id,
+        runtime_lifecycle=runtime_lifecycle,
+    )
+
+    with pytest.raises(WorkerShutdownError, match="worker is shutting down"):
+        worker.run()
+
+    assert runtime_lifecycle.completed_ids == []
+    assert runtime_lifecycle.failed_ids == []
+    assert runtime_lifecycle.failed_errors == []
 
 
 def test_worker_can_batch_across_shards() -> None:


### PR DESCRIPTION
## Summary

- Add `WorkerShutdownError` in `refiner.worker.runner`.
- Re-raise worker shutdown errors before ordinary execution failures are converted into shard failures.
- Add a focused worker runner regression test proving shutdown errors propagate without calling `runtime_lifecycle.fail`.

## Validation

- `uv run pytest tests/worker/test_runner.py`
- `uv run ty check src/refiner/worker/runner.py tests/worker/test_runner.py`
- `uv run ruff check --force-exclude src/refiner/worker/runner.py tests/worker/test_runner.py`
- `uv run ruff format --force-exclude --check src/refiner/worker/runner.py tests/worker/test_runner.py`
- `uv run ty check`
- `uv run ruff check --force-exclude .`
- `uv run ruff format --force-exclude --check .`
- `uv run pytest`