### PR TITLE
Defer optional IO and reader dependency resolution

### DIFF
--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -57,7 +57,7 @@ Use `launch_cloud()` on the same pipeline object you would launch locally:
 import refiner as mdr
 
 pipeline = (
-    mdr.read_lerobot("lerobot/aloha_mobile_cabinet")
+    mdr.read_lerobot("hf://datasets/lerobot/aloha_mobile_cabinet")
     .map(score_episode)
     .write_parquet("s3://acme-robotics/datasets/aloha-scored")
 )

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -41,7 +41,7 @@ class DataFile:
         - If `fs` is provided to `resolve()`, it wins and `storage_options` is ignored.
     """
 
-    __slots__ = ("_fs", "_path", "_storage_options")
+    __slots__ = ("_fs", "_path", "_storage_options", "_abs_path")
 
     def __init__(
         self,
@@ -56,6 +56,13 @@ class DataFile:
             fs._strip_protocol(path) if fs is not None and "://" in path else path
         )
         self._storage_options = dict(storage_options or {})
+        if fs is None:
+            if "://" not in path and "::" not in path:
+                self._abs_path = os.path.abspath(path)
+            else:
+                self._abs_path = path.removeprefix("file://")
+        else:
+            self._abs_path = fs.unstrip_protocol(self._path).removeprefix("file://")
 
     def _resolve(self) -> tuple[AbstractFileSystem, str]:
         if self._fs is None:
@@ -166,11 +173,7 @@ class DataFile:
         return self.fs.exists(self.path)
 
     def abs_path(self) -> str:
-        if self._fs is None:
-            if "://" not in self._path and "::" not in self._path:
-                return os.path.abspath(self._path)
-            return self._path.removeprefix("file://")
-        return self.fs.unstrip_protocol(self.path).removeprefix("file://")
+        return self._abs_path
 
     def required_refiner_extras(self) -> tuple[str, ...]:
         return required_refiner_extras(self._path, self._fs)
@@ -180,12 +183,7 @@ class DataFile:
         return isinstance(self.fs, LocalFileSystem)
 
     def __str__(self) -> str:
-        if self._fs is None:
-            return self.abs_path()
-        try:
-            return self.fs.unstrip_protocol(self.path)
-        except Exception:
-            return self.path
+        return self.abs_path()
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, DataFile):

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 import os
 from os import PathLike
 import posixpath
@@ -32,7 +31,6 @@ def _storage_options_for_path(
     return options
 
 
-@dataclass(frozen=True, slots=True)
 class DataFile:
     """A minimal (fs, path) file abstraction with a small normalization factory.
 
@@ -43,8 +41,37 @@ class DataFile:
         - If `fs` is provided to `resolve()`, it wins and `storage_options` is ignored.
     """
 
-    fs: AbstractFileSystem
-    path: str
+    __slots__ = ("_fs", "_path", "_storage_options")
+
+    def __init__(
+        self,
+        fs: AbstractFileSystem | None,
+        path: str,
+        storage_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._fs = fs
+        # Keep string paths unresolved so cloud submission can inspect manifests
+        # and infer extras without requiring local remote-storage credentials.
+        self._path = (
+            fs._strip_protocol(path) if fs is not None and "://" in path else path
+        )
+        self._storage_options = dict(storage_options or {})
+
+    def _resolve(self) -> tuple[AbstractFileSystem, str]:
+        if self._fs is None:
+            self._fs, self._path = url_to_fs(
+                self._path,
+                **_storage_options_for_path(self._path, self._storage_options),
+            )
+        return self._fs, self._path
+
+    @property
+    def fs(self) -> AbstractFileSystem:
+        return self._resolve()[0]
+
+    @property
+    def path(self) -> str:
+        return self._resolve()[1]
 
     @classmethod
     def resolve(
@@ -79,15 +106,9 @@ class DataFile:
         # simple string url/path
         if isinstance(data, str):
             if fs is not None:
-                # Best-effort strip protocol so `.path` is in the form expected by `fs.open/fs.exists`.
-                path = fs._strip_protocol(data)
-                return cls(fs=fs, path=path)
+                return cls(fs=fs, path=data)
 
-            next_fs, path = url_to_fs(
-                data,
-                **_storage_options_for_path(data, storage_options),
-            )
-            return cls(fs=next_fs, path=path)
+            return cls(fs=None, path=data, storage_options=storage_options)
 
         raise TypeError("DataFileLike must be: str | PathLike | (path, fs) | DataFile")
 
@@ -145,17 +166,31 @@ class DataFile:
         return self.fs.exists(self.path)
 
     def abs_path(self) -> str:
+        if self._fs is None:
+            if "://" not in self._path and "::" not in self._path:
+                return os.path.abspath(self._path)
+            return self._path.removeprefix("file://")
         return self.fs.unstrip_protocol(self.path).removeprefix("file://")
 
     def required_refiner_extras(self) -> tuple[str, ...]:
-        return required_refiner_extras(self.path, self.fs)
+        return required_refiner_extras(self._path, self._fs)
 
     @property
     def is_local(self) -> bool:
         return isinstance(self.fs, LocalFileSystem)
 
     def __str__(self) -> str:
+        if self._fs is None:
+            return self.abs_path()
         try:
             return self.fs.unstrip_protocol(self.path)
         except Exception:
             return self.path
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DataFile):
+            return NotImplemented
+        return self.fs == other.fs and self.path == other.path
+
+    def __hash__(self) -> int:
+        return hash((self.fs, self.path))

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -184,11 +184,3 @@ class DataFile:
 
     def __str__(self) -> str:
         return self.abs_path()
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, DataFile):
-            return NotImplemented
-        return self.fs == other.fs and self.path == other.path
-
-    def __hash__(self) -> int:
-        return hash((self.fs, self.path))

--- a/src/refiner/io/datafile.py
+++ b/src/refiner/io/datafile.py
@@ -31,6 +31,15 @@ def _storage_options_for_path(
     return options
 
 
+def _file_cache_key(file: "DataFile") -> tuple[object, str]:
+    fs = file.fs
+    fs_token = getattr(fs, "_fs_token", None)
+    if fs_token is None:
+        tokenize = getattr(fs, "__dask_tokenize__", None)
+        fs_token = tokenize() if callable(tokenize) else id(fs)
+    return (type(fs), fs_token), file.abs_path()
+
+
 class DataFile:
     """A minimal (fs, path) file abstraction with a small normalization factory.
 

--- a/src/refiner/io/datafolder.py
+++ b/src/refiner/io/datafolder.py
@@ -1,8 +1,10 @@
 from collections.abc import Iterable, Iterator, Mapping
+import os
 from os import PathLike
 from typing import IO, Any, TypeAlias, Union, cast
 
 from fsspec import AbstractFileSystem, url_to_fs
+from fsspec.asyn import AsyncFileSystem
 from fsspec.implementations.dirfs import DirFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
@@ -41,15 +43,41 @@ class DataFolder(DirFileSystem):
             auto_mkdir: if True, when opening a file in write mode its parent directories will be automatically created
             **storage_options: will be passed to a new fsspec filesystem object, when it is created. Ignored if fs is given
         """
-        if fs is None:
-            fs, path = url_to_fs(path, **storage_options)
-            path = "/" if path is None else path
-        else:
-            path = fs._strip_protocol(path)
-        if path == "":
-            path = "/"
-        super().__init__(path=path, fs=fs)
+        AsyncFileSystem.__init__(self)
+        self._fs = fs
+        # Keep string paths unresolved so cloud submission can inspect manifests
+        # and infer extras without requiring local remote-storage credentials.
+        self._path = fs._strip_protocol(path) if fs is not None else path
+        if fs is not None and not self._path:
+            self._path = "/"
+        self._storage_options = dict(storage_options)
         self.auto_mkdir = auto_mkdir
+
+    def _resolve(self) -> tuple[AbstractFileSystem, str]:
+        if self._fs is None:
+            self._fs, self._path = url_to_fs(
+                self._path,
+                **_storage_options_for_path(self._path, self._storage_options),
+            )
+            if not self._path:
+                self._path = "/"
+        return self._fs, self._path
+
+    @property
+    def fs(self) -> AbstractFileSystem:
+        return self._resolve()[0]
+
+    @fs.setter
+    def fs(self, value: AbstractFileSystem | None) -> None:
+        self._fs = value
+
+    @property
+    def path(self) -> str:
+        return self._resolve()[1]
+
+    @path.setter
+    def path(self, value: str) -> None:
+        self._path = value
 
     @classmethod
     def resolve(
@@ -92,19 +120,29 @@ class DataFolder(DirFileSystem):
         # simple string path
         if isinstance(data, str):
             if fs is not None:
-                path = fs._strip_protocol(data)
-                return cls(path, fs=fs)
-            return cls(data, **_storage_options_for_path(data, storage_options))
+                return cls(data, fs=fs)
+            return cls(data, **dict(storage_options or {}))
         raise TypeError(
             "You must pass a DataFolder instance, str path, PathLike, or (path, fs)"
         )
 
     def abs_path(self, path: str = "") -> str:
+        if self._fs is None:
+            if "://" not in self._path and "::" not in self._path:
+                base = os.path.abspath(self._path).rstrip("/")
+            else:
+                base = self._path.removeprefix("file://").rstrip("/")
+            relpath = path.lstrip("/")
+            if not relpath:
+                return base
+            if not base:
+                return relpath
+            return f"{base}/{relpath}"
         # make sure we strip file:// and similar
         return self.fs.unstrip_protocol(self._join(path)).removeprefix("file://")
 
     def required_refiner_extras(self) -> tuple[str, ...]:
-        return required_refiner_extras(self.path, self.fs)
+        return required_refiner_extras(self._path, self._fs)
 
     def abs_paths(self, paths: str | Iterable[str]) -> str | list[str]:
         """

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -22,24 +22,6 @@ DataFileSetInput: TypeAlias = Union[
 DataFileSetLike: TypeAlias = Union[DataFileSetInput, Sequence[DataFileSetInput]]
 
 
-def _glob_files(
-    fs: AbstractFileSystem,
-    path: str,
-    *,
-    limit: int | None = None,
-) -> tuple[DataFile, ...]:
-    files: list[DataFile] = []
-    matched = fs.glob(path, detail=True)
-    for expanded_path, info in sorted(matched.items()):
-        if limit is not None and len(files) >= limit:
-            break
-        if not isinstance(expanded_path, str) or not isinstance(info, Mapping):
-            continue
-        if info.get("type") == "file":
-            files.append(DataFile(fs=fs, path=expanded_path))
-    return tuple(files)
-
-
 @dataclass(slots=True)
 class _PathSource:
     _path: str
@@ -213,59 +195,6 @@ class DataFileSet:
                 }
             )
         )
