### PR TITLE
[codex] Bump Refiner to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.3.0"
+version = "0.3.1"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1673,7 +1673,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump macrodata-refiner from 0.3.0 to 0.3.1
- update the uv lockfile package entry to match

## Validation
- uv lock --check
- pre-commit during commit: ty passed; ruff skipped because no Python files changed