### PR TITLE
Update cloud dependency API

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -97,6 +97,7 @@ the manifest or source code.
 ```python
 pipeline.launch_cloud(
     name="private-dataset",
+    refiner_extras=["hf"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```

--- a/docs/episode-operations/hand-tracking.md
+++ b/docs/episode-operations/hand-tracking.md
@@ -50,7 +50,7 @@ pipeline = (
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        extra_dependencies=("ego-vision[models]==0.1.25",),
+        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )
@@ -149,7 +149,7 @@ pipeline = (
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        extra_dependencies=("ego-vision[models]==0.1.25",),
+        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/docs/examples/annotations/hand-tracking.md
+++ b/docs/examples/annotations/hand-tracking.md
@@ -62,7 +62,7 @@ def hand_tracking_annotation(row: Any) -> dict[str, Any]:
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        extra_dependencies=("ego-vision[models]==0.1.25",),
+        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/docs/examples/annotations/reward-models.md
+++ b/docs/examples/annotations/reward-models.md
@@ -46,7 +46,7 @@ def main() -> None:
             num_workers=1,
             cpus_per_worker=1,
             mem_mb_per_worker=4096,
-            extra_dependencies=("macrodata-refiner[hf,video]",),
+            refiner_extras=("hf", "video"),
             secrets={"HF_TOKEN": None},
         )
     )