-
-    def first_files(self, limit: int) -> tuple[DataFile, ...]:
-        if limit <= 0:
-            return ()
-
-        exts = tuple(e.lower() for e in self.extensions)
-        include_file = self.include_file
-        files: list[DataFile] = []
-
-        def append(file: DataFile) -> None:
-            if exts and not file.path.lower().endswith(exts):
-                return
-            if include_file is not None and not include_file(file.path):
-                return
-            files.append(file)
-
-        for entry in self.entries:
-            remaining = limit - len(files)
-            if remaining <= 0:
-                break
-            if isinstance(entry, DataFile):
-                append(entry)
-            elif isinstance(entry, DataFolder):
-                for file in entry.iter_files(recursive=self.recursive):
-                    append(file)
-                    if len(files) >= limit:
-                        break
-            elif glob.has_magic(entry.path):
-                for file in _glob_files(entry.fs, entry.path, limit=remaining):
-                    append(file)
-            else:
-                try:
-                    info = entry.fs.info(entry.path)
-                except FileNotFoundError:
-                    raise FileNotFoundError(
-                        f"Could not resolve input: {entry.fs.unstrip_protocol(entry.path)!r}"
-                    )
-                item_type = info.get("type")
-                if item_type == "directory":
-                    folder = DataFolder(path=entry.path, fs=entry.fs)
-                    for file in folder.iter_files(recursive=self.recursive):
-                        append(file)
-                        if len(files) >= limit:
-                            break
-                elif item_type == "file":
-                    append(DataFile(fs=entry.fs, path=entry.path))
-                else:
-                    raise TypeError(
-                        f"Unsupported file type {item_type!r} for input: "
-                        f"{entry.fs.unstrip_protocol(entry.path)!r}"
-                    )
-
-        return tuple(files[:limit])
 
     @property
     def resolved_entries(self) -> tuple[DataFile | DataFolder, ...]:

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -22,13 +22,39 @@ DataFileSetInput: TypeAlias = Union[
 DataFileSetLike: TypeAlias = Union[DataFileSetInput, Sequence[DataFileSetInput]]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _PathSource:
-    path: str
-    fs: AbstractFileSystem
+    _path: str
+    _fs: AbstractFileSystem | None = None
+    _storage_options: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self._fs is not None:
+            self._path = self._fs._strip_protocol(self._path)
+
+    def _resolve(self) -> tuple[AbstractFileSystem, str]:
+        if self._fs is None:
+            self._fs, self._path = url_to_fs(
+                self._path,
+                **_storage_options_for_path(self._path, self._storage_options),
+            )
+        return self._fs, self._path
+
+    @property
+    def fs(self) -> AbstractFileSystem:
+        return self._resolve()[0]
+
+    @property
+    def path(self) -> str:
+        return self._resolve()[1]
+
+    def abs_path(self) -> str:
+        if self._fs is None:
+            return self._path.removeprefix("file://")
+        return self.fs.unstrip_protocol(self.path).removeprefix("file://")
 
     def required_refiner_extras(self) -> tuple[str, ...]:
-        return required_refiner_extras(self.path, self.fs)
+        return required_refiner_extras(self._path, self._fs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,11 +111,7 @@ class DataFileSet:
             inputs = tuple(data)
 
         normalized_entries: list[DataFile | DataFolder | _PathSource] = []
-
-        def append_path_source(path: str, path_fs: AbstractFileSystem) -> None:
-            normalized_entries.append(
-                _PathSource(path=path_fs._strip_protocol(path), fs=path_fs)
-            )
+        source_storage_options = dict(storage_options or {})
 
         for item in inputs:
             if isinstance(item, DataFile):
@@ -117,11 +139,11 @@ class DataFileSet:
                         "DataFileSet inputs must be str | PathLike | (path, fs) | DataFile | DataFolder"
                     )
                 if expect_type == "folder":
-                    append_path_source(path, item_fs)
+                    normalized_entries.append(_PathSource(_path=path, _fs=item_fs))
                 elif expect_type == "file":
                     normalized_entries.append(DataFile(path=path, fs=item_fs))
                 else:
-                    append_path_source(path, item_fs)
+                    normalized_entries.append(_PathSource(_path=path, _fs=item_fs))
                 continue
 
             if isinstance(item, PathLike):
@@ -134,28 +156,30 @@ class DataFileSet:
 
             if fs is not None:
                 if expect_type == "folder":
-                    append_path_source(item, fs)
+                    normalized_entries.append(_PathSource(_path=item, _fs=fs))
                 elif expect_type == "file":
                     normalized_entries.append(DataFile.resolve(item, fs=fs))
                 else:
-                    append_path_source(item, fs)
+                    normalized_entries.append(_PathSource(_path=item, _fs=fs))
             else:
                 if expect_type == "folder":
-                    item_fs, path = url_to_fs(
-                        item,
-                        **_storage_options_for_path(item, storage_options),
+                    normalized_entries.append(
+                        _PathSource(
+                            _path=item,
+                            _storage_options=source_storage_options,
+                        )
                     )
-                    append_path_source(path, item_fs)
                 elif expect_type == "file":
                     normalized_entries.append(
                         DataFile.resolve(item, storage_options=storage_options)
                     )
                 else:
-                    item_fs, path = url_to_fs(
-                        item,
-                        **_storage_options_for_path(item, storage_options),
+                    normalized_entries.append(
+                        _PathSource(
+                            _path=item,
+                            _storage_options=source_storage_options,
+                        )
                     )
-                    append_path_source(path, item_fs)
 
         return cls(
             entries=tuple(normalized_entries),

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from os import PathLike
@@ -50,6 +51,8 @@ class _PathSource:
 
     def abs_path(self) -> str:
         if self._fs is None:
+            if "://" not in self._path and "::" not in self._path:
+                return os.path.abspath(self._path)
             return self._path.removeprefix("file://")
         return self.fs.unstrip_protocol(self.path).removeprefix("file://")
 

--- a/src/refiner/io/fileset.py
+++ b/src/refiner/io/fileset.py
@@ -22,6 +22,24 @@ DataFileSetInput: TypeAlias = Union[
 DataFileSetLike: TypeAlias = Union[DataFileSetInput, Sequence[DataFileSetInput]]
 
 
+def _glob_files(
+    fs: AbstractFileSystem,
+    path: str,
+    *,
+    limit: int | None = None,
+) -> tuple[DataFile, ...]:
+    files: list[DataFile] = []
+    matched = fs.glob(path, detail=True)
+    for expanded_path, info in sorted(matched.items()):
+        if limit is not None and len(files) >= limit:
+            break
+        if not isinstance(expanded_path, str) or not isinstance(info, Mapping):
+            continue
+        if info.get("type") == "file":
+            files.append(DataFile(fs=fs, path=expanded_path))
+    return tuple(files)
+
+
 @dataclass(slots=True)
 class _PathSource:
     _path: str
@@ -126,25 +144,14 @@ class DataFileSet:
                 normalized_entries.append(item)
                 continue
 
-            if (
-                isinstance(item, tuple)
-                and len(item) == 2
-                and isinstance(item[1], AbstractFileSystem)
-            ):
-                path, item_fs = cast(DataFileSpec | DataFolderSpec, item)
-                if isinstance(path, PathLike):
-                    path = str(path)
-                if not isinstance(path, str):
+            item_fs = fs
+            if isinstance(item, tuple):
+                if not (len(item) == 2 and isinstance(item[1], AbstractFileSystem)):
                     raise TypeError(
                         "DataFileSet inputs must be str | PathLike | (path, fs) | DataFile | DataFolder"
                     )
-                if expect_type == "folder":
-                    normalized_entries.append(_PathSource(_path=path, _fs=item_fs))
-                elif expect_type == "file":
-                    normalized_entries.append(DataFile(path=path, fs=item_fs))
-                else:
-                    normalized_entries.append(_PathSource(_path=path, _fs=item_fs))
-                continue
+                path, item_fs = cast(DataFileSpec | DataFolderSpec, item)
+                item = path
 
             if isinstance(item, PathLike):
                 item = str(item)
@@ -154,32 +161,22 @@ class DataFileSet:
                     "DataFileSet inputs must be str | PathLike | (path, fs) | DataFile | DataFolder"
                 )
 
-            if fs is not None:
-                if expect_type == "folder":
-                    normalized_entries.append(_PathSource(_path=item, _fs=fs))
-                elif expect_type == "file":
-                    normalized_entries.append(DataFile.resolve(item, fs=fs))
+            if item_fs is not None:
+                if expect_type == "file":
+                    normalized_entries.append(DataFile.resolve(item, fs=item_fs))
                 else:
-                    normalized_entries.append(_PathSource(_path=item, _fs=fs))
+                    normalized_entries.append(_PathSource(_path=item, _fs=item_fs))
+            elif expect_type == "file":
+                normalized_entries.append(
+                    DataFile.resolve(item, storage_options=storage_options)
+                )
             else:
-                if expect_type == "folder":
-                    normalized_entries.append(
-                        _PathSource(
-                            _path=item,
-                            _storage_options=source_storage_options,
-                        )
+                normalized_entries.append(
+                    _PathSource(
+                        _path=item,
+                        _storage_options=source_storage_options,
                     )
-                elif expect_type == "file":
-                    normalized_entries.append(
-                        DataFile.resolve(item, storage_options=storage_options)
-                    )
-                else:
-                    normalized_entries.append(
-                        _PathSource(
-                            _path=item,
-                            _storage_options=source_storage_options,
-                        )
-                    )
+                )
 
         return cls(
             entries=tuple(normalized_entries),
@@ -216,6 +213,59 @@ class DataFileSet:
                 }
             )
         )
+
+    def first_files(self, limit: int) -> tuple[DataFile, ...]:
+        if limit <= 0:
+            return ()
+
+        exts = tuple(e.lower() for e in self.extensions)
+        include_file = self.include_file
+        files: list[DataFile] = []
+
+        def append(file: DataFile) -> None:
+            if exts and not file.path.lower().endswith(exts):
+                return
+            if include_file is not None and not include_file(file.path):
+                return
+            files.append(file)
+
+        for entry in self.entries:
+            remaining = limit - len(files)
+            if remaining <= 0:
+                break
+            if isinstance(entry, DataFile):
+                append(entry)
+            elif isinstance(entry, DataFolder):
+                for file in entry.iter_files(recursive=self.recursive):
+                    append(file)
+                    if len(files) >= limit:
+                        break
+            elif glob.has_magic(entry.path):
+                for file in _glob_files(entry.fs, entry.path, limit=remaining):
+                    append(file)
+            else:
+                try:
+                    info = entry.fs.info(entry.path)
+                except FileNotFoundError:
+                    raise FileNotFoundError(
+                        f"Could not resolve input: {entry.fs.unstrip_protocol(entry.path)!r}"
+                    )
+                item_type = info.get("type")
+                if item_type == "directory":
+                    folder = DataFolder(path=entry.path, fs=entry.fs)
+                    for file in folder.iter_files(recursive=self.recursive):
+                        append(file)
+                        if len(files) >= limit:
+                            break
+                elif item_type == "file":
+                    append(DataFile(fs=entry.fs, path=entry.path))
+                else:
+                    raise TypeError(
+                        f"Unsupported file type {item_type!r} for input: "
+                        f"{entry.fs.unstrip_protocol(entry.path)!r}"
+                    )
+
+        return tuple(files[:limit])
 
     @property
     def resolved_entries(self) -> tuple[DataFile | DataFolder, ...]:

--- a/src/refiner/io/utils.py
+++ b/src/refiner/io/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fsspec import AbstractFileSystem
+from fsspec.core import split_protocol
 
 
 _PROTOCOL_REFINER_EXTRAS = {
@@ -12,18 +13,42 @@ _PROTOCOL_REFINER_EXTRAS = {
 }
 
 
-def required_refiner_extras(path: str, fs: AbstractFileSystem) -> tuple[str, ...]:
-    protocol = fs.protocol
-    protocols = (protocol,) if isinstance(protocol, str) else tuple(protocol)
-    path_protocol, sep, _rest = path.partition("://")
+def required_refiner_extras(
+    path: str,
+    fs: AbstractFileSystem | None = None,
+) -> tuple[str, ...]:
+    candidates: list[str] = []
+    path_bits = path.split("::")
+    for bit in path_bits:
+        protocol, _path = split_protocol(bit)
+        if protocol is not None:
+            candidates.append(protocol)
+        elif len(path_bits) > 1 and bit in _PROTOCOL_REFINER_EXTRAS:
+            candidates.append(bit)
+    if fs is not None:
+        seen: set[int] = set()
+        filesystems = [fs]
+        while filesystems:
+            current = filesystems.pop()
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            protocol = current.protocol
+            candidates.extend((protocol,) if isinstance(protocol, str) else protocol)
+            target_protocol = getattr(current, "target_protocol", None)
+            if isinstance(target_protocol, str):
+                candidates.append(target_protocol)
+            elif target_protocol is not None:
+                candidates.extend(target_protocol)
+            target_fs = getattr(current, "fs", None)
+            if isinstance(target_fs, AbstractFileSystem):
+                filesystems.append(target_fs)
     return tuple(
         sorted(
             {
                 extra
-                for item in (*protocols, path_protocol if sep else None)
-                if item is not None
-                and (extra := _PROTOCOL_REFINER_EXTRAS.get(str(item).lower()))
-                is not None
+                for protocol in candidates
+                if (extra := _PROTOCOL_REFINER_EXTRAS.get(protocol.lower())) is not None
             }
         )
     )

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -110,7 +110,7 @@ class BaseReader(BaseSource):
             elif isinstance(entry, DataFolder):
                 inputs.append(str(entry.abs_paths("")))
             else:
-                inputs.append(str(entry.fs.unstrip_protocol(entry.path)))
+                inputs.append(entry.abs_path())
         return {
             "path": ", ".join(inputs),
             "inputs": inputs,

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -145,7 +145,12 @@ class BaseReader(BaseSource):
         Returns:
             (fh, opened_new): `opened_new` is True if a new file handle was opened.
         """
-        if not force_reopen and self._open_file == file and self._open_fh is not None:
+        if (
+            not force_reopen
+            and self._open_file is not None
+            and self._open_file.abs_path() == file.abs_path()
+            and self._open_fh is not None
+        ):
             return self._open_fh, False
 
         if self._open_fh is not None:

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -9,6 +9,7 @@ from fsspec import AbstractFileSystem
 import pyarrow as pa
 
 from refiner.io import DataFile, DataFileSet, DataFolder
+from refiner.io.datafile import _file_cache_key
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.data.datatype import DTypeMapping, schema_with_dtypes
 from refiner.pipeline.data.shard import FilePart, Shard
@@ -148,7 +149,7 @@ class BaseReader(BaseSource):
         if (
             not force_reopen
             and self._open_file is not None
-            and self._open_file.abs_path() == file.abs_path()
+            and _file_cache_key(self._open_file) == _file_cache_key(file)
             and self._open_fh is not None
         ):
             return self._open_fh, False

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -248,9 +248,7 @@ class BaseReader(BaseSource):
                 path = file.abs_path()
                 size = self.fileset.size(source_index, path)
                 # Atomic files stay whole: `end=-1` means "reader decides how to read the full file".
-                if not self.split_by_bytes or not is_splittable_by_bytes(
-                    file.fs, file.path
-                ):
+                if not self.split_by_bytes or not is_splittable_by_bytes(file):
                     if (
                         current_parts
                         and current_size + size > target_bytes

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator, Mapping, Sequence
 from functools import cached_property
-from os import PathLike
-from typing import Any, cast
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -64,22 +63,8 @@ class LeRobotEpisodeReader(BaseSource):
         The shard-planning arguments apply to the episode parquet files under
         each dataset root's `meta/episodes` directory.
         """
-        root_inputs: DataFolderLike | Sequence[DataFolderLike] = inputs
-        if isinstance(inputs, str) and inputs.startswith("lerobot/"):
-            root_inputs = f"hf://datasets/{inputs}"
-        elif not isinstance(inputs, (str, PathLike, DataFolder)) and not (
-            isinstance(inputs, tuple)
-            and len(inputs) == 2
-            and isinstance(inputs[1], AbstractFileSystem)
-        ):
-            root_inputs = tuple(
-                f"hf://datasets/{item}"
-                if isinstance(item, str) and item.startswith("lerobot/")
-                else item
-                for item in cast(Sequence[DataFolderLike], inputs)
-            )
         self._root_fileset = DataFileSet.resolve(
-            root_inputs,
+            inputs,
             fs=fs,
             storage_options=storage_options,
             expect_type="folder",

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -198,7 +198,7 @@ class LeRobotEpisodeReader(BaseSource):
         if self._episode_reader is None:
             self._episode_reader = ParquetReader(
                 inputs=tuple(
-                    (str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT)), root.fs)
+                    str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT))
                     for root in self.roots
                 ),
                 recursive=True,

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -183,7 +183,7 @@ class LeRobotEpisodeReader(BaseSource):
         if self._episode_reader is None:
             self._episode_reader = ParquetReader(
                 inputs=tuple(
-                    str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT))
+                    (str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT)), root.fs)
                     for root in self.roots
                 ),
                 recursive=True,

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator, Mapping, Sequence
 from functools import cached_property
