### PR TITLE
[codex] Infer cloud Refiner extras from pipeline blocks

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -97,7 +97,6 @@ the manifest or source code.
 ```python
 pipeline.launch_cloud(
     name="private-dataset",
-    refiner_extras=["hf"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```

--- a/docs/episode-operations/hand-tracking.md
+++ b/docs/episode-operations/hand-tracking.md
@@ -50,7 +50,6 @@ pipeline = (
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )
@@ -58,10 +57,11 @@ pipeline = (
 
 ## Requirements
 
-Install the hand-tracking extra:
+Install the hand-tracking extra. If you use the `read_hf_dataset(...)` example
+on this page locally, install `datasets` too:
 
 ```bash
-pip install macrodata-refiner[hand_tracking]
+pip install macrodata-refiner[datasets,hand_tracking]
 ```
 
 Input rows must implement `RoboticsRow` and include the required `video_key` in
@@ -149,7 +149,6 @@ pipeline = (
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/docs/examples/annotations/hand-tracking.md
+++ b/docs/examples/annotations/hand-tracking.md
@@ -62,7 +62,6 @@ def hand_tracking_annotation(row: Any) -> dict[str, Any]:
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/docs/examples/annotations/reward-models.md
+++ b/docs/examples/annotations/reward-models.md
@@ -46,7 +46,6 @@ def main() -> None:
             num_workers=1,
             cpus_per_worker=1,
             mem_mb_per_worker=4096,
-            refiner_extras=("hf", "video"),
             secrets={"HF_TOKEN": None},
         )
     )

--- a/docs/examples/annotations/subtask-annotations.md
+++ b/docs/examples/annotations/subtask-annotations.md
@@ -35,7 +35,6 @@ pipeline.launch_cloud(
     num_workers=1,
     cpus_per_worker=1,
     mem_mb_per_worker=2048,
-    refiner_extras=("hf", "video"),
     secrets=mdr.Secrets.dict(
         {
             "HF_TOKEN": None,

--- a/docs/examples/datasets/merge-lerobot-datasets.md
+++ b/docs/examples/datasets/merge-lerobot-datasets.md
@@ -23,7 +23,6 @@ pipeline = (
 pipeline.launch_cloud(
     name="merge-pick-cubes",
     num_workers=4,
-    refiner_extras=("hf", "video"),
     secrets={"HF_TOKEN": None},
 )
 ```

--- a/docs/examples/formats/aloha-hdf5.md
+++ b/docs/examples/formats/aloha-hdf5.md
@@ -47,7 +47,6 @@ Then launch:
 pipeline.launch_cloud(
     name="convert-aloha",
     num_workers=8,
-    refiner_extras=("hdf5", "hf", "video"),
     secrets={"HF_TOKEN": None},
 )
 ```

--- a/docs/examples/formats/libero-hdf5.md
+++ b/docs/examples/formats/libero-hdf5.md
@@ -62,7 +62,6 @@ output = f"{output_prefix}/{stamp}-full-eval"
         num_workers=40,
         cpus_per_worker=1,
         mem_mb_per_worker=1024,
-        refiner_extras=("hdf5", "hf", "video"),
         secrets=mdr.Secrets.env(name="default", keys=["HF_TOKEN"]),
     )
 )
@@ -119,10 +118,10 @@ with spaces.
 example bounds per-worker video preparation with `max_video_prepare_in_flight=2`
 to keep memory use predictable while two camera streams are encoded.
 
-`launch_cloud(...)` runs the conversion with 40 workers. `refiner_extras`
-installs the packages needed to read HDF5, access Hugging Face storage, and
-encode videos. The `HF_TOKEN` secret is passed through so workers can read and
-write Hugging Face paths.
+`launch_cloud(...)` runs the conversion with 40 workers. Refiner automatically
+adds the extras needed to read HDF5, access Hugging Face storage, and encode
+videos. The `HF_TOKEN` secret is passed through so workers can read and write
+Hugging Face paths.
 
 Related: [HDF5 Reader](../../reading-data/hdf5.md),
 [Converting to Robot Rows](../../episode-data/converting-to-robot-rows.md).

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -78,7 +78,6 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
-    refiner_extras=["hf", "video"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```

--- a/docs/platform/manifests.md
+++ b/docs/platform/manifests.md
@@ -38,14 +38,19 @@ Use `--json` for an agent, notebook, or CI job.
 
 ## Dependency Entries
 
-Use `refiner_extras` for Refiner
-[optional dependency groups](../reference/optional-dependencies.md), such as
-Hugging Face, HDF5, video, S3, or hand tracking support:
+Built-in Refiner blocks automatically add the
+[optional dependency groups](../reference/optional-dependencies.md) they need to
+the manifest. Hugging Face dataset readers, Hugging Face paths, HDF5/Zarr
+readers, video writers, cloud storage paths, and hand tracking operations are
+recorded from the pipeline plan.
+
+Use `refiner_extras` only when code outside the built-in blocks needs a specific
+Refiner extra:
 
 ```python
 pipeline.launch_cloud(
-    name="hand-tracking",
-    refiner_extras=["hand_tracking"],
+    name="custom-datasets-helper",
+    refiner_extras=["datasets"],
 )
 ```
 
@@ -54,7 +59,6 @@ Use `dependencies` for other packages needed by your code:
 ```python
 pipeline.launch_cloud(
     name="custom-model-job",
-    refiner_extras=["hf"],
     dependencies=[
         "torch==2.6.0",
         "transformers>=4.55",

--- a/docs/platform/secrets-and-environment.md
+++ b/docs/platform/secrets-and-environment.md
@@ -55,7 +55,6 @@ time:
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
-    refiner_extras=["hf"],
     secrets=mdr.Secrets.dict({"HF_TOKEN": "---"}),
 )
 ```
@@ -67,7 +66,6 @@ with the real token before submitting. You can also pass a plain mapping, but
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
-    refiner_extras=["hf"],
     secrets={"HF_TOKEN": "---"},
 )
 ```
@@ -80,7 +78,6 @@ sent with this job:
 ```python
 pipeline.launch_cloud(
     name="private-hf-read",
-    refiner_extras=["hf"],
     secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
 )
 ```

--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -67,7 +67,6 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
-    refiner_extras=["hf", "s3"],
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```
@@ -81,7 +80,7 @@ Common launch settings:
 | `cpus_per_worker` | CPU allocation per worker. |
 | `mem_mb_per_worker` | Memory allocation per worker. |
 | `gpu` | GPU type/count per worker. |
-| `refiner_extras` | Refiner [optional dependency groups](../reference/optional-dependencies.md) to install on workers, such as `["hf", "video"]`. |
+| `refiner_extras` | Extra Refiner [optional dependency groups](../reference/optional-dependencies.md) to install on workers. Built-in blocks declare their own required extras automatically. |
 | `dependencies` | Additional pip requirement strings to install on workers. |
 | `sync_local_dependencies` | Ask Refiner to try syncing packages from the submitting environment. Defaults to `False`. |
 | `secrets` | Secret values or workspace secret references passed to workers. |
@@ -93,15 +92,19 @@ See [Cloud Launcher](../running-pipelines/cloud-launcher.md) and
 
 ### Dependency Overrides
 
-If your job requires support for a Refiner feature, pass the matching
-`refiner_extras`. See the
+Built-in Refiner readers, writers, and operations automatically declare the
+extras they require. For example, `read_hf_dataset(...)` adds `datasets`, Hugging
+Face paths add `hf`, HDF5 readers add `hdf5`, LeRobot/Zarr writers add their
+encoding extras, and `mdr.robotics.track_hands(...)` adds `hand_tracking`.
+
+You can still pass `refiner_extras` explicitly when code outside the built-in
+pipeline blocks needs a specific Refiner extra. See the
 [optional dependency groups](../reference/optional-dependencies.md):
 
 ```python
 pipeline.launch_cloud(
-    name="hand-tracking",
-    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
-    refiner_extras=["hand_tracking"],
+    name="custom-datasets-helper",
+    refiner_extras=["datasets"],
 )
 ```
 
@@ -110,7 +113,6 @@ If your code needs other packages, pass them with `dependencies`:
 ```python
 pipeline.launch_cloud(
     name="custom-model-job",
-    refiner_extras=["hf"],
     dependencies=["torch", "transformers>=4.55"],
 )
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -208,7 +208,6 @@ output = "hf://buckets/macrodata/test_bucket/libero-spatial"
         num_workers=10,
         cpus_per_worker=1,
         mem_mb_per_worker=1024,
-        refiner_extras=("hdf5", "hf", "video"),
         # Replace this with a token that can write the output.
         secrets=mdr.Secrets.dict({"HF_TOKEN": "---"}),
     )

--- a/docs/reading-data/hugging-face.md
+++ b/docs/reading-data/hugging-face.md
@@ -23,7 +23,6 @@ For private datasets, provide `HF_TOKEN` locally or as a cloud secret.
 ```python
 pipeline.launch_cloud(
     name="private-dataset-job",
-    refiner_extras=["hf"],
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -39,6 +38,9 @@ pipeline = mdr.read_hf_dataset(
     split="train",
 )
 ```
+
+For local use, install `macrodata-refiner[datasets]`. Cloud jobs add this extra
+automatically when the pipeline uses `read_hf_dataset(...)`.
 
 Use this for table-style datasets. For LeRobot dataset roots, prefer
 [`read_lerobot`](lerobot.md).

--- a/docs/reference/optional-dependencies.md
+++ b/docs/reference/optional-dependencies.md
@@ -10,7 +10,8 @@ Install extras based on the data and operations you use.
 | Extra | Enables |
 | --- | --- |
 | `all` | Includes every extra below; useful for testing and development. |
-| `hf` | Hugging Face datasets, Hub APIs, and HF filesystem helpers. |
+| `datasets` | Hugging Face dataset reader support; includes `hf`. |
+| `hf` | Hugging Face Hub APIs and HF filesystem helpers. |
 | `hand_tracking` | Hand tracking with ego-vision. |
 | `hdf5` | HDF5 reader support. |
 | `zarr` | Zarr reader and writer support. |
@@ -18,12 +19,13 @@ Install extras based on the data and operations you use.
 | `video` | Video decode/write support. |
 | `text` | Common Crawl text readers. |
 | `s3` | S3 filesystem support. |
+| `gcs` | Google Cloud Storage filesystem support. |
 
 Examples:
 
 ```bash
 pip install macrodata-refiner[hf,video]
-pip install macrodata-refiner[hf]
+pip install macrodata-refiner[datasets]
 pip install macrodata-refiner[hdf5,zarr]
 pip install macrodata-refiner[mcap]
 pip install macrodata-refiner[hand_tracking]

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -14,7 +14,6 @@ pipeline.launch_cloud(
     num_workers=8,
     cpus_per_worker=4,
     mem_mb_per_worker=8192,
-    refiner_extras=["hand_tracking"],
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -35,18 +34,19 @@ You can inspect submitted metadata through the platform and CLI. See
 
 ## Runtime Dependencies
 
-By default, cloud launch installs base Refiner. Add only the runtime pieces your
-workers need.
+Built-in Refiner readers, writers, and operations automatically declare the
+[optional dependency groups](../reference/optional-dependencies.md) they need.
+For example, `read_hf_dataset(...)` adds `datasets`, Hugging Face paths add
+`hf`, HDF5 readers add `hdf5`, cloud storage paths add the relevant storage
+extra, and `mdr.robotics.track_hands(...)` adds `hand_tracking`.
 
-If your pipeline needs a Refiner feature such as Hugging Face readers, HDF5,
-video, S3, or hand tracking, pass the matching `refiner_extras`. See the
-[optional dependency groups](../reference/optional-dependencies.md):
+You can still pass `refiner_extras` explicitly when code outside the built-in
+pipeline blocks needs a specific Refiner extra:
 
 ```python
 pipeline.launch_cloud(
-    name="hand-tracking",
-    gpu=mdr.GPU(count=1, type="h100", cuda_version="12.8"),
-    refiner_extras=["hand_tracking"],
+    name="custom-datasets-helper",
+    refiner_extras=["datasets"],
 )
 ```
 
@@ -57,7 +57,6 @@ ranges, and package extras are accepted:
 ```python
 pipeline.launch_cloud(
     name="custom-model-job",
-    refiner_extras=["hf"],
     dependencies=[
         "torch",
         "transformers>=4.55",

--- a/examples/hand_tracking.py
+++ b/examples/hand_tracking.py
@@ -48,7 +48,6 @@ def hand_tracking_annotation(row: Any) -> dict[str, Any]:
         num_workers=1,
         mem_mb_per_worker=32 * 1024,
         gpu=mdr.GPU(count=1, type="h100"),
-        refiner_extras=("hand_tracking",),
         secrets=mdr.Secrets.env(keys=("HF_TOKEN",)),
     )
 )

--- a/examples/inference/anthropic_image_descriptions.py
+++ b/examples/inference/anthropic_image_descriptions.py
@@ -76,7 +76,6 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-anthropic-descriptions",
             num_workers=1,
-            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "ANTHROPIC_API_KEY": None}),
         )
     )