--- a/docs/examples/annotations/subtask-annotations.md
+++ b/docs/examples/annotations/subtask-annotations.md
@@ -35,6 +35,7 @@ pipeline.launch_cloud(
     num_workers=1,
     cpus_per_worker=1,
     mem_mb_per_worker=2048,
+    refiner_extras=("hf", "video"),
     secrets=mdr.Secrets.dict(
         {
             "HF_TOKEN": None,

--- a/docs/examples/datasets/merge-lerobot-datasets.md
+++ b/docs/examples/datasets/merge-lerobot-datasets.md
@@ -23,10 +23,10 @@ pipeline = (
 pipeline.launch_cloud(
     name="merge-pick-cubes",
     num_workers=4,
+    refiner_extras=("hf", "video"),
     secrets={"HF_TOKEN": None},
 )
 ```
 
 The reader merges task metadata. The writer finalizes output metadata in a
 reducer stage.
-

--- a/docs/examples/formats/aloha-hdf5.md
+++ b/docs/examples/formats/aloha-hdf5.md
@@ -47,6 +47,7 @@ Then launch:
 pipeline.launch_cloud(
     name="convert-aloha",
     num_workers=8,
+    refiner_extras=("hdf5", "hf", "video"),
     secrets={"HF_TOKEN": None},
 )
 ```

--- a/docs/examples/formats/libero-hdf5.md
+++ b/docs/examples/formats/libero-hdf5.md
@@ -62,7 +62,7 @@ output = f"{output_prefix}/{stamp}-full-eval"
         num_workers=40,
         cpus_per_worker=1,
         mem_mb_per_worker=1024,
-        extra_dependencies=("av", "h5py", "huggingface-hub>=1.4.1", "pillow"),
+        refiner_extras=("hdf5", "hf", "video"),
         secrets=mdr.Secrets.env(name="default", keys=["HF_TOKEN"]),
     )
 )
@@ -119,7 +119,7 @@ with spaces.
 example bounds per-worker video preparation with `max_video_prepare_in_flight=2`
 to keep memory use predictable while two camera streams are encoded.
 
-`launch_cloud(...)` runs the conversion with 40 workers. `extra_dependencies`
+`launch_cloud(...)` runs the conversion with 40 workers. `refiner_extras`
 installs the packages needed to read HDF5, access Hugging Face storage, and
 encode videos. The `HF_TOKEN` secret is passed through so workers can read and
 write Hugging Face paths.

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -78,6 +78,7 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
+    refiner_extras=["hf", "video"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```

--- a/docs/platform/manifests.md
+++ b/docs/platform/manifests.md
@@ -38,25 +38,26 @@ Use `--json` for an agent, notebook, or CI job.
 
 ## Dependency Entries
 
-Cloud launch normally captures installed packages from the submitting Python
-environment. Those entries appear as package/version pairs in the manifest:
-
-```text
-pandas==2.3.3
-pyarrow==23.0.1
-```
-
-`launch_cloud(extra_dependencies=[...])` merges additional pip requirement
-strings into that list. Extra dependencies take precedence over captured
-packages with the same normalized package name:
+Use `refiner_extras` for Refiner
+[optional dependency groups](../reference/optional-dependencies.md), such as
+Hugging Face, HDF5, video, S3, or hand tracking support:
 
 ```python
 pipeline.launch_cloud(
-    name="gpu-run",
-    extra_dependencies=[
+    name="hand-tracking",
+    refiner_extras=["hand_tracking"],
+)
+```
+
+Use `dependencies` for other packages needed by your code:
+
+```python
+pipeline.launch_cloud(
+    name="custom-model-job",
+    refiner_extras=["hf"],
+    dependencies=[
         "torch==2.6.0",
         "transformers>=4.55",
-        "macrodata-refiner[hand_tracking]",
     ],
 )
 ```
@@ -67,16 +68,17 @@ ranges are shown as the submitted install string:
 ```text
 torch==2.6.0
 transformers>=4.55
-macrodata-refiner[hand_tracking]
 ```
 
 Environment markers are not preserved. Do not include markers in
-`extra_dependencies`; list the package as it should install on Macrodata Cloud.
+`dependencies`; list the package as it should install on Macrodata Cloud.
 For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
 
-If `sync_local_dependencies=False`, the manifest skips locally detected
-packages. Explicit `extra_dependencies` still appear and install in the cloud
-runtime.
+Finally, if `sync_local_dependencies=True`, Refiner tries to sync packages from
+the submitting Python environment. Those entries appear as package/version
+pairs in the manifest. Explicit `dependencies` take precedence over synced
+packages with the same package name. If any synced package cannot be resolved
+from PyPI during cloud image setup, the job will fail.
 
 ## What To Look For
 

--- a/docs/platform/secrets-and-environment.md
+++ b/docs/platform/secrets-and-environment.md
@@ -55,6 +55,7 @@ time:
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
+    refiner_extras=["hf"],
     secrets=mdr.Secrets.dict({"HF_TOKEN": "---"}),
 )
 ```
@@ -66,6 +67,7 @@ with the real token before submitting. You can also pass a plain mapping, but
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
+    refiner_extras=["hf"],
     secrets={"HF_TOKEN": "---"},
 )
 ```
@@ -78,6 +80,7 @@ sent with this job:
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
+    refiner_extras=["hf"],
     secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
 )
 ```

--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -67,6 +67,7 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
+    refiner_extras=["hf", "s3"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```
@@ -80,8 +81,9 @@ Common launch settings:
 | `cpus_per_worker` | CPU allocation per worker. |
 | `mem_mb_per_worker` | Memory allocation per worker. |
 | `gpu` | GPU type/count per worker. |
-| `sync_local_dependencies` | Include detected packages from the submitting environment. Defaults to `True`. |
-| `extra_dependencies` | Additional pip requirement strings to install on workers. These override captured packages with the same package name. |
+| `refiner_extras` | Refiner [optional dependency groups](../reference/optional-dependencies.md) to install on workers, such as `["hf", "video"]`. |
+| `dependencies` | Additional pip requirement strings to install on workers. |
+| `sync_local_dependencies` | Ask Refiner to try syncing packages from the submitting environment. Defaults to `False`. |
 | `secrets` | Secret values or workspace secret references passed to workers. |
 | `env` | Non-secret environment variables. |
 | `continue_from_job` | Reuse compatible outputs from a prior cloud job. |
@@ -91,29 +93,40 @@ See [Cloud Launcher](../running-pipelines/cloud-launcher.md) and
 
 ### Dependency Overrides
 
-Most cloud launches use the locally captured package list. Use
-`extra_dependencies` when the worker needs a package that is not installed
-locally, or when a cloud run should pin a different version:
+If your job requires support for a Refiner feature, pass the matching
+`refiner_extras`. See the
+[optional dependency groups](../reference/optional-dependencies.md):
 
 ```python
 pipeline.launch_cloud(
     name="hand-tracking",
     gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
-    extra_dependencies=["macrodata-refiner[hand_tracking]"],
+    refiner_extras=["hand_tracking"],
 )
 ```
 
-Entries are pip requirement strings. Exact pins, versionless requirements,
-ranges, and extras are supported. Extra dependencies are merged into the
-dependency manifest by package name and take precedence over locally captured
-packages with the same name.
+If your code needs other packages, pass them with `dependencies`:
+
+```python
+pipeline.launch_cloud(
+    name="custom-model-job",
+    refiner_extras=["hf"],
+    dependencies=["torch", "transformers>=4.55"],
+)
+```
+
+Dependency entries are pip requirement strings. Exact pins, versionless
+requirements, ranges, and package extras are supported.
 
 Environment markers are not preserved. Do not include markers in
-`extra_dependencies`; list the package as it should install on Macrodata Cloud.
+`dependencies`; list the package as it should install on Macrodata Cloud.
 For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
 
-Set `sync_local_dependencies=False` to skip local package capture while still
-installing explicitly listed `extra_dependencies`.
+Finally, if you would like Refiner to try syncing the packages installed in
+your current Python environment, set `sync_local_dependencies=True`. Explicit
+`dependencies` take precedence over synced packages with the same package name.
+If one of those packages cannot be resolved from PyPI during cloud image setup,
+the job will fail.
 
 ## What Gets Submitted
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -208,7 +208,7 @@ output = "hf://buckets/macrodata/test_bucket/libero-spatial"
         num_workers=10,
         cpus_per_worker=1,
         mem_mb_per_worker=1024,
-        extra_dependencies=("av", "h5py", "huggingface-hub>=1.4.1", "pillow"),
+        refiner_extras=("hdf5", "hf", "video"),
         # Replace this with a token that can write the output.
         secrets=mdr.Secrets.dict({"HF_TOKEN": "---"}),
     )

--- a/docs/reading-data/hugging-face.md
+++ b/docs/reading-data/hugging-face.md
@@ -23,6 +23,7 @@ For private datasets, provide `HF_TOKEN` locally or as a cloud secret.
 ```python
 pipeline.launch_cloud(
     name="private-dataset-job",
+    refiner_extras=["hf"],
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -46,4 +47,3 @@ Use this for table-style datasets. For LeRobot dataset roots, prefer
 
 - [Path Formats](../reference/path-formats.md)
 - [Secrets and Environment](../platform/secrets-and-environment.md)
-

--- a/docs/reference/optional-dependencies.md
+++ b/docs/reference/optional-dependencies.md
@@ -9,6 +9,7 @@ Install extras based on the data and operations you use.
 
 | Extra | Enables |
 | --- | --- |
+| `all` | Includes every extra below; useful for testing and development. |
 | `hf` | Hugging Face datasets, Hub APIs, and HF filesystem helpers. |
 | `hand_tracking` | Hand tracking with ego-vision. |
 | `hdf5` | HDF5 reader support. |
@@ -17,7 +18,6 @@ Install extras based on the data and operations you use.
 | `video` | Video decode/write support. |
 | `text` | Common Crawl text readers. |
 | `s3` | S3 filesystem support. |
-| `all` | Development/testing superset. |
 
 Examples:
 

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -14,7 +14,7 @@ pipeline.launch_cloud(
     num_workers=8,
     cpus_per_worker=4,
     mem_mb_per_worker=8192,
-    extra_dependencies=["macrodata-refiner[hand_tracking]"],
+    refiner_extras=["hand_tracking"],
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -35,51 +35,45 @@ You can inspect submitted metadata through the platform and CLI. See
 
 ## Runtime Dependencies
 
-By default, cloud launch captures packages from the local Python environment and
-adds them to the job manifest. Workers install the submitted dependency list
-before running the pipeline.
+By default, cloud launch installs base Refiner. Add only the runtime pieces your
+workers need.
 
-Use `extra_dependencies` when a cloud worker needs packages that are not present
-locally, or when the cloud package should override the locally captured version:
+If your pipeline needs a Refiner feature such as Hugging Face readers, HDF5,
+video, S3, or hand tracking, pass the matching `refiner_extras`. See the
+[optional dependency groups](../reference/optional-dependencies.md):
 
 ```python
 pipeline.launch_cloud(
     name="hand-tracking",
     gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
-    extra_dependencies=["macrodata-refiner[hand_tracking]"],
+    refiner_extras=["hand_tracking"],
 )
 ```
 
+For packages outside Refiner's optional feature groups, pass `dependencies`.
 Each entry is a pip requirement string. Versionless requirements, exact pins,
-ranges, and extras are accepted:
-
-```python
-extra_dependencies=[
-    "torch",
-    "transformers>=4.55",
-    "macrodata-refiner[hand_tracking]",
-]
-```
-
-Environment markers are not preserved. Do not include markers in
-`extra_dependencies`; list the package as it should install on Macrodata Cloud.
-For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
-
-Extra dependencies take precedence over captured local packages with the same
-package name. For example, if the local environment has `torch==2.4.0` but
-`extra_dependencies` includes `torch==2.6.0`, the submitted manifest keeps the
-explicit `torch==2.6.0` pin.
-
-Set `sync_local_dependencies=False` to skip local environment capture. Extra
-dependencies still install:
+ranges, and package extras are accepted:
 
 ```python
 pipeline.launch_cloud(
-    name="minimal-runtime",
-    sync_local_dependencies=False,
-    extra_dependencies=["torch", "macrodata-refiner[hf]"],
+    name="custom-model-job",
+    refiner_extras=["hf"],
+    dependencies=[
+        "torch",
+        "transformers>=4.55",
+    ],
 )
 ```
+
+Environment markers are not preserved. Do not include markers in
+`dependencies`; list the package as it should install on Macrodata Cloud.
+For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
+
+Finally, if you would like Refiner to try syncing the packages installed in
+your current Python environment, set `sync_local_dependencies=True`. Explicit
+`dependencies` take precedence over synced packages with the same package name.
+If any synced package cannot be resolved from PyPI, the cloud job setup will
+fail.
 
 ## Secrets
 

--- a/examples/hand_tracking.py
+++ b/examples/hand_tracking.py
@@ -48,7 +48,7 @@ def hand_tracking_annotation(row: Any) -> dict[str, Any]:
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        extra_dependencies=("ego-vision[models]==0.1.25",),
+        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/examples/inference/anthropic_image_descriptions.py
+++ b/examples/inference/anthropic_image_descriptions.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-anthropic-descriptions",
             num_workers=1,
+            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "ANTHROPIC_API_KEY": None}),
         )
     )

--- a/examples/inference/gemini_image_descriptions.py
+++ b/examples/inference/gemini_image_descriptions.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-gemini-descriptions",
             num_workers=1,
+            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict(
                 {"HF_TOKEN": None, "GOOGLE_GENERATIVE_AI_API_KEY": None}
             ),

--- a/examples/inference/inference_endpoint.py
+++ b/examples/inference/inference_endpoint.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-openai-endpoint-descriptions",
             num_workers=1,
+            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "OPENAI_API_KEY": None}),
         )
     )