-from typing import Any
+from os import PathLike
+from typing import Any, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -15,7 +16,7 @@ from refiner.io.datafolder import DataFolderLike
 from refiner.io.fileset import DataFileSet
 from refiner.pipeline.data.shard import FilePartsDescriptor, Shard
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
-from refiner.pipeline.sources.base import SourceUnit
+from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.pipeline.sources.readers.parquet import ParquetReader
 from refiner.pipeline.sources.readers.utils import DEFAULT_TARGET_SHARD_BYTES
 from refiner.robotics.lerobot_format import (
@@ -36,7 +37,7 @@ _STATS_JSON = "meta/stats.json"
 _TASKS_PARQUET = "meta/tasks.parquet"
 
 
-class LeRobotEpisodeReader(ParquetReader):
+class LeRobotEpisodeReader(BaseSource):
     """Read LeRobot episode datasets into `LeRobotTabular` blocks.
 
     Episode parquet shards are loaded through `ParquetReader`, then hydrated
@@ -63,33 +64,45 @@ class LeRobotEpisodeReader(ParquetReader):
         The shard-planning arguments apply to the episode parquet files under
         each dataset root's `meta/episodes` directory.
         """
-        self.roots = self._resolve_roots(
-            inputs,
+        root_inputs: DataFolderLike | Sequence[DataFolderLike] = inputs
+        if isinstance(inputs, str) and inputs.startswith("lerobot/"):
+            root_inputs = f"hf://datasets/{inputs}"
+        elif not isinstance(inputs, (str, PathLike, DataFolder)) and not (
+            isinstance(inputs, tuple)
+            and len(inputs) == 2
+            and isinstance(inputs[1], AbstractFileSystem)
+        ):
+            root_inputs = tuple(
+                f"hf://datasets/{item}"
+                if isinstance(item, str) and item.startswith("lerobot/")
+                else item
+                for item in cast(Sequence[DataFolderLike], inputs)
+            )
+        self._root_fileset = DataFileSet.resolve(
+            root_inputs,
             fs=fs,
             storage_options=storage_options,
+            expect_type="folder",
         )
+        if not self._root_fileset.entries:
+            raise ValueError("LeRobot reader requires at least one dataset root")
+        self._roots: tuple[DataFolder, ...] | None = None
+        self._episode_reader: ParquetReader | None = None
+        self.target_shard_bytes = target_shard_bytes
+        self.num_shards = num_shards
+        self.arrow_batch_size = arrow_batch_size
+        self.split_row_groups = split_row_groups
+        self.dtypes = None
         self._last_frame_table: tuple[tuple[int, Any, Any], pa.Table] | None = None
         self.skip_malformed_rows = skip_malformed_rows
         self._warned_malformed_row = False
 
-        super().__init__(
-            inputs=tuple(
-                (str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT)), root.fs)
-                for root in self.roots
-            ),
-            fs=fs,
-            storage_options=storage_options,
-            recursive=True,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            arrow_batch_size=arrow_batch_size,
-            split_row_groups=split_row_groups,
-            file_path_column=None,
-        )
-
     def describe(self) -> dict[str, Any]:
-        inputs = [str(root.abs_paths("")) for root in self.roots]
+        inputs = [entry.abs_path() for entry in self._root_fileset.entries]
         return {"path": ", ".join(inputs), "inputs": inputs}
+
+    def list_shards(self) -> list[Shard]:
+        return self._parquet_reader().list_shards()
 
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one planned episode shard and emit `LeRobotTabular` blocks."""
@@ -98,7 +111,7 @@ class LeRobotEpisodeReader(ParquetReader):
         metadata, remaps = self._metadata_bundle
         for part in descriptor.parts:
             part_shard = Shard.from_file_parts((part,))
-            for batch in super().read_shard(part_shard):
+            for batch in self._parquet_reader().read_shard(part_shard):
                 if not isinstance(batch, Tabular):
                     raise TypeError(
                         "LeRobotEpisodeReader requires Tabular batches from ParquetReader"
@@ -172,28 +185,33 @@ class LeRobotEpisodeReader(ParquetReader):
                     roots_by_row=(root,) * batch.num_rows,
                 )
 
-    @staticmethod
-    def _resolve_roots(
-        inputs: DataFolderLike | Sequence[DataFolderLike],
-        *,
-        fs: AbstractFileSystem | None,
-        storage_options: Mapping[str, Any] | None,
-    ) -> tuple[DataFolder, ...]:
-        """Resolve reader inputs into concrete LeRobot dataset roots.
+    @property
+    def roots(self) -> tuple[DataFolder, ...]:
+        if self._roots is None:
+            roots = self._root_fileset.datafolders
+            if not roots:
+                raise ValueError("LeRobot reader requires at least one dataset root")
+            self._roots = roots
+        return self._roots
 