--- a/examples/inference/gemini_image_descriptions.py
+++ b/examples/inference/gemini_image_descriptions.py
@@ -81,7 +81,6 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-gemini-descriptions",
             num_workers=1,
-            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict(
                 {"HF_TOKEN": None, "GOOGLE_GENERATIVE_AI_API_KEY": None}
             ),

--- a/examples/inference/inference_endpoint.py
+++ b/examples/inference/inference_endpoint.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-openai-endpoint-descriptions",
             num_workers=1,
-            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "OPENAI_API_KEY": None}),
         )
     )

--- a/examples/inference/inference_service.py
+++ b/examples/inference/inference_service.py
@@ -76,7 +76,6 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-vllm-descriptions",
             num_workers=1,
-            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
         )
     )

--- a/examples/inference/openai_image_descriptions.py
+++ b/examples/inference/openai_image_descriptions.py
@@ -76,7 +76,6 @@ if __name__ == "__main__":
         .launch_cloud(
             name="food101-openai-descriptions",
             num_workers=1,
-            refiner_extras=("hf",),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None, "OPENAI_API_KEY": None}),
         )
     )

--- a/examples/robotics/libero_hdf5.py
+++ b/examples/robotics/libero_hdf5.py
@@ -56,7 +56,6 @@ def main() -> None:
             num_workers=40,
             cpus_per_worker=1,
             mem_mb_per_worker=1024,
-            refiner_extras=("hdf5", "hf", "video"),
             secrets=mdr.Secrets.dict({"HF_TOKEN": None}),
         )
     )

--- a/examples/robotics/merging.py
+++ b/examples/robotics/merging.py
@@ -11,6 +11,5 @@ mdr.read_lerobot(
     name="merge_aloha",
     num_workers=1,
     mem_mb_per_worker=1024 * 8,
-    refiner_extras=("hf", "video"),
     secrets={"HF_TOKEN": None},
 )

--- a/examples/robotics/motion_trim.py
+++ b/examples/robotics/motion_trim.py
@@ -21,7 +21,6 @@ if __name__ == "__main__":
             name="motion_trim-robot",
             num_workers=1,
             mem_mb_per_worker=1024 * 2,
-            refiner_extras=("hf", "video"),
             secrets={
                 "HF_TOKEN": None,
             },

--- a/examples/robotics/robometer_reward.py
+++ b/examples/robotics/robometer_reward.py
@@ -33,7 +33,6 @@ def main() -> None:
             num_workers=1,
             cpus_per_worker=1,
             mem_mb_per_worker=4096,
-            refiner_extras=("hf", "video"),
             secrets={"HF_TOKEN": None},
         )
     )