--- a/examples/inference/inference_service.py
+++ b/examples/inference/inference_service.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-vllm-descriptions",
             num_workers=1,
+            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
         )
     )

--- a/examples/inference/openai_image_descriptions.py
+++ b/examples/inference/openai_image_descriptions.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-openai-descriptions",
             num_workers=1,
+            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "OPENAI_API_KEY": None}),
         )
     )

--- a/examples/robotics/libero_hdf5.py
+++ b/examples/robotics/libero_hdf5.py
@@ -56,7 +56,7 @@ def main() -> None:
             num_workers=40,
             cpus_per_worker=1,
             mem_mb_per_worker=1024,
-            extra_dependencies=("av", "h5py", "huggingface-hub>=1.4.1", "pillow"),
+            refiner_extras=("hdf5", "hf", "video"),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
         )
     )

--- a/examples/robotics/merging.py
+++ b/examples/robotics/merging.py
@@ -11,5 +11,6 @@ mdr.read_lerobot(
     name="merge_aloha",
     num_workers=1,
     mem_mb_per_worker=1024 * 8,
+    refiner_extras=("hf", "video"),
     secrets={"HF_TOKEN": None},
 )

--- a/examples/robotics/motion_trim.py
+++ b/examples/robotics/motion_trim.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
             name="motion_trim-robot",
             num_workers=1,
             mem_mb_per_worker=1024 * 2,