-        Inputs may be single paths, `(path, fs)` pairs, `DataFolder`s, or
-        sequences of those values.
-        """
-        fileset = DataFileSet.resolve(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            expect_type="folder",
-        )
-        roots = fileset.datafolders
-        if not roots:
-            raise ValueError("LeRobot reader requires at least one dataset root")
-        return roots
+    def _parquet_reader(self) -> ParquetReader:
+        if self._episode_reader is None:
+            self._episode_reader = ParquetReader(
+                inputs=tuple(
+                    (str(root.abs_paths(_DEFAULT_EPISODES_GLOB_ROOT)), root.fs)
+                    for root in self.roots
+                ),
+                recursive=True,
+                target_shard_bytes=self.target_shard_bytes,
+                num_shards=self.num_shards,
+                arrow_batch_size=self.arrow_batch_size,
+                split_row_groups=self.split_row_groups,
+                file_path_column=None,
+            )
+        return self._episode_reader
+
+    def _io_refiner_extras(self) -> tuple[str, ...]:
+        return self._root_fileset.required_refiner_extras()
 
     @cached_property
     def _metadata_bundle(

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 from fsspec import AbstractFileSystem
 
 from refiner.io import DataFile
+from refiner.io.datafile import _file_cache_key
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.data.datatype import (
     DTypeMapping,
@@ -153,7 +154,8 @@ class ParquetReader(BaseReader):
         if (
             self._open_fragment is not None
             and self._open_fragment_file is not None
-            and self._open_fragment_file.abs_path() == source_file.abs_path()
+            and _file_cache_key(self._open_fragment_file)
+            == _file_cache_key(source_file)
         ):
             return self._open_fragment
 

--- a/src/refiner/pipeline/sources/readers/parquet.py
+++ b/src/refiner/pipeline/sources/readers/parquet.py
@@ -150,7 +150,11 @@ class ParquetReader(BaseReader):
 
     def _get_parquet_fragment(self, source_file: DataFile) -> ds.ParquetFileFragment:
         """Build a Parquet fragment for row-group-aware filter pushdown."""
-        if self._open_fragment is not None and self._open_fragment_file == source_file:
+        if (
+            self._open_fragment is not None
+            and self._open_fragment_file is not None
+            and self._open_fragment_file.abs_path() == source_file.abs_path()
+        ):
             return self._open_fragment
 
         pyfs = pafs.PyFileSystem(pafs.FSSpecHandler(source_file.fs))

--- a/src/refiner/pipeline/sources/readers/tfds.py
+++ b/src/refiner/pipeline/sources/readers/tfds.py
@@ -81,8 +81,6 @@ class TfdsReader(BaseSource):
             raise ValueError("examples_per_shard must be > 0")
         if num_shards is not None and num_shards <= 0:
             raise ValueError("num_shards must be > 0 when provided")
-        self._tf: Any | None = None
-        self._tfds: Any | None = None
         self.inputs = (input,) if isinstance(input, str) else tuple(input)
         if not self.inputs:
             raise ValueError("read_tfds input sequence cannot be empty")
@@ -129,8 +127,6 @@ class TfdsReader(BaseSource):
         state["_remote_folders"] = {}
         state["num_examples_by_input"] = [None] * len(self.inputs)
         state["dataset_names"] = [None] * len(self.inputs)
-        state["_tf"] = None
-        state["_tfds"] = None
         return state
 
     def _ensure_builder(self, input_index: int) -> Any:
@@ -138,7 +134,15 @@ class TfdsReader(BaseSource):
         if builder is not None:
             return builder
 
-        tfds = self._tensorflow_datasets()
+        check_required_dependencies(
+            "read_tfds",
+            [
+                ("tensorflow", "tensorflow"),
+                ("tensorflow_datasets", "tensorflow-datasets"),
+            ],
+            dist="tfds",
+        )
+        tfds = importlib.import_module("tensorflow_datasets")
         input = self._ensure_prepared_dir(input_index)
         input_path = Path(input)
         is_prepared_dir = (
@@ -177,25 +181,6 @@ class TfdsReader(BaseSource):
     def _ensure_builders(self) -> None:
         for input_index in range(len(self.inputs)):
             self._ensure_builder(input_index)
-
-    def _tensorflow(self) -> Any:
-        if self._tf is None:
-            check_required_dependencies(
-                "read_tfds",
-                [
-                    ("tensorflow", "tensorflow"),
-                    ("tensorflow_datasets", "tensorflow-datasets"),
-                ],
-                dist="tfds",
-            )
-            self._tf = importlib.import_module("tensorflow")
-        return self._tf
-
-    def _tensorflow_datasets(self) -> Any:
-        if self._tfds is None:
-            self._tensorflow()
-            self._tfds = importlib.import_module("tensorflow_datasets")
-        return self._tfds
 
     def _ensure_prepared_dir(self, input_index: int) -> str:
         if not self._remote_inputs[input_index]:
@@ -338,7 +323,7 @@ class TfdsReader(BaseSource):
             batch_size=None,
         )
         try:
-            tf = self._tensorflow()
+            tf = importlib.import_module("tensorflow")
             has_nested_datasets = any(
                 isinstance(spec, tf.data.DatasetSpec)
                 for spec in tf.nest.flatten(dataset.element_spec)

--- a/src/refiner/pipeline/sources/readers/tfds.py
+++ b/src/refiner/pipeline/sources/readers/tfds.py
@@ -81,16 +81,8 @@ class TfdsReader(BaseSource):
             raise ValueError("examples_per_shard must be > 0")
         if num_shards is not None and num_shards <= 0:
             raise ValueError("num_shards must be > 0 when provided")
-        check_required_dependencies(
-            "read_tfds",
-            [
-                ("tensorflow", "tensorflow"),
-                ("tensorflow_datasets", "tensorflow-datasets"),
-            ],
-            dist="tfds",
-        )
-        self.tf = importlib.import_module("tensorflow")
-        self.tfds = importlib.import_module("tensorflow_datasets")
+        self._tf: Any | None = None
+        self._tfds: Any | None = None
         self.inputs = (input,) if isinstance(input, str) else tuple(input)
         if not self.inputs:
             raise ValueError("read_tfds input sequence cannot be empty")
@@ -137,6 +129,8 @@ class TfdsReader(BaseSource):
         state["_remote_folders"] = {}
         state["num_examples_by_input"] = [None] * len(self.inputs)
         state["dataset_names"] = [None] * len(self.inputs)
+        state["_tf"] = None
+        state["_tfds"] = None
         return state
 
     def _ensure_builder(self, input_index: int) -> Any:
@@ -144,6 +138,7 @@ class TfdsReader(BaseSource):
         if builder is not None:
             return builder
 
+        tfds = self._tensorflow_datasets()
         input = self._ensure_prepared_dir(input_index)
         input_path = Path(input)
         is_prepared_dir = (
@@ -158,9 +153,9 @@ class TfdsReader(BaseSource):
         if is_prepared_dir and self.download:
             raise ValueError("download cannot be used with a prepared TFDS directory")
         if is_prepared_dir:
-            builder = self.tfds.builder_from_directory(input)
+            builder = tfds.builder_from_directory(input)
         else:
-            builder = self.tfds.builder(
+            builder = tfds.builder(
                 input,
                 config=self.config,
                 data_dir=self.data_dir,
@@ -182,6 +177,25 @@ class TfdsReader(BaseSource):
     def _ensure_builders(self) -> None:
         for input_index in range(len(self.inputs)):
             self._ensure_builder(input_index)
+
+    def _tensorflow(self) -> Any:
+        if self._tf is None:
+            check_required_dependencies(
+                "read_tfds",
+                [
+                    ("tensorflow", "tensorflow"),
+                    ("tensorflow_datasets", "tensorflow-datasets"),
+                ],
+                dist="tfds",
+            )
+            self._tf = importlib.import_module("tensorflow")
+        return self._tf
+
+    def _tensorflow_datasets(self) -> Any:
+        if self._tfds is None:
+            self._tensorflow()
+            self._tfds = importlib.import_module("tensorflow_datasets")
+        return self._tfds
 
     def _ensure_prepared_dir(self, input_index: int) -> str:
         if not self._remote_inputs[input_index]:
@@ -324,9 +338,10 @@ class TfdsReader(BaseSource):
             batch_size=None,
         )
         try:
+            tf = self._tensorflow()
             has_nested_datasets = any(
-                isinstance(spec, self.tf.data.DatasetSpec)
-                for spec in self.tf.nest.flatten(dataset.element_spec)
+                isinstance(spec, tf.data.DatasetSpec)
+                for spec in tf.nest.flatten(dataset.element_spec)
             )
             if not has_nested_datasets:
                 dataset = dataset.ragged_batch(self.batch_size)
@@ -336,7 +351,7 @@ class TfdsReader(BaseSource):
                 if has_nested_datasets:
                     row: dict[str, Any] = {}
                     for name, value in batch.items():
-                        if isinstance(value, self.tf.data.Dataset):
+                        if isinstance(value, tf.data.Dataset):
                             paths = self._excluded_video_paths.get(name, ())
                             if paths:
                                 value = value.map(

--- a/src/refiner/pipeline/sources/readers/tfrecord.py
+++ b/src/refiner/pipeline/sources/readers/tfrecord.py
@@ -95,7 +95,6 @@ class TfrecordReader(BaseReader):
             file_path_column=file_path_column,
             split_by_bytes=False,
         )
-        self._tf: Any | None = None
         self.features = dict(features)
         self.batch_size = int(batch_size)
         if compression not in {None, "auto", "gzip", "zlib"}:
@@ -122,21 +121,24 @@ class TfrecordReader(BaseReader):
     def _declared_refiner_extras(self) -> tuple[str, ...]:
         return ("tensorflow",)
 
-    def _tensorflow(self) -> Any:
-        if self._tf is None:
-            check_required_dependencies(
-                "read_tfrecords",
-                [("tensorflow", "tensorflow")],
-                dist="tensorflow",
-            )
-            self._tf = importlib.import_module("tensorflow")
-        return self._tf
-
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one file-granular shard as parsed TensorFlow batches."""
+        check_required_dependencies(
+            "read_tfrecords",
+            [("tensorflow", "tensorflow")],
+            dist="tensorflow",
+        )
+        tf = importlib.import_module("tensorflow")
+
+        def parse_batch(records, paths=None):
+            parsed = tf.io.parse_example(records, self.features)
+            if self._add_file_path:
+                assert self.file_path_column is not None
+                parsed[self.file_path_column] = paths
+            return parsed
+
         descriptor = shard.descriptor
         assert isinstance(descriptor, FilePartsDescriptor)
-        tf = self._tensorflow()
         dataset = None
         for part in descriptor.parts:
             source = self.fileset.resolve_file(part.source_index, part.path)
@@ -164,7 +166,7 @@ class TfrecordReader(BaseReader):
 
         dataset = dataset.batch(self.batch_size)
         dataset = dataset.map(
-            self._parse_batch,
+            parse_batch,
             num_parallel_calls=self.num_parallel_calls,
         )
         if self.prefetch is not None:
@@ -181,13 +183,6 @@ class TfrecordReader(BaseReader):
                 )
             if table.num_rows > 0:
                 yield Tabular(table)
-
-    def _parse_batch(self, records, paths=None):
-        parsed = self._tensorflow().io.parse_example(records, self.features)
-        if self._add_file_path:
-            assert self.file_path_column is not None
-            parsed[self.file_path_column] = paths
-        return parsed
 
     def _compression_type(self, source: DataFile) -> str:
         if self.compression is None:

--- a/src/refiner/pipeline/sources/readers/tfrecord.py
+++ b/src/refiner/pipeline/sources/readers/tfrecord.py
@@ -95,12 +95,7 @@ class TfrecordReader(BaseReader):
             file_path_column=file_path_column,
             split_by_bytes=False,
         )
-        check_required_dependencies(
-            "read_tfrecords",
-            [("tensorflow", "tensorflow")],
-            dist="tensorflow",
-        )
-        self.tf = importlib.import_module("tensorflow")
+        self._tf: Any | None = None
         self.features = dict(features)
         self.batch_size = int(batch_size)
         if compression not in {None, "auto", "gzip", "zlib"}:
@@ -127,10 +122,21 @@ class TfrecordReader(BaseReader):
     def _declared_refiner_extras(self) -> tuple[str, ...]:
         return ("tensorflow",)
 
+    def _tensorflow(self) -> Any:
+        if self._tf is None:
+            check_required_dependencies(
+                "read_tfrecords",
+                [("tensorflow", "tensorflow")],
+                dist="tensorflow",
+            )
+            self._tf = importlib.import_module("tensorflow")
+        return self._tf
+
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one file-granular shard as parsed TensorFlow batches."""
         descriptor = shard.descriptor
         assert isinstance(descriptor, FilePartsDescriptor)
+        tf = self._tensorflow()
         dataset = None
         for part in descriptor.parts:
             source = self.fileset.resolve_file(part.source_index, part.path)
@@ -140,13 +146,13 @@ class TfrecordReader(BaseReader):
                     "paths. Custom fsspec filesystems are not supported."
                 )
             path = source.abs_path()
-            records = self.tf.data.TFRecordDataset(
+            records = tf.data.TFRecordDataset(
                 [path],
                 compression_type=self._compression_type(source),
             )
             if self._add_file_path:
-                paths = self.tf.data.Dataset.from_tensors(path).repeat()
-                records = self.tf.data.Dataset.zip(
+                paths = tf.data.Dataset.from_tensors(path).repeat()
+                records = tf.data.Dataset.zip(
                     (
                         records,
                         paths,
@@ -177,7 +183,7 @@ class TfrecordReader(BaseReader):
                 yield Tabular(table)
 
     def _parse_batch(self, records, paths=None):
-        parsed = self.tf.io.parse_example(records, self.features)
+        parsed = self._tensorflow().io.parse_example(records, self.features)
         if self._add_file_path:
             assert self.file_path_column is not None
             parsed[self.file_path_column] = paths

--- a/src/refiner/pipeline/sources/readers/utils.py
+++ b/src/refiner/pipeline/sources/readers/utils.py
@@ -6,8 +6,9 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 from typing import cast
 
-from fsspec import AbstractFileSystem
 import pyarrow as pa
+
+from refiner.io import DataFile
 
 DEFAULT_TARGET_SHARD_BYTES = 128 * 1024 * 1024
 PathSelection = Mapping[str, str] | Sequence[str] | str
@@ -141,14 +142,14 @@ def path_selection_map(
     return out
 
 
-def is_splittable_by_bytes(fs: AbstractFileSystem, path: str) -> bool:
+def is_splittable_by_bytes(file: DataFile) -> bool:
     """Return True if the input can be safely sharded by byte offsets."""
-    lp = path.lower()
+    lp = file.path.lower()
     if lp.endswith(NON_SPLITTABLE_WHOLEFILE_EXTS):
         return False
     # best-effort: if raw file object is not seekable, treat as non-splittable
     try:
-        with fs.open(path, mode="rb") as f:
+        with file.open(mode="rb") as f:
             if hasattr(f, "seekable") and callable(f.seekable):
                 return bool(f.seekable())
     except Exception:

--- a/src/refiner/pipeline/sources/readers/zarr.py
+++ b/src/refiner/pipeline/sources/readers/zarr.py
@@ -139,7 +139,7 @@ class ZarrReader(BaseSource):
                 resolved_inputs.append((entry, entry.abs_path()))
                 continue
             if entry.path.endswith(".zip"):
-                zip_file = DataFile(fs=entry.fs, path=entry.path)
+                zip_file = entry.file("")
                 resolved_inputs.append((zip_file, zip_file.abs_path()))
             else:
                 resolved_inputs.append((entry, entry.abs_path()))

--- a/src/refiner/pipeline/sources/readers/zarr.py
+++ b/src/refiner/pipeline/sources/readers/zarr.py
@@ -76,21 +76,9 @@ class ZarrReader(BaseSource):
             dtypes: Optional dtype overrides for output columns.
         """
         self.fileset = DataFileSet.resolve(input)
-        resolved_inputs: list[tuple[DataFolder | DataFile, str]] = []
-        for entry in self.fileset.resolved_entries:
-            if isinstance(entry, DataFile):
-                if not entry.path.endswith(".zip"):
-                    raise TypeError("read_zarr file inputs must be .zip Zarr stores")
-                resolved_inputs.append((entry, entry.abs_path()))
-                continue
-            if entry.path.endswith(".zip"):
-                zip_file = DataFile(fs=entry.fs, path=entry.path)
-                resolved_inputs.append((zip_file, zip_file.abs_path()))
-            else:
-                resolved_inputs.append((entry, entry.abs_path()))
-        if not resolved_inputs:
+        if not self.fileset.entries:
             raise ValueError("read_zarr requires at least one input")
-        self.inputs = resolved_inputs
+        self._inputs: list[tuple[DataFolder | DataFile, str]] | None = None
         if row_ends is not None and split_leading_axis:
             raise ValueError("row_ends and split_leading_axis are mutually exclusive")
         if leading_axis_row_size <= 0:
@@ -139,16 +127,35 @@ class ZarrReader(BaseSource):
             raise ValueError("file_path_column and index_column must be distinct")
 
     @property
+    def inputs(self) -> list[tuple[DataFolder | DataFile, str]]:
+        if self._inputs is not None:
+            return self._inputs
+
+        resolved_inputs: list[tuple[DataFolder | DataFile, str]] = []
+        for entry in self.fileset.resolved_entries:
+            if isinstance(entry, DataFile):
+                if not entry.path.endswith(".zip"):
+                    raise TypeError("read_zarr file inputs must be .zip Zarr stores")
+                resolved_inputs.append((entry, entry.abs_path()))
+                continue
+            if entry.path.endswith(".zip"):
+                zip_file = DataFile(fs=entry.fs, path=entry.path)
+                resolved_inputs.append((zip_file, zip_file.abs_path()))
+            else:
+                resolved_inputs.append((entry, entry.abs_path()))
+        if not resolved_inputs:
+            raise ValueError("read_zarr requires at least one input")
+        self._inputs = resolved_inputs
+        return resolved_inputs
+
+    @property
     def schema(self) -> pa.Schema | None:
         return schema_with_dtypes(None, self.dtypes)
 
     def describe(self) -> dict[str, Any]:
+        input_paths = [entry.abs_path() for entry in self.fileset.entries]
         return {
-            "path": (
-                self.inputs[0][1]
-                if len(self.inputs) == 1
-                else [source_path for _input, source_path in self.inputs]
-            ),
+            "path": (input_paths[0] if len(input_paths) == 1 else input_paths),
             "arrays": dict(self.arrays) if self.arrays is not None else None,
             "attrs": dict(self.attrs) if self.attrs is not None else None,
             "row_ends": self.row_ends,

--- a/src/refiner/pipeline/utils/cache/file_cache.py
+++ b/src/refiner/pipeline/utils/cache/file_cache.py
@@ -137,7 +137,7 @@ class MediaLocalCache:
         return _CachedFileContext(cache=self, file=file)
 
     async def acquire_file_lease(self, file: DataFile) -> _CacheFileLease:
-        key = _FileCacheKey(resolved=file.fs.unstrip_protocol(file.path), file=file)
+        key = _FileCacheKey(resolved=file.abs_path(), file=file)
         lease = await self._cache.acquire(key)
         return _CacheFileLease(lease, path=lease.resource.path)
 

--- a/src/refiner/pipeline/utils/cache/file_cache.py
+++ b/src/refiner/pipeline/utils/cache/file_cache.py
@@ -137,7 +137,7 @@ class MediaLocalCache:
         return _CachedFileContext(cache=self, file=file)
 
     async def acquire_file_lease(self, file: DataFile) -> _CacheFileLease:
-        key = _FileCacheKey(resolved=str(file), file=file)
+        key = _FileCacheKey(resolved=file.fs.unstrip_protocol(file.path), file=file)
         lease = await self._cache.acquire(key)
         return _CacheFileLease(lease, path=lease.resource.path)
 

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -540,7 +540,12 @@ class CommonCrawlWarcIndexSource(BaseSource):
     ) -> tuple[Any, bool]:
         current_file = getattr(self._thread_local, "open_file", None)
         current_fh = getattr(self._thread_local, "open_fh", None)
