### PR TITLE
[codex] Bump Refiner to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.3.1"
+version = "0.3.2"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2055,7 +2055,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump macrodata-refiner package version from 0.3.1 to 0.3.2
- update uv.lock to match

## Validation
- uv run python -c "import importlib.metadata; print(importlib.metadata.version('macrodata-refiner'))"
- pre-commit ty hook from git commit