+            refiner_extras=("hf", "video"),
             secrets={
                 "HF_TOKEN": None,
             },

--- a/examples/robotics/robometer_reward.py
+++ b/examples/robotics/robometer_reward.py
@@ -33,7 +33,7 @@ def main() -> None:
             num_workers=1,
             cpus_per_worker=1,
             mem_mb_per_worker=4096,
-            extra_dependencies=("macrodata-refiner[hf,video]",),
+            refiner_extras=("hf", "video"),
             secrets={"HF_TOKEN": None},
         )
     )

--- a/examples/robotics/subtask_annotation.py
+++ b/examples/robotics/subtask_annotation.py
@@ -32,6 +32,7 @@ pipeline.launch_cloud(
     num_workers=1,
     cpus_per_worker=1,
     mem_mb_per_worker=2048,
+    refiner_extras=("hf", "video"),
     secrets=mdr.Secrets.dict(
         {
             "HF_TOKEN": None,

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -103,9 +103,10 @@ class CloudLauncher(BaseLauncher):
         gpu: Optional GPU runtime request for cloud scheduling.
         sync_local_dependencies: Whether to include packages detected from the
             local environment in the cloud runtime.
-        extra_dependencies: Additional packages to install in the cloud runtime.
-            Entries are requirement strings. These take precedence over packages
-            detected from the local environment.
+        dependencies: Additional packages to install in the cloud runtime.
+            Entries are requirement strings.
+        refiner_extras: Optional macrodata-refiner extras to install in the cloud
+            runtime, such as "hf" or "video".
         secrets: Optional secret sources mounted into the cloud runtime.
         env: Optional plain environment variables mounted into the cloud runtime.
     """
@@ -119,8 +120,9 @@ class CloudLauncher(BaseLauncher):
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
-        sync_local_dependencies: bool = True,
-        extra_dependencies: Sequence[str] | None = None,
+        sync_local_dependencies: bool = False,
+        dependencies: Sequence[str] | None = None,
+        refiner_extras: Sequence[str] | None = None,
         secrets: SecretInput | None = None,
         env: dict[str, object | None] | None = None,
         continue_from_job: str | None = None,
@@ -141,7 +143,8 @@ class CloudLauncher(BaseLauncher):
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
         self.sync_local_dependencies = sync_local_dependencies
-        self.extra_dependencies = extra_dependencies
+        self.dependencies = dependencies
+        self.refiner_extras = refiner_extras
         self.secrets = normalize_secret_sources(secrets)
         self.env = env
         self.continue_from_job = normalized_continue_from_job
@@ -158,7 +161,8 @@ class CloudLauncher(BaseLauncher):
         manifest = build_run_manifest(
             secret_values=secret_values,
             capture_dependencies=self.sync_local_dependencies,
-            extra_dependencies=self.extra_dependencies,
+            dependencies=self.dependencies,
+            refiner_extras=self.refiner_extras,
         )
         environment = manifest.get("environment")
         if environment is None:

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -708,8 +708,9 @@ class RefinerPipeline:
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
-        sync_local_dependencies: bool = True,
-        extra_dependencies: Sequence[str] | None = None,
+        sync_local_dependencies: bool = False,
+        dependencies: Sequence[str] | None = None,
+        refiner_extras: Sequence[str] | None = None,
         secrets: SecretInput | None = None,
         env: Mapping[str, object | None] | None = None,
         continue_from_job: str | None = None,
@@ -725,10 +726,11 @@ class RefinerPipeline:
             gpu: Optional structured GPU request.
             sync_local_dependencies: Include packages detected from the local
                 environment in the cloud runtime.
-            extra_dependencies: Additional packages to install in the cloud runtime.
+            dependencies: Additional packages to install in the cloud runtime.
                 Entries are requirement strings such as `"torch"` or
-                `"ego-vision[models]==0.1.2"`. These take precedence over packages
-                detected from the local environment.
+                `"ego-vision[models]==0.1.2"`.
+            refiner_extras: Optional macrodata-refiner extras to install in the
+                cloud runtime, such as `"hf"` or `"video"`.
             secrets: Secret sources to mount inside the cloud image. A mapping keeps
                 the legacy behavior; `None` values are loaded from the submitting
                 environment. `Secrets.env(...)` references stored workspace secrets.
@@ -750,7 +752,8 @@ class RefinerPipeline:
             mem_mb_per_worker=mem_mb_per_worker,
             gpu=gpu,
             sync_local_dependencies=sync_local_dependencies,
-            extra_dependencies=extra_dependencies,
+            dependencies=dependencies,
+            refiner_extras=refiner_extras,
             secrets=secrets,
             env=dict(env) if env is not None else None,
             continue_from_job=continue_from_job,

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -102,25 +102,25 @@ def _dependency_key(name: str) -> str:
     return _NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN.sub("-", package_name).lower()
 
 
-def _merge_extra_dependencies(
-    dependencies: list[dict[str, str]],
-    extra_dependencies: Sequence[str] | None,
+def _merge_dependencies(
+    captured_dependencies: list[dict[str, str]],
+    dependencies: Sequence[str] | None,
 ) -> list[dict[str, str]]:
-    if not extra_dependencies:
-        return dependencies
-    if isinstance(extra_dependencies, str):
-        raise ValueError("extra_dependencies must be a sequence of requirement strings")
+    if not dependencies:
+        return captured_dependencies
+    if isinstance(dependencies, str):
+        raise ValueError("dependencies must be a sequence of requirement strings")
 
-    merged = {_dependency_key(dep["name"]): dict(dep) for dep in dependencies}
-    for dependency in extra_dependencies:
+    merged = {_dependency_key(dep["name"]): dict(dep) for dep in captured_dependencies}
+    for dependency in dependencies:
         text = str(dependency).strip()
         if not text:
-            raise ValueError("extra_dependencies contains an empty dependency name")
+            raise ValueError("dependencies contains an empty dependency name")
         try:
             requirement = Requirement(text)
         except InvalidRequirement as err:
             raise ValueError(
-                f"extra_dependencies contains invalid requirement {text!r}"
+                f"dependencies contains invalid requirement {text!r}"
             ) from err
 
         specifiers = list(requirement.specifier)
@@ -135,6 +135,35 @@ def _merge_extra_dependencies(
         else:
             merged[_dependency_key(requirement.name)] = {"name": text}
     return list(merged.values())
+
+
+def _normalize_refiner_extras(refiner_extras: Sequence[str] | None) -> list[str]:
+    if not refiner_extras:
+        return []
+    if isinstance(refiner_extras, str):
+        raise ValueError("refiner_extras must be a sequence of extra names")
+
+    extras: set[str] = set()
+    for extra in refiner_extras:
+        text = str(extra).strip()
+        if text:
+            extras.add(_NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN.sub("-", text).lower())
+    try:
+        metadata = importlib_metadata.metadata("macrodata-refiner")
+    except importlib_metadata.PackageNotFoundError:
+        available: set[str] = set()
+    else:
+        available = {
+            _NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN.sub("-", extra).lower()
+            for extra in metadata.get_all("Provides-Extra") or []
+        }
+    invalid = sorted(extras.difference(available)) if available else []
+    if invalid:
+        valid = ", ".join(sorted(available)) or "<none>"
+        raise ValueError(
+            f"refiner_extras contains unknown extra {invalid[0]!r}; valid extras: {valid}"
+        )
+    return sorted(extras)
 
 
 def _resolve_installed_version() -> str | None:
@@ -207,7 +236,8 @@ def build_run_manifest(
     *,
     secret_values: Sequence[str] = (),
     capture_dependencies: bool = True,
-    extra_dependencies: Sequence[str] | None = None,
+    dependencies: Sequence[str] | None = None,
+    refiner_extras: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     script_path = _detect_script_path()
     path, text, sha256 = _read_script(script_path)
@@ -227,14 +257,15 @@ def build_run_manifest(
             "python_version": platform.python_version(),
             "refiner_version": refiner_version,
             "refiner_ref": refiner_ref,
+            "refiner_extras": _normalize_refiner_extras(refiner_extras),
             "platform": f"{platform.system().lower()}-{platform.machine().lower()}",
         },
     }
-    dependencies = _collect_dependencies() if capture_dependencies else []
-    if capture_dependencies or extra_dependencies:
-        manifest["dependencies"] = _merge_extra_dependencies(
+    captured_dependencies = _collect_dependencies() if capture_dependencies else []
+    if capture_dependencies or dependencies:
+        manifest["dependencies"] = _merge_dependencies(
+            captured_dependencies,
             dependencies,
-            extra_dependencies,
         )
     return manifest
 

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -317,7 +317,9 @@ def test_gpu_rejects_unsupported_values() -> None:
         GPU(count=1, type="h100", cuda_version="13.0")  # type: ignore[arg-type]
 
 
-def test_pipeline_launch_cloud_can_skip_local_dependency_capture(monkeypatch) -> None:
+def test_pipeline_launch_cloud_skips_local_dependency_capture_by_default(
+    monkeypatch,
+) -> None:
     captured_manifest_kwargs = {}
 
     def manifest(**kwargs):
@@ -335,14 +337,15 @@ def test_pipeline_launch_cloud_can_skip_local_dependency_capture(monkeypatch) ->
     pipeline = read_jsonl("input.jsonl")
     pipeline.launch_cloud(
         name="demo cloud",
-        sync_local_dependencies=False,
-        extra_dependencies=["torch"],
+        dependencies=["torch"],
+        refiner_extras=["hf", "video"],
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.manifest == {"version": 1}
     assert captured_manifest_kwargs["capture_dependencies"] is False
-    assert captured_manifest_kwargs["extra_dependencies"] == ["torch"]
+    assert captured_manifest_kwargs["dependencies"] == ["torch"]
+    assert captured_manifest_kwargs["refiner_extras"] == ["hf", "video"]
 
 
 def test_pipeline_launch_cloud_resolves_secrets(monkeypatch) -> None:

--- a/tests/platform/test_manifest.py
+++ b/tests/platform/test_manifest.py
@@ -41,6 +41,7 @@ def test_build_run_manifest_captures_script_from_argv(
     assert manifest["environment"]["python_version"]
     assert manifest["environment"]["refiner_version"] == "0.2.0"
     assert manifest["environment"]["refiner_ref"] == "abc123def456"
+    assert manifest["environment"]["refiner_extras"] == []
     assert isinstance(manifest["dependencies"], list)
 
 
@@ -70,9 +71,7 @@ def test_build_run_manifest_can_skip_dependency_capture(
     assert "dependencies" not in manifest
 
 
-def test_build_run_manifest_merges_extra_dependencies(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_build_run_manifest_merges_dependencies(monkeypatch, tmp_path: Path) -> None:
     script_path = tmp_path / "demo_job.py"
     script_path.write_text("print('hello')\n", encoding="utf-8")
 
@@ -100,7 +99,7 @@ def test_build_run_manifest_merges_extra_dependencies(
     )
 
     manifest = build_run_manifest(
-        extra_dependencies=[
+        dependencies=[
             "torch==2.6.0",
             "ego-vision[models]==0.1.2",
             "new-package",
@@ -118,7 +117,7 @@ def test_build_run_manifest_merges_extra_dependencies(
     ]
 
 
-def test_build_run_manifest_adds_extra_dependencies_without_capture(
+def test_build_run_manifest_adds_dependencies_without_capture(
     monkeypatch, tmp_path: Path
 ) -> None:
     script_path = tmp_path / "demo_job.py"
@@ -140,13 +139,13 @@ def test_build_run_manifest_adds_extra_dependencies_without_capture(
 
     manifest = build_run_manifest(
         capture_dependencies=False,
-        extra_dependencies=["torch==2.6.0"],
+        dependencies=["torch==2.6.0"],
     )
 
     assert manifest["dependencies"] == [{"name": "torch", "version": "2.6.0"}]
 
 
-def test_build_run_manifest_rejects_invalid_extra_dependency(
+def test_build_run_manifest_rejects_invalid_dependency(
     monkeypatch, tmp_path: Path
 ) -> None:
     script_path = tmp_path / "demo_job.py"
@@ -154,10 +153,113 @@ def test_build_run_manifest_rejects_invalid_extra_dependency(
 
     monkeypatch.setattr(sys, "argv", [str(script_path)])
 
-    with pytest.raises(
-        ValueError, match="extra_dependencies contains invalid requirement"
-    ):
-        build_run_manifest(extra_dependencies=["not a requirement"])
+    with pytest.raises(ValueError, match="dependencies contains invalid requirement"):
+        build_run_manifest(dependencies=["not a requirement"])
+
+
+def test_build_run_manifest_records_refiner_extras(monkeypatch, tmp_path: Path) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+
+    manifest = build_run_manifest(
+        capture_dependencies=False,
+        refiner_extras=["video", "hf", "hf"],
+    )
+
+    assert manifest["environment"]["refiner_extras"] == ["hf", "video"]
+    assert "dependencies" not in manifest
+
+
+def test_build_run_manifest_normalizes_refiner_extra_names(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+
+    manifest = build_run_manifest(
+        capture_dependencies=False,
+        refiner_extras=["HAND_tracking", "hand-tracking", "hf"],
+    )
+
+    assert manifest["environment"]["refiner_extras"] == ["hand-tracking", "hf"]
+    assert "dependencies" not in manifest
+
+
+def test_build_run_manifest_validates_refiner_extras_from_package_metadata(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+    metadata = Message()
+    metadata["Provides-Extra"] = "hf"
+    metadata["Provides-Extra"] = "hand_tracking"
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest.importlib_metadata.metadata",
+        lambda name: metadata,
+    )
+
+    manifest = build_run_manifest(
+        capture_dependencies=False,
+        refiner_extras=["HAND-tracking"],
+    )
+
+    assert manifest["environment"]["refiner_extras"] == ["hand-tracking"]
+    with pytest.raises(ValueError, match="unknown extra 'hand-trakcing'"):
+        build_run_manifest(capture_dependencies=False, refiner_extras=["hand_trakcing"])
+
+
+def test_build_run_manifest_rejects_string_refiner_extras(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+
+    with pytest.raises(ValueError, match="refiner_extras must be a sequence"):
+        build_run_manifest(capture_dependencies=False, refiner_extras="hf")
+
+
+def test_build_run_manifest_skips_refiner_extra_validation_without_metadata_extras(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest.importlib_metadata.metadata",
+        lambda _name: Message(),
+    )
+
+    manifest = build_run_manifest(capture_dependencies=False, refiner_extras=["bad"])
+
+    assert manifest["environment"]["refiner_extras"] == ["bad"]
+
+
+def test_build_run_manifest_rejects_unknown_refiner_extra(
+    monkeypatch, tmp_path: Path
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+    metadata = Message()
+    metadata["Provides-Extra"] = "hf"
+    metadata["Provides-Extra"] = "video"
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+    monkeypatch.setattr(
+        "refiner.platform.manifest.importlib_metadata.metadata",
+        lambda _name: metadata,
+    )
+
+    with pytest.raises(ValueError, match="unknown extra 'not-real'"):
+        build_run_manifest(capture_dependencies=False, refiner_extras=["not-real"])
 
 
 def test_build_run_manifest_redacts_secret_values(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Summary
- Default cloud launches to not sync local dependencies.
- Rename extra_dependencies to dependencies and add explicit refiner_extras.
- Record refiner_extras in manifests and update cloud docs/examples.

Tests
- uv run pytest tests/platform/test_manifest.py tests/launchers/test_cloud_launcher.py
- uv run ruff check src/refiner/platform/manifest.py src/refiner/launchers/cloud.py src/refiner/pipeline/pipeline.py tests/platform/test_manifest.py tests/launchers/test_cloud_launcher.py examples/hand_tracking.py examples/robotics/libero_hdf5.py examples/robotics/robometer_reward.py
- uv run ty check src/refiner/platform/manifest.py src/refiner/launchers/cloud.py src/refiner/pipeline/pipeline.py tests/platform/test_manifest.py tests/launchers/test_cloud_launcher.py examples/hand_tracking.py examples/robotics/libero_hdf5.py examples/robotics/robometer_reward.py