-        if not force_reopen and current_file == file and current_fh is not None:
+        if (
+            not force_reopen
+            and current_file is not None
+            and current_file.abs_path() == file.abs_path()
+            and current_fh is not None
+        ):
             return current_fh, False
         if current_fh is not None:
             try:

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -226,9 +226,6 @@ class CommonCrawlReader(BaseReader):
             if base_url is not None
             else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
         )
-        if resolved_base_url.startswith("s3://"):
-            check_required_dependencies("read_commoncrawl", ["s3fs"], dist="s3")
-
         if format not in {"warc", "wet"}:
             raise ValueError("format must be 'warc' or 'wet'")
         if isinstance(dumps, str):
@@ -346,7 +343,7 @@ class CommonCrawlReader(BaseReader):
             self._archive_iterator = ArchiveIterator
         return self._archive_iterator
 
-    def _source_globs(self) -> tuple[tuple[str, Any], ...]:
+    def _source_globs(self) -> tuple[str, ...]:
         """Build the dump/segment-specific WARC or WET glob inputs for BaseReader."""
         rel_globs: list[str] = []
         suffix = "warc/*.warc.gz" if self.format == "warc" else "wet/*.warc.wet.gz"
@@ -356,9 +353,7 @@ class CommonCrawlReader(BaseReader):
             else:
                 for segment in self.segments:
                     rel_globs.append(f"crawl-data/{dump}/segments/{segment}/{suffix}")
-        return tuple(
-            (self.root.abs_path(rel_glob), self.root.fs) for rel_glob in rel_globs
-        )
+        return tuple(self.root.abs_path(rel_glob) for rel_glob in rel_globs)
 
 
 class CommonCrawlWarcIndexSource(BaseSource):
@@ -390,11 +385,6 @@ class CommonCrawlWarcIndexSource(BaseSource):
             if base_url is not None
             else (_DEFAULT_HTTPS_BASE_URL if use_https else _DEFAULT_S3_BASE_URL)
         )
-        if resolved_base_url.startswith("s3://"):
-            check_required_dependencies(
-                "read_commoncrawl_from_index", ["s3fs"], dist="s3"
-            )
-
         if isinstance(dumps, str):
             self.dumps = (dumps,)
         else:

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from refiner.execution.asyncio.runtime import io_executor
 from refiner.execution.asyncio.window import AsyncWindow
 from refiner.io import DataFile, DataFolder
+from refiner.io.datafile import _file_cache_key
 from refiner.pipeline import RefinerPipeline
 from refiner.pipeline.data.datatype import DTypeMapping
 from refiner.pipeline.expressions import Expr, col
@@ -543,7 +544,7 @@ class CommonCrawlWarcIndexSource(BaseSource):
         if (
             not force_reopen
             and current_file is not None
-            and current_file.abs_path() == file.abs_path()
+            and _file_cache_key(current_file) == _file_cache_key(file)
             and current_fh is not None
         ):
             return current_fh, False

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -281,26 +281,7 @@ class CommonCrawlReader(BaseReader):
         if self.num_files is not None and not self._num_files_applied:
             from refiner.io import DataFileSet
 
-            files: list[DataFile] = []
-            remaining = self.num_files
-            for entry in self.fileset.entries:
-                if remaining <= 0:
-                    break
-                if isinstance(entry, DataFile):
-                    files.append(entry)
-                    remaining -= 1
-                    continue
-                matched = entry.fs.glob(entry.path, detail=True)
-                for expanded_path, info in sorted(matched.items()):
-                    if remaining <= 0:
-                        break
-                    if not isinstance(expanded_path, str) or not isinstance(info, dict):
-                        continue
-                    if info.get("type") != "file":
-                        continue
-                    files.append(DataFile(fs=entry.fs, path=expanded_path))
-                    remaining -= 1
-            self.fileset = DataFileSet.resolve(tuple(files))
+            self.fileset = DataFileSet.resolve(self.fileset.first_files(self.num_files))
             self._num_files_applied = True
         return super().list_shards()
 
@@ -346,7 +327,7 @@ class CommonCrawlReader(BaseReader):
             self._archive_iterator = ArchiveIterator
         return self._archive_iterator
 
-    def _source_globs(self) -> tuple[tuple[str, Any], ...]:
+    def _source_globs(self) -> tuple[str, ...]:
         """Build the dump/segment-specific WARC or WET glob inputs for BaseReader."""
         rel_globs: list[str] = []
         suffix = "warc/*.warc.gz" if self.format == "warc" else "wet/*.warc.wet.gz"
@@ -356,9 +337,7 @@ class CommonCrawlReader(BaseReader):
             else:
                 for segment in self.segments:
                     rel_globs.append(f"crawl-data/{dump}/segments/{segment}/{suffix}")
-        return tuple(
-            (self.root.abs_path(rel_glob), self.root.fs) for rel_glob in rel_globs
-        )
+        return tuple(self.root.abs_path(rel_glob) for rel_glob in rel_globs)
 
 
 class CommonCrawlWarcIndexSource(BaseSource):

--- a/src/refiner/text/commoncrawl.py
+++ b/src/refiner/text/commoncrawl.py
@@ -281,7 +281,26 @@ class CommonCrawlReader(BaseReader):
         if self.num_files is not None and not self._num_files_applied:
             from refiner.io import DataFileSet
 
-            self.fileset = DataFileSet.resolve(self.fileset.first_files(self.num_files))
+            files: list[DataFile] = []
+            remaining = self.num_files
+            for entry in self.fileset.entries:
+                if remaining <= 0:
+                    break
+                if isinstance(entry, DataFile):
+                    files.append(entry)
+                    remaining -= 1
+                    continue
+                matched = entry.fs.glob(entry.path, detail=True)
+                for expanded_path, info in sorted(matched.items()):
+                    if remaining <= 0:
+                        break
+                    if not isinstance(expanded_path, str) or not isinstance(info, dict):
+                        continue
+                    if info.get("type") != "file":
+                        continue
+                    files.append(DataFile(fs=entry.fs, path=expanded_path))
+                    remaining -= 1
+            self.fileset = DataFileSet.resolve(tuple(files))
             self._num_files_applied = True
         return super().list_shards()
 
@@ -327,7 +346,7 @@ class CommonCrawlReader(BaseReader):
             self._archive_iterator = ArchiveIterator
         return self._archive_iterator
 
-    def _source_globs(self) -> tuple[str, ...]:
+    def _source_globs(self) -> tuple[tuple[str, Any], ...]:
         """Build the dump/segment-specific WARC or WET glob inputs for BaseReader."""
         rel_globs: list[str] = []
         suffix = "warc/*.warc.gz" if self.format == "warc" else "wet/*.warc.wet.gz"
@@ -337,7 +356,9 @@ class CommonCrawlReader(BaseReader):
             else:
                 for segment in self.segments:
                     rel_globs.append(f"crawl-data/{dump}/segments/{segment}/{suffix}")
-        return tuple(self.root.abs_path(rel_glob) for rel_glob in rel_globs)
+        return tuple(
+            (self.root.abs_path(rel_glob), self.root.fs) for rel_glob in rel_globs
+        )
 
 
 class CommonCrawlWarcIndexSource(BaseSource):

--- a/src/refiner/video/remux.py
+++ b/src/refiner/video/remux.py
@@ -80,8 +80,6 @@ class RemuxWriter:
         probe: VideoSourceProbe,
     ) -> "RemuxWriter":
         check_required_dependencies("video remuxing", ["av"], dist="video")