--- a/examples/robotics/subtask_annotation.py
+++ b/examples/robotics/subtask_annotation.py
@@ -32,7 +32,6 @@ pipeline.launch_cloud(
     num_workers=1,
     cpus_per_worker=1,
     mem_mb_per_worker=2048,
-    refiner_extras=("hf", "video"),
     secrets=mdr.Secrets.dict(
         {
             "HF_TOKEN": None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,12 @@ video = [
     "pillow",
 ]
 hf = [
-    "datasets>=3.0.0",
     "huggingface-hub>=1.4.1",
     "hf>=1.7.1",
+]
+datasets = [
+    "macrodata-refiner[hf]",
+    "datasets>=3.0.0",
 ]
 hand_tracking = [
     "macrodata-refiner[hf]",
@@ -64,6 +67,9 @@ mcap = [
 s3 = [
     "s3fs",
 ]
+gcs = [
+    "gcsfs",
+]
 tensorflow = [
     "tensorflow",
 ]
@@ -77,6 +83,7 @@ testing = [
     "pytest-cov>=5.0.0",
 ]
 all = [
+    "macrodata-refiner[datasets]",
     "macrodata-refiner[hdf5]",
     "macrodata-refiner[hf]",
     "macrodata-refiner[mcap]",
@@ -84,6 +91,7 @@ all = [
     "macrodata-refiner[zarr]",
     "macrodata-refiner[text]",
     "macrodata-refiner[s3]",
+    "macrodata-refiner[gcs]",
     "macrodata-refiner[tfds]",
 ]
 

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -11,6 +11,7 @@ from typing import Any, TypeAlias, Union, cast
 from fsspec import AbstractFileSystem, url_to_fs
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileSystem
+from refiner.io.utils import required_refiner_extras
 
 DataFilePath: TypeAlias = str | PathLike[str]
 DataFileSpec: TypeAlias = tuple[DataFilePath, AbstractFileSystem]
@@ -145,6 +146,9 @@ class DataFile:
 
     def abs_path(self) -> str:
         return self.fs.unstrip_protocol(self.path).removeprefix("file://")
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return required_refiner_extras(self.path, self.fs)
 
     @property
     def is_local(self) -> bool:

--- a/src/refiner/io/datafolder.py
+++ b/src/refiner/io/datafolder.py
@@ -7,6 +7,7 @@ from fsspec.implementations.dirfs import DirFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
 from refiner.io.datafile import DataFile, _storage_options_for_path
+from refiner.io.utils import required_refiner_extras
 
 DataFolderPath: TypeAlias = str | PathLike[str]
 DataFolderSpec: TypeAlias = tuple[DataFolderPath, AbstractFileSystem]
@@ -101,6 +102,9 @@ class DataFolder(DirFileSystem):
     def abs_path(self, path: str = "") -> str:
         # make sure we strip file:// and similar
         return self.fs.unstrip_protocol(self._join(path)).removeprefix("file://")
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return required_refiner_extras(self.path, self.fs)
 
     def abs_paths(self, paths: str | Iterable[str]) -> str | list[str]:
         """

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -8,8 +8,13 @@ from typing import Any, Literal, TypeAlias, Union, cast
 
 from fsspec import AbstractFileSystem, url_to_fs
 
-from refiner.io.datafile import DataFile, DataFileSpec, _storage_options_for_path
+from refiner.io.datafile import (
+    DataFile,
+    DataFileSpec,
+    _storage_options_for_path,
+)
 from refiner.io.datafolder import DataFolder, DataFolderSpec
+from refiner.io.utils import required_refiner_extras
 
 DataFileSetInput: TypeAlias = Union[
     str, PathLike[str], DataFileSpec, DataFolderSpec, DataFile, DataFolder
@@ -21,6 +26,9 @@ DataFileSetLike: TypeAlias = Union[DataFileSetInput, Sequence[DataFileSetInput]]
 class _PathSource:
     path: str
     fs: AbstractFileSystem
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return required_refiner_extras(self.path, self.fs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,6 +181,17 @@ class DataFileSet:
         if not all(isinstance(entry, DataFolder) for entry in entries):
             raise TypeError("DataFileSet entries are not all folders")
         return cast(tuple[DataFolder, ...], entries)
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    extra
+                    for entry in self.entries
+                    for extra in entry.required_refiner_extras()
+                }
+            )
+        )
 
     @property
     def resolved_entries(self) -> tuple[DataFile | DataFolder, ...]:

--- a/src/refiner/io/utils.py
+++ b/src/refiner/io/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fsspec import AbstractFileSystem
+
+
+_PROTOCOL_REFINER_EXTRAS = {
+    "s3": "s3",
+    "s3a": "s3",
+    "hf": "hf",
+    "gcs": "gcs",
+    "gs": "gcs",
+}
+
+
+def required_refiner_extras(path: str, fs: AbstractFileSystem) -> tuple[str, ...]:
+    protocol = fs.protocol
+    protocols = (protocol,) if isinstance(protocol, str) else tuple(protocol)
+    path_protocol, sep, _rest = path.partition("://")
+    return tuple(
+        sorted(
+            {
+                extra
+                for item in (*protocols, path_protocol if sep else None)
+                if item is not None
+                and (extra := _PROTOCOL_REFINER_EXTRAS.get(str(item).lower()))
+                is not None
+            }
+        )
+    )

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -105,8 +105,9 @@ class CloudLauncher(BaseLauncher):
             local environment in the cloud runtime.
         dependencies: Additional packages to install in the cloud runtime.
             Entries are requirement strings.
-        refiner_extras: Optional macrodata-refiner extras to install in the cloud
-            runtime, such as "hf" or "video".
+        refiner_extras: Additional macrodata-refiner extras to install in the
+            cloud runtime. Built-in blocks automatically declare the extras they
+            require; pass this for extras used outside those blocks.
         secrets: Optional secret sources mounted into the cloud runtime.
         env: Optional plain environment variables mounted into the cloud runtime.
     """
@@ -156,13 +157,14 @@ class CloudLauncher(BaseLauncher):
         return raw.strip().lower() in {"1", "true", "yes", "on"}
 
     def _resolve_cloud_manifest(
-        self, *, secret_values: tuple[str, ...]
+        self, *, secret_values: tuple[str, ...], stages: list[PlannedStage]
     ) -> dict[str, object]:
         manifest = build_run_manifest(
             secret_values=secret_values,
             capture_dependencies=self.sync_local_dependencies,
             dependencies=self.dependencies,
             refiner_extras=self.refiner_extras,
+            pipeline_stages=stages,
         )
         environment = manifest.get("environment")
         if environment is None:
@@ -290,7 +292,10 @@ class CloudLauncher(BaseLauncher):
         resolved_secret_sources, secret_values = resolve_secret_sources(self.secrets)
         resolved_env = resolve_env_mapping(self.env) if self.env else None
         stages = self._resolved_stages()
-        manifest = self._resolve_cloud_manifest(secret_values=secret_values)
+        manifest = self._resolve_cloud_manifest(
+            secret_values=secret_values,
+            stages=stages,
+        )
         plan = self._compiled_plan(stages, secret_values=secret_values)
         try:
             pipeline_payloads = self._upload_stage_payloads(

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -729,8 +729,10 @@ class RefinerPipeline:
             dependencies: Additional packages to install in the cloud runtime.
                 Entries are requirement strings such as `"torch"` or
                 `"ego-vision[models]==0.1.2"`.
-            refiner_extras: Optional macrodata-refiner extras to install in the
-                cloud runtime, such as `"hf"` or `"video"`.
+            refiner_extras: Additional macrodata-refiner extras to install in
+                the cloud runtime. Built-in blocks automatically declare the
+                extras they require; pass this for extras used outside those
+                blocks.
             secrets: Secret sources to mount inside the cloud image. A mapping keeps
                 the legacy behavior; `None` values are loaded from the submitting
                 environment. `Secrets.env(...)` references stored workspace secrets.

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -329,10 +329,19 @@ def _builtin_description(fn: Any) -> dict[str, Any] | None:
     return {"name": name, "args": args, "services": tuple(parsed_services)}
 
 
-def describe_builtin(name: str, **args: Any) -> Any:
+def describe_builtin(
+    name: str, *, refiner_extras: tuple[str, ...] = (), **args: Any
+) -> Any:
     def _decorate(fn: Any) -> Any:
         setattr(
-            fn, _REFINER_BUILTIN_CALL_ATTR, {"name": name, "args": args, "services": ()}
+            fn,
+            _REFINER_BUILTIN_CALL_ATTR,
+            {
+                "name": name,
+                "args": args,
+                "services": (),
+                "refiner_extras": refiner_extras,
+            },
         )
         return fn
 

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any
+from typing import Any, cast
 
 import pyarrow as pa
 
@@ -55,6 +55,27 @@ class BaseSink(ABC):
         pipeline descriptions.
         """
         return None
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        """macrodata-refiner extras required by this sink."""
+        return tuple(
+            sorted(
+                {
+                    *self._declared_refiner_extras(),
+                    *self._io_refiner_extras(),
+                }
+            )
+        )
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        """Feature extras declared by this sink."""
+        return ()
+
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        """Storage extras required by this sink's output, if it has one."""
+        if not hasattr(self, "output"):
+            return ()
+        return cast(Any, self).output.required_refiner_extras()
 
     def build_reducer(self) -> "BaseSink | None":
         """Return an optional 1-worker reducer sink for launched execution.

--- a/src/refiner/pipeline/sinks/lerobot.py
+++ b/src/refiner/pipeline/sinks/lerobot.py
@@ -36,7 +36,6 @@ from refiner.robotics.lerobot_format import (
     infer_feature_info,
 )
 from refiner.robotics.row import RoboticsRow
-from refiner.utils import check_required_dependencies
 from refiner.worker.context import get_active_worker_token
 from refiner.worker.metrics.api import register_gauge
 
@@ -101,7 +100,6 @@ class LeRobotWriterSink(BaseSink):
         quantile_bins: int = 5000,
         force_recompute_video_stats: bool = False,
     ):
-        check_required_dependencies("write_lerobot", ["av"], dist="robotics")
         self.output = DataFolder.resolve(output)
         self.data_files_size_in_mb = data_files_size_in_mb
         self.video_files_size_in_mb = video_files_size_in_mb
@@ -122,6 +120,9 @@ class LeRobotWriterSink(BaseSink):
             preserve_order=False,
         )
         self._episodes_in_flight_registered = False
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("video",)
 
     def write_shard_block(self, shard_id: str, block: Block) -> None:
         """Submit one async write task per episode row in the shard-local block."""

--- a/src/refiner/pipeline/sinks/reducer/zarr.py
+++ b/src/refiner/pipeline/sinks/reducer/zarr.py
@@ -15,7 +15,6 @@ from refiner.pipeline.sinks.zarr import (
     _render_store_relpath,
     _zarr_store,
 )
-from refiner.utils import check_required_dependencies
 from refiner.worker.context import get_active_stage_index, get_finalized_workers
 from refiner.worker.lifecycle import sort_finalized_workers
 
@@ -30,7 +29,6 @@ class ZarrReducerSink(FileCleanupReducerSink):
         array_chunk_bytes: int = _DEFAULT_ARRAY_CHUNK_BYTES,
         reduce_to_single_store: bool = True,
     ) -> None:
-        check_required_dependencies("write_zarr", ["zarr"], dist="zarr")
         super().__init__(
             output=output,
             filename_template=(
@@ -42,6 +40,9 @@ class ZarrReducerSink(FileCleanupReducerSink):
         self.episode_ends_path = episode_ends_path
         self.array_chunk_bytes = array_chunk_bytes
         self.reduce_to_single_store = reduce_to_single_store
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("zarr",)
 
     def write_shard_block(self, shard_id: str, block: Block) -> None:
         self._run_cleanup()

--- a/src/refiner/pipeline/sinks/zarr.py
+++ b/src/refiner/pipeline/sinks/zarr.py
@@ -42,7 +42,6 @@ class ZarrSink(BaseSink):
         array_chunk_bytes: int = _DEFAULT_ARRAY_CHUNK_BYTES,
         reduce_to_single_store: bool = True,
     ):
-        check_required_dependencies("write_zarr", ["zarr"], dist="zarr")
         if video_frame_batch_size <= 0:
             raise ValueError("video_frame_batch_size must be greater than zero")
         if array_chunk_bytes <= 0:
@@ -69,6 +68,9 @@ class ZarrSink(BaseSink):
         self.reduce_to_single_store = reduce_to_single_store
         self._stores: dict[str, _ZarrWriteState] = {}
         self._default_arrays: dict[str, str] | None = None
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("zarr",)
 
     def write_shard_block(self, shard_id: str, block: Block) -> int:
         count = 0
@@ -311,6 +313,7 @@ class ZarrSink(BaseSink):
         store = self._stores.get(relpath)
         if store is not None:
             return store
+        check_required_dependencies("write_zarr", ["zarr"], dist="zarr")
         import zarr
 
         store = _ZarrWriteState(
@@ -535,6 +538,7 @@ def _matching_length(lengths: list[int]) -> int | None:
 
 
 def _zarr_store(output: DataFolder, path: str = "", *, mode: str = "r"):
+    check_required_dependencies("write_zarr", ["zarr"], dist="zarr")
     import zarr
 
     return zarr.storage.FSStore(

--- a/src/refiner/pipeline/sources/base.py
+++ b/src/refiner/pipeline/sources/base.py
@@ -47,6 +47,25 @@ class BaseSource(ABC):
         """Optional source metadata for planning/observability."""
         return {}
 
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        """macrodata-refiner extras required by this source."""
+        return tuple(
+            sorted(
+                {
+                    *self._declared_refiner_extras(),
+                    *self._io_refiner_extras(),
+                }
+            )
+        )
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        """Feature extras declared by this source."""
+        return ()
+
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        """Storage extras required by this source's normalized IO handles."""
+        return ()
+
 
 __all__ = ["BaseSource"]
 

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -117,6 +117,9 @@ class BaseReader(BaseSource):
             "file_path_column": self.file_path_column,
         }
 
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        return self.fileset.required_refiner_extras()
+
     def _with_file_path(
         self, row: dict[str, Any], source_file: DataFile
     ) -> dict[str, Any]:

--- a/src/refiner/pipeline/sources/readers/hdf5.py
+++ b/src/refiner/pipeline/sources/readers/hdf5.py
@@ -119,6 +119,9 @@ class Hdf5Reader(BaseReader):
         )
         return description
 
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("hdf5",)
+
     def _validate_column_names(self) -> None:
         for name, path in self.datasets.items():
             if path.startswith("/"):

--- a/src/refiner/pipeline/sources/readers/hf_dataset.py
+++ b/src/refiner/pipeline/sources/readers/hf_dataset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
+import importlib.util
 from typing import Any
 from typing import cast
 from urllib.parse import quote
@@ -55,6 +56,8 @@ class HFDatasetReader(BaseSource):
         file_path_column: str | None = "file_path",
     ):
         self.repo = repo
+        self.config = config or "default"
+        self._config_arg = config
         self.split = split
         self.timeout = float(timeout)
         self.target_shard_bytes = target_shard_bytes
@@ -64,26 +67,9 @@ class HFDatasetReader(BaseSource):
             tuple(columns_to_read) if columns_to_read is not None else None
         )
         self.file_path_column = file_path_column
-
-        check_required_dependencies("read_hf_dataset", ["datasets"], dist="huggingface")
-        from datasets import get_dataset_config_info
-
-        info_kwargs: dict[str, Any] = {}
-        if config is not None:
-            info_kwargs["config_name"] = config
-        info = get_dataset_config_info(self.repo, **info_kwargs)
-        self.config: str = str(info.config_name or config or "default")
-
-        inferred_dtypes: dict[str, pa.Field] = {}
-        for name, feature in (info.features or {}).items():
-            dtype_factory = _HF_ASSET_FEATURE_DTYPES.get(type(feature).__name__)
-            if dtype_factory is not None:
-                inferred_dtypes[name] = dtype_factory()
-
-        effective_dtypes = dict(inferred_dtypes)
-        if dtypes:
-            effective_dtypes.update(dtypes)
-        self.dtypes = effective_dtypes or None
+        self._user_dtypes = dict(dtypes or {})
+        self.dtypes = self._user_dtypes or None
+        self._dataset_info_loaded = False
 
         referenced_filter_columns = (
             filter.referenced_columns() if filter is not None else set()
@@ -124,6 +110,8 @@ class HFDatasetReader(BaseSource):
                 for col in self._parquet_columns_to_read
                 if col != self.file_path_column
             )
+        if importlib.util.find_spec("datasets") is not None:
+            self._ensure_dataset_info()
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -132,6 +120,32 @@ class HFDatasetReader(BaseSource):
             "split": self.split,
             "dtypes": list(self.dtypes) if self.dtypes else None,
         }
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("datasets",)
+
+    def _ensure_dataset_info(self) -> None:
+        if self._dataset_info_loaded:
+            return
+        check_required_dependencies("read_hf_dataset", ["datasets"], dist="datasets")
+        from datasets import get_dataset_config_info
+
+        info_kwargs: dict[str, Any] = {}
+        if self._config_arg is not None:
+            info_kwargs["config_name"] = self._config_arg
+        info = get_dataset_config_info(self.repo, **info_kwargs)
+        self.config = str(info.config_name or self._config_arg or "default")
+
+        inferred_dtypes: dict[str, pa.Field] = {}
+        for name, feature in (info.features or {}).items():
+            dtype_factory = _HF_ASSET_FEATURE_DTYPES.get(type(feature).__name__)
+            if dtype_factory is not None:
+                inferred_dtypes[name] = dtype_factory()
+
+        effective_dtypes = dict(inferred_dtypes)
+        effective_dtypes.update(self._user_dtypes)
+        self.dtypes = effective_dtypes or None
+        self._dataset_info_loaded = True
 
     def list_shards(self) -> list[Shard]:
         try:
@@ -164,6 +178,7 @@ class HFDatasetReader(BaseSource):
         if self._delegate is not None:
             return self._delegate
 
+        self._ensure_dataset_info()
         # URL discovery is intentionally separate from scanning; ParquetReader still
         # owns byte planning, projection, filtering, and Arrow conversion.
         urls = _list_parquet_urls(
@@ -210,6 +225,7 @@ class HFDatasetReader(BaseSource):
         return self._make_parquet_reader(paths), parquet_shard
 
     def _make_parquet_reader(self, urls: Sequence[str]) -> ParquetReader:
+        self._ensure_dataset_info()
         return ParquetReader(
             list(urls),
             target_shard_bytes=self.target_shard_bytes,
@@ -239,6 +255,10 @@ class HFDatasetReader(BaseSource):
 
     def _load_fallback_dataset(self) -> object:
         if self._fallback_dataset is None:
+            self._ensure_dataset_info()
+            check_required_dependencies(
+                "read_hf_dataset", ["datasets"], dist="datasets"
+            )
             from datasets import load_dataset
 
             kwargs: dict[str, Any] = {
@@ -359,6 +379,7 @@ def _list_parquet_urls(
         if urls:
             return urls
 
+    check_required_dependencies("read_hf_dataset", ["datasets"], dist="datasets")
     from datasets import load_dataset_builder
     from datasets.packaged_modules.parquet.parquet import Parquet
 
@@ -399,6 +420,11 @@ def _get_json_or_none(url: str, *, timeout: float) -> object:
 
 
 def _get_json(url: str, *, timeout: float) -> object:
+    check_required_dependencies(
+        "read_hf_dataset",
+        [("huggingface_hub", "huggingface-hub")],
+        dist="datasets",
+    )
     from huggingface_hub.utils import build_hf_headers
 
     response = httpx.get(

--- a/src/refiner/pipeline/sources/readers/mcap.py
+++ b/src/refiner/pipeline/sources/readers/mcap.py
@@ -185,6 +185,9 @@ class McapReader(BaseReader):
         )
         return description
 
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("mcap",)
+
     def _episode_row(
         self,
         topic_events: Mapping[str, Sequence[_McapEvent]],

--- a/src/refiner/pipeline/sources/readers/tfds.py
+++ b/src/refiner/pipeline/sources/readers/tfds.py
@@ -249,6 +249,9 @@ class TfdsReader(BaseSource):
             "fps": self.fps,
         }
 
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("tfds",)
+
     def list_shards(self) -> list[Shard]:
         """Plan deterministic row ranges for the configured split."""
         self._ensure_builders()

--- a/src/refiner/pipeline/sources/readers/tfrecord.py
+++ b/src/refiner/pipeline/sources/readers/tfrecord.py
@@ -124,6 +124,9 @@ class TfrecordReader(BaseReader):
         )
         return description
 
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("tensorflow",)
+
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one file-granular shard as parsed TensorFlow batches."""
         descriptor = shard.descriptor

--- a/src/refiner/pipeline/sources/readers/zarr.py
+++ b/src/refiner/pipeline/sources/readers/zarr.py
@@ -75,8 +75,9 @@ class ZarrReader(BaseSource):
                 or None to omit it.
             dtypes: Optional dtype overrides for output columns.
         """
+        self.fileset = DataFileSet.resolve(input)
         resolved_inputs: list[tuple[DataFolder | DataFile, str]] = []
-        for entry in DataFileSet.resolve(input).resolved_entries:
+        for entry in self.fileset.resolved_entries:
             if isinstance(entry, DataFile):
                 if not entry.path.endswith(".zip"):
                     raise TypeError("read_zarr file inputs must be .zip Zarr stores")
@@ -90,7 +91,6 @@ class ZarrReader(BaseSource):
         if not resolved_inputs:
             raise ValueError("read_zarr requires at least one input")
         self.inputs = resolved_inputs
-        check_required_dependencies("read_zarr", ["zarr"], dist="zarr")
         if row_ends is not None and split_leading_axis:
             raise ValueError("row_ends and split_leading_axis are mutually exclusive")
         if leading_axis_row_size <= 0:
@@ -165,6 +165,12 @@ class ZarrReader(BaseSource):
                 else None
             ),
         }
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("zarr",)
+
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        return self.fileset.required_refiner_extras()
 
     def list_shards(self) -> list[Shard]:
         shards: list[Shard] = []
@@ -263,6 +269,7 @@ class ZarrReader(BaseSource):
 
     @contextmanager
     def _open_group(self, input: DataFolder | DataFile) -> Any:
+        check_required_dependencies("read_zarr", ["zarr"], dist="zarr")
         import zarr
         import zarr.storage
 

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -12,12 +12,16 @@ from urllib import request as urllib_request
 from collections.abc import Sequence
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from refiner.pipeline.planning import PlannedStage
 
 from packaging.requirements import InvalidRequirement, Requirement
 
 _REDACTION_PLACEHOLDER = "REDACTED_SECRET"
 _NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN = re.compile(r"[-_.]+")
+_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
 
 
 def _redact_captured_text(text: str, *, secret_values: Sequence[str]) -> str:
@@ -238,11 +242,35 @@ def build_run_manifest(
     capture_dependencies: bool = True,
     dependencies: Sequence[str] | None = None,
     refiner_extras: Sequence[str] | None = None,
+    pipeline_stages: Sequence["PlannedStage"] | None = None,
 ) -> dict[str, Any]:
     script_path = _detect_script_path()
     path, text, sha256 = _read_script(script_path)
     refiner_version = _resolve_installed_version()
     refiner_ref = _resolve_direct_url_git_sha() or _resolve_local_repo_git_sha()
+    pipeline_refiner_extras: set[str] = set()
+    for stage in pipeline_stages or ():
+        pipeline = stage.pipeline
+        pipeline_refiner_extras.update(pipeline.source.required_refiner_extras())
+        for step in pipeline.pipeline_steps:
+            for candidate in getattr(step, "ops", (step,)):
+                for attr in ("fn", "predicate"):
+                    spec = getattr(
+                        getattr(candidate, attr, None), _REFINER_BUILTIN_CALL_ATTR, None
+                    )
+                    if isinstance(spec, dict):
+                        declared = spec.get("refiner_extras", ())
+                        if isinstance(declared, tuple):
+                            pipeline_refiner_extras.update(declared)
+        if pipeline.sink is not None:
+            pipeline_refiner_extras.update(pipeline.sink.required_refiner_extras())
+    if isinstance(refiner_extras, str):
+        merged_refiner_extras: Sequence[str] | None = refiner_extras
+    else:
+        merged_refiner_extras = [
+            *(refiner_extras or ()),
+            *sorted(pipeline_refiner_extras),
+        ]
 
     manifest: dict[str, Any] = {
         "version": 1,
@@ -257,7 +285,7 @@ def build_run_manifest(
             "python_version": platform.python_version(),
             "refiner_version": refiner_version,
             "refiner_ref": refiner_ref,
-            "refiner_extras": _normalize_refiner_extras(refiner_extras),
+            "refiner_extras": _normalize_refiner_extras(merged_refiner_extras),
             "platform": f"{platform.system().lower()}-{platform.machine().lower()}",
         },
     }

--- a/src/refiner/robotics/hand_tracking.py
+++ b/src/refiner/robotics/hand_tracking.py
@@ -10,6 +10,7 @@ from refiner.pipeline.data.row import Row
 from refiner.pipeline.planning import describe_builtin
 from refiner.pipeline.steps import BatchFn
 from refiner.robotics.row import RoboticsRow
+from refiner.utils import check_required_dependencies
 from refiner.worker.context import logger
 
 
@@ -76,6 +77,7 @@ def track_hands(
 
     @describe_builtin(
         "robotics.hand_tracking:track_hands",
+        refiner_extras=("hand_tracking",),
         video_key=video_key,
         output_key=output_key,
     )
@@ -123,13 +125,12 @@ def track_hands(
 
 
 def _load_egovision(config: Any | None) -> tuple[Any, Any]:
-    try:
-        egovision: Any = importlib.import_module("egovision")
-    except ImportError as exc:
-        raise ImportError(
-            "track_hands requires ego-vision. Install it with "
-            "`pip install macrodata-refiner[hand_tracking]`."
-        ) from exc
+    check_required_dependencies(
+        "track_hands",
+        [("egovision", "ego-vision")],
+        dist="hand_tracking",
+    )
+    egovision: Any = importlib.import_module("egovision")
 
     if config is None:
         config = egovision.HandTrackingConfig(

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -221,10 +221,13 @@ class CommonCrawlReader(BaseReader):
         file_path_column: object = _DEFAULT_FILE_PATH_COLUMN,
         dtypes: DTypeMapping | None = None,
     ) -> None:
-        check_required_dependencies("read_commoncrawl", ["warcio"], dist="text")
-        if not use_https:
+        resolved_base_url = (
+            str(base_url)
+            if base_url is not None
+            else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
+        )
+        if resolved_base_url.startswith("s3://"):
             check_required_dependencies("read_commoncrawl", ["s3fs"], dist="s3")
-        from warcio.archiveiterator import ArchiveIterator
 
         if format not in {"warc", "wet"}:
             raise ValueError("format must be 'warc' or 'wet'")
@@ -246,12 +249,9 @@ class CommonCrawlReader(BaseReader):
             )
             if not self.output_fields:
                 raise ValueError("output_fields must contain at least one field")
-        self.base_url = (
-            str(base_url)
-            if base_url is not None
-            else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
-        )
-        self._archive_iterator = ArchiveIterator
+        self.base_url = resolved_base_url
+        self.use_https = use_https
+        self._archive_iterator: Any | None = None
         self.root = DataFolder.resolve(self.base_url)
         self.num_files = None if num_files is None else int(num_files)
         self._num_files_applied = False
@@ -273,6 +273,9 @@ class CommonCrawlReader(BaseReader):
             split_by_bytes=False,
             dtypes=dtypes,
         )
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("text",)
 
     def list_shards(self) -> list[Shard]:
         if self.num_files is not None and not self._num_files_applied:
@@ -327,13 +330,21 @@ class CommonCrawlReader(BaseReader):
                 raise ValueError("Common Crawl files are expected to be atomic")
             source = self.fileset.resolve_file(part.source_index, part.path)
             with source.open(mode="rb") as raw:
-                for record in self._archive_iterator(raw):
+                for record in self._get_archive_iterator()(raw):
                     payload = _warc_record_to_row(
                         record, output_fields=self.output_fields
                     )
                     if payload is None:
                         continue
                     yield DictRow(self._with_file_path(payload, source))
+
+    def _get_archive_iterator(self) -> Any:
+        if self._archive_iterator is None:
+            check_required_dependencies("read_commoncrawl", ["warcio"], dist="text")
+            from warcio.archiveiterator import ArchiveIterator
+
+            self._archive_iterator = ArchiveIterator
+        return self._archive_iterator
 
     def _source_globs(self) -> tuple[tuple[str, Any], ...]:
         """Build the dump/segment-specific WARC or WET glob inputs for BaseReader."""
@@ -374,14 +385,15 @@ class CommonCrawlWarcIndexSource(BaseSource):
         file_path_column: str | None = "warc_path",
         max_inflight: int = 4,
     ) -> None:
-        check_required_dependencies(
-            "read_commoncrawl_from_index", ["warcio"], dist="text"
+        resolved_base_url = (
+            str(base_url)
+            if base_url is not None
+            else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
         )
-        if not use_https:
+        if resolved_base_url.startswith("s3://"):
             check_required_dependencies(
                 "read_commoncrawl_from_index", ["s3fs"], dist="s3"
             )
-        from warcio.archiveiterator import ArchiveIterator
 
         if isinstance(dumps, str):
             self.dumps = (dumps,)
@@ -402,12 +414,9 @@ class CommonCrawlWarcIndexSource(BaseSource):
             )
             if not self.output_fields:
                 raise ValueError("output_fields must contain at least one field")
-        self.base_url = (
-            str(base_url)
-            if base_url is not None
-            else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
-        )
-        self._archive_iterator = ArchiveIterator
+        self.base_url = resolved_base_url
+        self.use_https = use_https
+        self._archive_iterator: Any | None = None
         self.root = DataFolder.resolve(self.base_url)
         self.target_shard_bytes = target_shard_bytes
         self.num_shards = num_shards
@@ -417,6 +426,12 @@ class CommonCrawlWarcIndexSource(BaseSource):
             raise ValueError("max_inflight must be positive")
         self._index_reader: ParquetReader | None = None
         self._thread_local = threading.local()
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("text",)
+
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        return self.root.required_refiner_extras()
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -557,8 +572,18 @@ class CommonCrawlWarcIndexSource(BaseSource):
             fh, _ = self._get_thread_file_handle(source, mode="rb", force_reopen=True)
             fh.seek(offset)
         member = fh.read(length)
-        iterator = self._archive_iterator(io.BytesIO(member))
+        iterator = self._get_archive_iterator()(io.BytesIO(member))
         return next(iterator)
+
+    def _get_archive_iterator(self) -> Any:
+        if self._archive_iterator is None:
+            check_required_dependencies(
+                "read_commoncrawl_from_index", ["warcio"], dist="text"
+            )
+            from warcio.archiveiterator import ArchiveIterator
+
+            self._archive_iterator = ArchiveIterator
+        return self._archive_iterator
 
     def _fetch_index_row_payload(self, row: Row) -> dict[str, Any] | None:
         warc_filename = str(row["warc_filename"])

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -348,6 +348,30 @@ def test_pipeline_launch_cloud_skips_local_dependency_capture_by_default(
     assert captured_manifest_kwargs["refiner_extras"] == ["hf", "video"]
 
 
+def test_pipeline_launch_cloud_passes_pipeline_stages_to_manifest(
+    monkeypatch,
+) -> None:
+    captured_manifest_kwargs = {}
+
+    def manifest(**kwargs):
+        captured_manifest_kwargs.update(kwargs)
+        return {"version": 1}
+
+    _stub_cloud_submit(monkeypatch, manifest=manifest)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    pipeline = read_jsonl("input.jsonl")
+    pipeline.launch_cloud(name="demo cloud", refiner_extras=["video"])
+
+    stages = cast(list[PlannedStage], captured_manifest_kwargs["pipeline_stages"])
+    assert captured_manifest_kwargs["refiner_extras"] == ["video"]
+    assert len(stages) == 1
+    assert stages[0].pipeline is pipeline
+
+
 def test_pipeline_launch_cloud_resolves_secrets(monkeypatch) -> None:
     captured = _stub_cloud_submit(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "env-secret")

--- a/tests/pipeline/test_lerobot_sink.py
+++ b/tests/pipeline/test_lerobot_sink.py
@@ -9,6 +9,7 @@ from typing import Any, Iterator, cast
 
 import av
 import fsspec
+from fsspec.implementations.memory import MemoryFileSystem
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -41,6 +42,18 @@ _ALOHA_REPO_IDS = (
     "macrodata/aloha_static_battery_ep000_004",
     "macrodata/aloha_static_battery_ep005_009",
 )
+
+
+class _S3MemoryFileSystem(MemoryFileSystem):
+    protocol = "s3"
+
+
+class _HFMemoryFileSystem(MemoryFileSystem):
+    protocol = "hf"
+
+
+class _GCSMemoryFileSystem(MemoryFileSystem):
+    protocol = "gcs"
 
 
 class _FakeRoboticsRow(Row, RoboticsRow):
@@ -230,6 +243,25 @@ def test_lerobot_sink_defaults_encoder_options_to_none(tmp_path: Path) -> None:
     writer = LeRobotWriterSink(str(tmp_path / "out"))
 
     assert writer.video_transcode_config.encoder_options is None
+
+
+@pytest.mark.parametrize(
+    ("url", "fs", "extra"),
+    [
+        ("s3://bucket/out", _S3MemoryFileSystem(), "s3"),
+        ("hf://buckets/org/out", _HFMemoryFileSystem(), "hf"),
+        ("gs://bucket/out", _GCSMemoryFileSystem(), "gcs"),
+    ],
+)
+def test_write_lerobot_remote_output_declares_storage_extra(
+    url: str,
+    fs: MemoryFileSystem,
+    extra: str,
+) -> None:
+    output = (url, fs)
+
+    assert LeRobotWriterSink(output).required_refiner_extras() == (extra, "video")
+    assert LeRobotMetaReduceSink(output).required_refiner_extras() == (extra,)
 
 
 def test_write_lerobot_defaults_gop_to_two(tmp_path: Path) -> None:

--- a/tests/platform/test_manifest.py
+++ b/tests/platform/test_manifest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from contextlib import nullcontext
 from email.message import Message
 from importlib import metadata as importlib_metadata
@@ -9,7 +10,39 @@ from urllib import error as urllib_error
 
 import pytest
 
+from refiner.pipeline import RefinerPipeline
+from refiner.pipeline.data.block import Block
+from refiner.pipeline.data.shard import Shard
+from refiner.pipeline.planning import (
+    PlannedStage,
+    StageComputeRequirements,
+    describe_builtin,
+)
+from refiner.pipeline.sinks.base import BaseSink
+from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.platform.manifest import build_run_manifest, refiner_ref_exists_on_remote
+
+
+class _RefinerExtrasSource(BaseSource):
+    name = "extra_source"
+
+    def list_shards(self) -> list[Shard]:
+        return []
+
+    def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
+        del shard
+        return iter(())
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("hf",)
+
+
+class _RefinerExtrasSink(BaseSink):
+    def write_shard_block(self, shard_id: str, block: Block) -> None:
+        del shard_id, block
+
+    def _declared_refiner_extras(self) -> tuple[str, ...]:
+        return ("zarr",)
 
 
 def test_build_run_manifest_captures_script_from_argv(
@@ -170,6 +203,57 @@ def test_build_run_manifest_records_refiner_extras(monkeypatch, tmp_path: Path) 
 
     assert manifest["environment"]["refiner_extras"] == ["hf", "video"]
     assert "dependencies" not in manifest
+
+
+def test_build_run_manifest_adds_refiner_extras_declared_by_pipeline(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    script_path = tmp_path / "demo_job.py"
+    script_path.write_text("print('hello')\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [str(script_path)])
+
+    @describe_builtin("test:filter_needs_video", refiner_extras=("video",))
+    def keep_row(row) -> bool:
+        del row
+        return True
+
+    @describe_builtin(
+        "test:table_needs_hand_tracking", refiner_extras=("hand_tracking",)
+    )
+    def passthrough_table(table):
+        return table
+
+    pipeline = (
+        RefinerPipeline(_RefinerExtrasSource())
+        .filter(keep_row)
+        .select("value")
+        .map_table(passthrough_table)
+        .with_sink(_RefinerExtrasSink())
+    )
+    stages = [
+        PlannedStage(
+            index=0,
+            name="stage_0",
+            pipeline=pipeline,
+            compute=StageComputeRequirements(num_workers=1),
+        )
+    ]
+
+    manifest = build_run_manifest(
+        capture_dependencies=False,
+        refiner_extras=["text"],
+        pipeline_stages=stages,
+    )
+
+    assert manifest["environment"]["refiner_extras"] == [
+        "hand-tracking",
+        "hf",
+        "text",
+        "video",
+        "zarr",
+    ]
 
 
 def test_build_run_manifest_normalizes_refiner_extra_names(

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -18,6 +18,7 @@ from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.shard import RowRangeDescriptor
 from refiner.pipeline.sinks.reducer.zarr import ZarrReducerSink
 from refiner.pipeline.sinks.zarr import ZarrSink
+from refiner.pipeline.sources.readers.zarr import ZarrReader
 from refiner.worker.context import set_active_run_context, worker_token_for
 from refiner.worker.lifecycle import FinalizedShardWorker, RuntimeLifecycle
 
@@ -53,6 +54,18 @@ class _EmptyVideoSource:
         raise NotImplementedError
 
 
+class _S3MemoryFileSystem(MemoryFileSystem):
+    protocol = "s3"
+
+
+class _HFMemoryFileSystem(MemoryFileSystem):
+    protocol = "hf"
+
+
+class _GCSMemoryFileSystem(MemoryFileSystem):
+    protocol = "gcs"
+
+
 def _open_test_zarr(path: Path, *, mode: Literal["r", "r+", "a", "w", "w-"]):
     kwargs: dict[str, Any] = {"mode": mode, "zarr_format": 2}
     try:
@@ -66,6 +79,77 @@ def _create_array(root, name: str, data, **kwargs):
         kwargs.pop("shape", None)
         return root.create_array(name, data=data, **kwargs)
     return root.create_dataset(name, data=data, **kwargs)
+
+
+def test_read_zarr_constructor_defers_dependency_check(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fail(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise AssertionError("dependency check should be deferred")
+
+    monkeypatch.setattr(
+        "refiner.pipeline.sources.readers.zarr.check_required_dependencies",
+        fail,
+    )
+
+    path = tmp_path / "episodes.zarr"
+    path.mkdir()
+    mdr.read_zarr(str(path))
+
+
+def test_write_zarr_constructor_defers_dependency_check(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fail(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise AssertionError("dependency check should be deferred")
+
+    monkeypatch.setattr("refiner.pipeline.sinks.zarr.check_required_dependencies", fail)
+
+    mdr.from_items([]).write_zarr(str(tmp_path / "out.zarr"))
+
+
+@pytest.mark.parametrize(
+    ("url", "fs", "extra"),
+    [
+        ("s3://bucket/out.zarr", _S3MemoryFileSystem(), "s3"),
+        ("hf://datasets/org/repo/out.zarr", _HFMemoryFileSystem(), "hf"),
+        ("gs://bucket/out.zarr", _GCSMemoryFileSystem(), "gcs"),
+    ],
+)
+def test_write_zarr_remote_output_declares_storage_extra(
+    url: str,
+    fs: MemoryFileSystem,
+    extra: str,
+) -> None:
+    output = (url, fs)
+
+    assert ZarrSink(output).required_refiner_extras() == (extra, "zarr")
+    assert ZarrReducerSink(
+        output,
+        store_template="{shard_id}__w{worker_id}.zarr",
+    ).required_refiner_extras() == (extra, "zarr")
+
+
+@pytest.mark.parametrize(
+    ("url", "fs", "extra"),
+    [
+        ("s3://bucket/input.zarr", _S3MemoryFileSystem(), "s3"),
+        ("hf://datasets/org/repo/input.zarr", _HFMemoryFileSystem(), "hf"),
+        ("gs://bucket/input.zarr", _GCSMemoryFileSystem(), "gcs"),
+    ],
+)
+def test_read_zarr_remote_input_declares_storage_extra(
+    url: str,
+    fs: MemoryFileSystem,
+    extra: str,
+) -> None:
+    fs.mkdir(url)
+
+    reader = ZarrReader((url, fs))
+
+    assert reader.required_refiner_extras() == (extra, "zarr")
 
 
 def _write_policy_zarr(path: Path) -> None:

--- a/tests/test_commoncrawl_text.py
+++ b/tests/test_commoncrawl_text.py
@@ -170,6 +170,31 @@ def test_read_commoncrawl_s3_transport_checks_s3fs(monkeypatch) -> None:
     assert ("read_commoncrawl_from_index", ("s3fs",), "s3") in calls
 
 
+def test_read_commoncrawl_s3_base_url_declares_s3_extra(monkeypatch) -> None:
+    calls: list[tuple[str, tuple[str, ...], str | None]] = []
+
+    def fake_check(name: str, deps: list[str], dist: str | None = None) -> None:
+        calls.append((name, tuple(deps), dist))
+
+    monkeypatch.setattr(
+        "refiner.text.commoncrawl.check_required_dependencies", fake_check
+    )
+
+    source = mdr.text.read_commoncrawl(
+        "CC-MAIN-TEST",
+        base_url="s3://commoncrawl",
+    ).source
+    index_source = mdr.text.read_commoncrawl_from_index(
+        "CC-MAIN-TEST",
+        base_url="s3://commoncrawl",
+    ).source
+
+    assert source.required_refiner_extras() == ("s3", "text")
+    assert index_source.required_refiner_extras() == ("s3", "text")
+    assert ("read_commoncrawl", ("s3fs",), "s3") in calls
+    assert ("read_commoncrawl_from_index", ("s3fs",), "s3") in calls
+
+
 def test_read_commoncrawl_warc_uses_file_backed_reader(tmp_path: Path) -> None:
     dump = "CC-MAIN-TEST"
     warc_rel = f"crawl-data/{dump}/segments/00000/warc/test.warc.gz"

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,88 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -656,6 +738,66 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +892,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/34/14cd8e76f907f7d4dca2334cfeec9f81d30fd15c25a015f99aaea694eaed/datasets-4.8.5.tar.gz", hash = "sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772", size = 605649, upload-time = "2026-04-27T15:43:57.384Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/99/00f3196036501b53032c4b1ab8337a0b978dee832ed276dae3815df4e8b5/datasets-4.8.5-py3-none-any.whl", hash = "sha256:5079900781719c0e063a8efdd2cd95a31ad0c63209178669cd23cf1b926149ff", size = 528973, upload-time = "2026-04-27T15:43:53.702Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
 ]
 
 [[package]]
@@ -1132,6 +1283,158 @@ wheels = [
 ]
 
 [[package]]
+name = "gcsfs"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "decorator" },
+    { name = "fsspec" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage-control" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/91/e7a2f237d51436a4fc947f30f039d2c277bb4f4ce02f86628ba0a094a3ce/gcsfs-2026.2.0.tar.gz", hash = "sha256:d58a885d9e9c6227742b86da419c7a458e1f33c1de016e826ea2909f6338ed84", size = 163376, upload-time = "2026-02-06T18:35:52.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/6b/c2f68ac51229fc94f094c7f802648fc1de3d19af36434def5e64c0caa32b/gcsfs-2026.2.0-py3-none-any.whl", hash = "sha256:407feaa2af0de81ebce44ea7e6f68598a3753e5e42257b61d6a9f8c0d6d4754e", size = 57557, upload-time = "2026-02-06T18:35:51.09Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status", version = "1.80.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "grpcio-status", version = "1.81.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/7e/ee0dd1a67ac75d29d0c438969d85d4fadbc4bcab47b0a8ccfa7eb22f643c/google_cloud_storage-3.11.0-py3-none-any.whl", hash = "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2", size = 339654, upload-time = "2026-06-03T16:12:46.052Z" },
+]
+
+[[package]]
+name = "google-cloud-storage-control"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/ae/707995271f77e3c1da715c740160f98f87a79a5c601b28d17c4d2500c037/google_cloud_storage_control-1.12.0.tar.gz", hash = "sha256:49090d03532c0c84c6246a5fd490c31fd4bbffb4c7771c0a6744ec23a194a5f6", size = 137036, upload-time = "2026-06-03T16:14:00.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl", hash = "sha256:20f7f1252fa5635d47e12f746aa69d719e31eb9405cbbd14cdfba317db27d421", size = 102205, upload-time = "2026-06-03T16:12:43.266Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
 name = "google-pasta"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1144,15 +1447,48 @@ wheels = [
 ]
 
 [[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
 ]
 
 [[package]]
@@ -1214,6 +1550,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
     { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'win32'",
+    "python_full_version < '3.11' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version < '3.11'" },
+    { name = "grpcio", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.11'" },
+    { name = "grpcio", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b6/cdc177114997d15c887fb09ccfd16705c8ceb8b4ca2487902b54a7bfd1af/grpcio_status-1.81.0.tar.gz", hash = "sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69", size = 13900, upload-time = "2026-06-01T06:00:32.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b7/5aa346bf1cdecd4ed64b86c10a4d5a089ce3da89145f8328caf0b22b240d/grpcio_status-1.81.0-py3-none-any.whl", hash = "sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab", size = 14634, upload-time = "2026-06-01T06:00:13.345Z" },
 ]
 
 [[package]]
@@ -1694,6 +2076,7 @@ dependencies = [
 all = [
     { name = "av" },
     { name = "datasets" },
+    { name = "gcsfs" },
     { name = "h5py" },
     { name = "hf" },
     { name = "huggingface-hub" },
@@ -1708,9 +2091,16 @@ all = [
     { name = "warcio" },
     { name = "zarr" },
 ]
+datasets = [
+    { name = "datasets" },
+    { name = "hf" },
+    { name = "huggingface-hub" },
+]
+gcs = [
+    { name = "gcsfs" },
+]
 hand-tracking = [
     { name = "av" },
-    { name = "datasets" },
     { name = "ego-vision", extra = ["models"] },
     { name = "hf" },
     { name = "huggingface-hub" },
@@ -1720,7 +2110,6 @@ hdf5 = [
     { name = "h5py" },
 ]
 hf = [
-    { name = "datasets" },
     { name = "hf" },
     { name = "huggingface-hub" },
 ]
@@ -1740,6 +2129,7 @@ tensorflow = [
 testing = [
     { name = "av" },
     { name = "datasets" },
+    { name = "gcsfs" },
     { name = "h5py" },
     { name = "hf" },
     { name = "huggingface-hub" },
@@ -1786,17 +2176,21 @@ requires-dist = [
     { name = "av", marker = "extra == 'mcap'" },
     { name = "av", marker = "extra == 'video'" },
     { name = "cloudpickle", specifier = "==3.1.2" },
-    { name = "datasets", marker = "extra == 'hf'", specifier = ">=3.0.0" },
+    { name = "datasets", marker = "extra == 'datasets'", specifier = ">=3.0.0" },
     { name = "ego-vision", extras = ["models"], marker = "extra == 'hand-tracking'", specifier = ">=0.1.25" },
     { name = "fsspec", extras = ["http"] },
+    { name = "gcsfs", marker = "extra == 'gcs'" },
     { name = "h5py", marker = "extra == 'hdf5'" },
     { name = "hf", marker = "extra == 'hf'", specifier = ">=1.7.1" },
     { name = "httpx" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.4.1" },
     { name = "loguru" },
     { name = "macrodata-refiner", extras = ["all"], marker = "extra == 'testing'" },
+    { name = "macrodata-refiner", extras = ["datasets"], marker = "extra == 'all'" },
+    { name = "macrodata-refiner", extras = ["gcs"], marker = "extra == 'all'" },
     { name = "macrodata-refiner", extras = ["hdf5"], marker = "extra == 'all'" },
     { name = "macrodata-refiner", extras = ["hf"], marker = "extra == 'all'" },
+    { name = "macrodata-refiner", extras = ["hf"], marker = "extra == 'datasets'" },
     { name = "macrodata-refiner", extras = ["hf"], marker = "extra == 'hand-tracking'" },
     { name = "macrodata-refiner", extras = ["mcap"], marker = "extra == 'all'" },
     { name = "macrodata-refiner", extras = ["s3"], marker = "extra == 'all'" },
@@ -1826,7 +2220,7 @@ requires-dist = [
     { name = "warcio", marker = "extra == 'text'" },
     { name = "zarr", marker = "extra == 'zarr'", specifier = ">=2.18,<3" },
 ]
-provides-extras = ["video", "hf", "hand-tracking", "text", "hdf5", "zarr", "mcap", "s3", "tensorflow", "tfds", "testing", "all"]
+provides-extras = ["video", "hf", "datasets", "hand-tracking", "text", "hdf5", "zarr", "mcap", "s3", "gcs", "tensorflow", "tfds", "testing", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2665,6 +3059,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -3275,6 +3678,19 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", version = "6.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "protobuf", version = "7.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3404,6 +3820,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -3689,6 +4135,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds pipeline-declared Refiner extras so cloud submission can install feature dependencies without requiring users to pass every `refiner_extras` value manually.

- Adds `refiner_extras()` declarations on sources and sinks.
- Adds builtin transform metadata for Refiner extras and declares `hand_tracking` for `track_hands()`.
- Unions explicit `refiner_extras` with extras declared by resolved cloud stages, including reducer stages.
- Defers zarr reader/writer dependency checks out of constructors, and removes the eager LeRobot writer `av` check so base installs can construct cloud pipelines more easily.

## Validation

- `uv run ruff check src/refiner/launchers/cloud.py src/refiner/pipeline/planning.py src/refiner/pipeline/sources/base.py src/refiner/pipeline/sinks/base.py src/refiner/pipeline/sources/readers/hdf5.py src/refiner/pipeline/sources/readers/hf_dataset.py src/refiner/pipeline/sources/readers/mcap.py src/refiner/pipeline/sources/readers/tfds.py src/refiner/pipeline/sources/readers/tfrecord.py src/refiner/pipeline/sources/readers/zarr.py src/refiner/pipeline/sinks/zarr.py src/refiner/pipeline/sinks/reducer/zarr.py src/refiner/pipeline/sinks/lerobot.py src/refiner/robotics/hand_tracking.py src/refiner/text/commoncrawl.py tests/launchers/test_cloud_launcher.py tests/readers/test_zarr_reader.py`
- `uv run ty check src/refiner/launchers/cloud.py src/refiner/pipeline/planning.py src/refiner/pipeline/sources/base.py src/refiner/pipeline/sinks/base.py src/refiner/pipeline/sources/readers/hdf5.py src/refiner/pipeline/sources/readers/hf_dataset.py src/refiner/pipeline/sources/readers/mcap.py src/refiner/pipeline/sources/readers/tfds.py src/refiner/pipeline/sources/readers/tfrecord.py src/refiner/pipeline/sources/readers/zarr.py src/refiner/pipeline/sinks/zarr.py src/refiner/pipeline/sinks/reducer/zarr.py src/refiner/pipeline/sinks/lerobot.py src/refiner/robotics/hand_tracking.py src/refiner/text/commoncrawl.py tests/launchers/test_cloud_launcher.py tests/readers/test_zarr_reader.py`
- `uv run pytest tests/launchers/test_cloud_launcher.py tests/readers/test_zarr_reader.py tests/pipeline/test_planning.py`