-        output_abs = folder._join(output_rel)
-        folder.fs.makedirs(folder.fs._parent(output_abs), exist_ok=True)
         output_file = folder.open(output_rel, mode="wb")
         return cls.open_file(
             output_file=output_file,

--- a/tests/io/test_datafile_datafolder.py
+++ b/tests/io/test_datafile_datafolder.py
@@ -1,8 +1,9 @@
 from fsspec.implementations.memory import MemoryFileSystem
 from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.http import HTTPFileSystem
 from typing import Any, cast
 
-from refiner.io.datafile import DataFile
+from refiner.io.datafile import DataFile, _file_cache_key
 from refiner.io.datafolder import DataFolder
 from refiner.io.fileset import DataFileSet
 
@@ -35,6 +36,31 @@ def test_datafile_resolve_with_path_fs_tuple(tmp_path):
     df = DataFile.resolve((p, fs))
     assert df.exists()
     assert df.is_local
+
+
+def test_datafile_cache_key_tracks_backing_filesystem_configuration():
+    left = DataFile(
+        fs=LocalFileSystem(skip_instance_cache=True),
+        path="bucket/file.txt",
+    )
+    right = DataFile(
+        fs=LocalFileSystem(skip_instance_cache=True),
+        path="bucket/file.txt",
+    )
+
+    assert left.fs is not right.fs
+    assert _file_cache_key(left) == _file_cache_key(right)
+
+    first_auth = DataFile(
+        fs=HTTPFileSystem(headers={"Authorization": "first"}),
+        path="https://example.com/file.txt",
+    )
+    second_auth = DataFile(
+        fs=HTTPFileSystem(headers={"Authorization": "second"}),
+        path="https://example.com/file.txt",
+    )
+
+    assert _file_cache_key(first_auth) != _file_cache_key(second_auth)
 
 
 def test_datafile_copy_skips_same_source_and_destination(tmp_path):

--- a/tests/io/test_datafile_datafolder.py
+++ b/tests/io/test_datafile_datafolder.py
@@ -70,7 +70,9 @@ def test_datafile_resolve_adds_hf_token_for_huggingface_http_urls(monkeypatch):
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafile.url_to_fs", fake_url_to_fs)
 
-    DataFile.resolve("https://huggingface.co/datasets/org/repo/resolve/main/file.mp4")
+    _ = DataFile.resolve(
+        "https://huggingface.co/datasets/org/repo/resolve/main/file.mp4"
+    ).fs
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer hf_test"}
 
@@ -85,7 +87,7 @@ def test_datafile_resolve_adds_hf_token_for_hf_short_urls(monkeypatch):
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafile.url_to_fs", fake_url_to_fs)
 
-    DataFile.resolve("https://hf.co/datasets/org/repo/resolve/main/file.mp4")
+    _ = DataFile.resolve("https://hf.co/datasets/org/repo/resolve/main/file.mp4").fs
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer hf_test"}
 
@@ -102,10 +104,10 @@ def test_datafile_resolve_preserves_explicit_headers_for_huggingface_http_urls(
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafile.url_to_fs", fake_url_to_fs)
 
-    DataFile.resolve(
+    _ = DataFile.resolve(
         "https://huggingface.co/datasets/org/repo/resolve/main/file.mp4",
         storage_options={"headers": {"Authorization": "Bearer explicit"}},
-    )
+    ).fs
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer explicit"}
 
@@ -120,10 +122,10 @@ def test_datafile_resolve_merges_hf_token_with_existing_headers(monkeypatch):
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafile.url_to_fs", fake_url_to_fs)
 
-    DataFile.resolve(
+    _ = DataFile.resolve(
         "https://huggingface.co/datasets/org/repo/resolve/main/file.mp4",
         storage_options={"headers": {"User-Agent": "refiner-test"}},
-    )
+    ).fs
 
     assert captured["kwargs"]["headers"] == {
         "User-Agent": "refiner-test",
@@ -141,10 +143,10 @@ def test_datafile_resolve_preserves_lowercase_authorization_header(monkeypatch):
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafile.url_to_fs", fake_url_to_fs)
 
-    DataFile.resolve(
+    _ = DataFile.resolve(
         "https://huggingface.co/datasets/org/repo/resolve/main/file.mp4",
         storage_options={"headers": {"authorization": "Bearer explicit"}},
-    )
+    ).fs
 
     assert captured["kwargs"]["headers"] == {"authorization": "Bearer explicit"}
 
@@ -160,7 +162,9 @@ def test_datafolder_resolve_adds_hf_token_for_huggingface_http_urls(monkeypatch)
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.datafolder.url_to_fs", fake_url_to_fs)
 
-    DataFolder.resolve("https://huggingface.co/datasets/org/repo/tree/main/assets")
+    _ = DataFolder.resolve(
+        "https://huggingface.co/datasets/org/repo/tree/main/assets"
+    ).fs
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer hf_test"}
 
@@ -175,7 +179,10 @@ def test_datafileset_resolve_adds_hf_token_for_generic_hf_http_urls(monkeypatch)
     monkeypatch.setenv("HF_TOKEN", "hf_test")
     monkeypatch.setattr("refiner.io.fileset.url_to_fs", fake_url_to_fs)
 
-    DataFileSet.resolve("https://huggingface.co/datasets/org/repo/resolve/main/file")
+    entry = DataFileSet.resolve(
+        "https://huggingface.co/datasets/org/repo/resolve/main/file"
+    ).entries[0]
+    _ = getattr(entry, "fs")
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer hf_test"}
 

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -412,8 +412,8 @@ def test_lerobot_reader_describe_uses_dataset_roots(tmp_path: Path) -> None:
     }
 
 
-def test_lerobot_reader_treats_lerobot_repo_shorthand_as_hf_dataset() -> None:
-    reader = LeRobotEpisodeReader("lerobot/aloha_mobile_cabinet")
+def test_lerobot_reader_accepts_hf_dataset_url() -> None:
+    reader = LeRobotEpisodeReader("hf://datasets/lerobot/aloha_mobile_cabinet")
 
     assert reader.describe() == {
         "path": "hf://datasets/lerobot/aloha_mobile_cabinet",

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -412,6 +412,16 @@ def test_lerobot_reader_describe_uses_dataset_roots(tmp_path: Path) -> None:
     }
 
 
+def test_lerobot_reader_treats_lerobot_repo_shorthand_as_hf_dataset() -> None:
+    reader = LeRobotEpisodeReader("lerobot/aloha_mobile_cabinet")
+
+    assert reader.describe() == {
+        "path": "hf://datasets/lerobot/aloha_mobile_cabinet",
+        "inputs": ["hf://datasets/lerobot/aloha_mobile_cabinet"],
+    }
+    assert reader.required_refiner_extras() == ("hf",)
+
+
 def test_remap_task_index_table_raises_when_index_cannot_be_remapped() -> None:
     table = pa.Table.from_pydict(
         {

--- a/tests/readers/test_multi_source_readers.py
+++ b/tests/readers/test_multi_source_readers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -92,6 +93,23 @@ def test_datafileset_extensions_do_not_filter_explicit_globs() -> None:
 
         assert len(fileset.files) == 1
         assert fileset.files[0].path == str(local_path)
+
+
+def test_reader_describe_normalizes_deferred_relative_local_globs(tmp_path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_jsonl(data_dir / "row.jsonl", [1])
+
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        description = read_json("data/*.jsonl", lines=True).source.describe()
+    finally:
+        os.chdir(old_cwd)
+
+    expected = str(tmp_path / "data" / "*.jsonl")
+    assert description["path"] == expected
+    assert description["inputs"] == [expected]
 
 
 def test_jsonl_reader_reads_across_multiple_directories() -> None:

--- a/tests/test_commoncrawl_text.py
+++ b/tests/test_commoncrawl_text.py
@@ -153,7 +153,7 @@ def test_read_commoncrawl_schema_contains_dtype_overrides() -> None:
     assert source.schema.field("content_bytes").type == pa.binary()
 
 
-def test_read_commoncrawl_s3_transport_checks_s3fs(monkeypatch) -> None:
+def test_read_commoncrawl_s3_transport_defers_s3fs_check(monkeypatch) -> None:
     calls: list[tuple[str, tuple[str, ...], str | None]] = []
 
     def fake_check(name: str, deps: list[str], dist: str | None = None) -> None:
@@ -166,8 +166,7 @@ def test_read_commoncrawl_s3_transport_checks_s3fs(monkeypatch) -> None:
     mdr.text.read_commoncrawl("CC-MAIN-TEST", use_https=False)
     mdr.text.read_commoncrawl_from_index("CC-MAIN-TEST", use_https=False)
 
-    assert ("read_commoncrawl", ("s3fs",), "s3") in calls
-    assert ("read_commoncrawl_from_index", ("s3fs",), "s3") in calls
+    assert calls == []
 
 
 def test_read_commoncrawl_s3_base_url_declares_s3_extra(monkeypatch) -> None:
@@ -191,8 +190,7 @@ def test_read_commoncrawl_s3_base_url_declares_s3_extra(monkeypatch) -> None:
 
     assert source.required_refiner_extras() == ("s3", "text")
     assert index_source.required_refiner_extras() == ("s3", "text")
-    assert ("read_commoncrawl", ("s3fs",), "s3") in calls
-    assert ("read_commoncrawl_from_index", ("s3fs",), "s3") in calls
+    assert calls == []
 
 
 def test_read_commoncrawl_warc_uses_file_backed_reader(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- defer remote `DataFile`, `DataFolder`, and `DataFileSet` filesystem resolution until planning or I/O actually needs it
- keep built-in source extra detection working from unresolved paths, including LeRobot/HF and remote CommonCrawl roots
- make LeRobot delegate to a lazily constructed `ParquetReader` while preserving explicit filesystem inputs
- defer optional dependency checks/imports for TFRecord, TFDS, and CommonCrawl readers until runtime use

## Why
Base Refiner should be able to construct and submit cloud jobs that reference optional remote storage or optional reader stacks without requiring those local extras during submission. The cloud manifest can declare the extras the job needs, and workers install them before executing the actual read path.

## Validation
- `uv run pytest tests/test_commoncrawl_text.py tests/readers/test_tfrecord_reader.py tests/readers/test_tfds_reader.py`
- full local suite previously passed: `997 passed, 8 warnings`
- PR CI is green: `ci`, `base-import-smoke`, CodeQL, and analysis checks
- base-only cloud submission path was validated against the dev quickstart job after the matching Perpetuity manifest fix
