### PR TITLE
[codex] Normalize docs headings and billing copy

### DIFF
--- a/docs/cli/auth-and-run.md
+++ b/docs/cli/auth-and-run.md
@@ -1,9 +1,9 @@
 ---
-title: "Auth and Run"
+title: "Auth and run"
 description: "Authenticate and run Refiner scripts from the CLI"
 ---
 
-# Auth And Run
+# Auth and run
 
 ## Login
 
@@ -37,7 +37,7 @@ printf '%s' "$MACRODATA_API_KEY" | macrodata login --token-stdin --quiet
 | `--token-stdin` | Read the key from stdin |
 | `--quiet` | Suppress banner and key-creation prompt |
 
-## Check Identity
+## Check identity
 
 ```bash
 macrodata whoami
@@ -80,7 +80,7 @@ If no credentials exist, it prints:
 No local credentials found.
 ```
 
-## Run A Script
+## Run a script
 
 ```bash
 macrodata run train_data_pipeline.py
@@ -136,7 +136,7 @@ macrodata run --logs none train_data_pipeline.py
 | `--logs errors` | Show error lines only |
 | `--logs none` | Hide log lines and update only the header |
 
-## Related Pages
+## Related pages
 
 - [Workspaces and API Keys](../platform/workspaces-and-api-keys.md)
 - [Cloud Launcher](../running-pipelines/cloud-launcher.md)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -38,7 +38,7 @@ macrodata secrets list --env production --json
 - [`secrets remove`](secrets.md#remove-a-secret): Remove a workspace secret.
 - [`secrets delete`](secrets.md#remove-a-secret): Alias for `secrets remove`.
 
-## Agent-Friendly Output
+## Agent-friendly output
 
 Use `--json` on commands that return structured platform data:
 

--- a/docs/cli/jobs-logs-and-metrics.md
+++ b/docs/cli/jobs-logs-and-metrics.md
@@ -1,9 +1,9 @@
 ---
-title: "Jobs, Logs, and Metrics"
+title: "Jobs, logs, and metrics"
 description: "Inspect cloud jobs from the Macrodata CLI"
 ---
 
-# Jobs, Logs, And Metrics
+# Jobs, logs, and metrics
 
 Job inspection commands default to terminal-friendly output. Add `--json` when
 an agent, script, or CI job needs structured data.
@@ -43,7 +43,7 @@ Next cursor: macrodata jobs list --limit 20 --cursor eyJwYWdlIjoyfQ
 | `--cursor <cursor>` | Continue a paginated listing |
 | `--json` | Print raw JSON |
 
-## Inspect One Job
+## Inspect one Job
 
 ```bash
 macrodata jobs get job_123
@@ -74,7 +74,7 @@ Stage  Step  Name          Type  Columns
 
 For local jobs, the summary also prints the run directory.
 
-## Attach To A Running Job
+## Attach to a running Job
 
 ```bash
 macrodata jobs attach job_123
@@ -162,7 +162,7 @@ Next cursor: macrodata jobs workers job_123 --stage 0 --limit 20 --cursor eyJwYW
 | `--cursor <cursor>` | Continue a paginated worker listing |
 | `--json` | Print raw JSON |
 
-## Follow Logs
+## Follow logs
 
 ```bash
 macrodata jobs logs job_123 --follow
@@ -210,7 +210,7 @@ search requires an explicit `--stage` and a time window with `--start-ms` and
 | `--follow` | Poll continuously for new entries |
 | `--json` | Print raw JSON |
 
-## Stage Metrics
+## Stage metrics
 
 ```bash
 macrodata jobs metrics job_123 0
@@ -270,7 +270,7 @@ Per Worker (lifetime): 30000
 `--metric`, `--worker`, and `--workers` require `--step`. `--worker` also
 requires `--metric`. `--asc` and `--desc` apply to worker rankings.
 
-## Resource Metrics
+## Resource metrics
 
 ```bash
 macrodata jobs resource-metrics job_123 0
@@ -327,7 +327,7 @@ Canceled: job_123
   Failed: 0
 ```
 
-## Related Pages
+## Related pages
 
 - [Observability](../running-pipelines/observability.md)
 - [Cloud Jobs and Files](../platform/cloud-jobs-and-files.md)

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -1,15 +1,15 @@
 ---
-title: "CLI Secrets"
+title: "CLI secrets"
 description: "Manage workspace secrets from the Macrodata CLI"
 ---
 
-# CLI Secrets
+# CLI secrets
 
 Use CLI secrets for values that cloud jobs need but source code should not
 contain. Secret values are stored in a workspace environment and are injected
 into launched jobs only when the pipeline requests them.
 
-## List Secrets
+## List secrets
 
 ```bash
 macrodata secrets list --env production
@@ -38,7 +38,7 @@ No secrets found.
 | `--env <name>` | Secret environment to list |
 | `--json` | Print raw JSON |
 
-## Set A Secret
+## Set a secret
 
 ```bash
 printf '%s' "$HF_TOKEN" | macrodata secrets set HF_TOKEN --env production --value-stdin
@@ -67,7 +67,7 @@ printf '%s' "$OPENAI_API_KEY" | macrodata secrets set OPENAI_API_KEY --value-std
 | `--value-stdin` | Read the secret value from stdin |
 | `--json` | Print raw JSON |
 
-## Remove A Secret
+## Remove a secret
 
 ```bash
 macrodata secrets remove HF_TOKEN --env production
@@ -88,7 +88,7 @@ Removed secret production/HF_TOKEN.
 | `--env <name>` | Secret environment; defaults to `default` |
 | `--json` | Print raw JSON |
 
-## Use In A Pipeline
+## Use in a pipeline
 
 After storing a secret, request it from the cloud launcher by environment name
 and key. Refiner makes the value available to the job without writing it into
@@ -101,4 +101,4 @@ pipeline.launch_cloud(
 )
 ```
 
-See [Secrets and Environment](../platform/secrets-and-environment.md).
+See [Secrets and environment](../platform/secrets-and-environment.md).

--- a/docs/episode-data/converting-to-robot-rows.md
+++ b/docs/episode-data/converting-to-robot-rows.md
@@ -1,14 +1,14 @@
 ---
-title: "Converting to Robot Rows"
+title: "Converting to robot rows"
 description: "Map generic rows into Refiner's robotics episode view"
 ---
 
-# Converting To Robot Rows
+# Converting to robot rows
 
 Use `to_robot_rows(...)` when a generic reader produces episode-shaped rows that
 should be treated as robotics episodes.
 
-## Basic Mapping
+## Basic mapping
 
 ```python
 pipeline = (
@@ -35,7 +35,7 @@ pipeline = (
 The input columns remain available by their original names. The robotics view
 adds semantic properties such as `row.actions`, `row.states`, and `row.videos`.
 
-## Key Mapping
+## Key mapping
 
 | Option | Use it for |
 | --- | --- |
@@ -49,7 +49,7 @@ adds semantic properties such as `row.actions`, `row.states`, and `row.videos`.
 | `extra_observation_keys` | Additional observations exposed by name. |
 | `video_keys` | Video columns exposed through `row.videos`. |
 
-## Multiple State Columns
+## Multiple state columns
 
 ```python
 pipeline = source.to_robot_rows(
@@ -61,7 +61,7 @@ pipeline = source.to_robot_rows(
 Tuple state keys are concatenated into `row.states` and exposed as
 `observation.state`.
 
-## Nested Frame Data
+## Nested frame data
 
 If a row contains a nested frame table, pass `nested_frames_key`:
 
@@ -77,7 +77,7 @@ This is useful for custom readers that already group frames per episode.
 For RLDS-style rows, `task_key` can point into the nested frame data, such as
 `task_key="steps/language_instruction"`.
 
-## Writing Converted Rows
+## Writing converted rows
 
 Converted rows can be written as LeRobot:
 

--- a/docs/episode-data/episode-rows.md
+++ b/docs/episode-data/episode-rows.md
@@ -1,14 +1,14 @@
 ---
-title: "Episode Rows"
+title: "Episode rows"
 description: "The episode-level row model used by Refiner"
 ---
 
-# Episode Rows
+# Episode rows
 
 Refiner exposes robotics data as rows. A row may be a plain mapping, a
 `RoboticsRow` semantic view, or a `LeRobotRow`.
 
-## Plain Rows
+## Plain rows
 
 Generic readers emit regular rows:
 
@@ -55,7 +55,7 @@ print(row.metadata.info.fps)
 `LeRobotRow` is also a `RoboticsRow`, so episode operations such as
 [Motion Trimming](../episode-operations/motion-trimming.md) can use it directly.
 
-## Updating Rows
+## Updating rows
 
 Rows are immutable-style values: update methods return new rows.
 
@@ -71,7 +71,7 @@ def zero_actions(row):
     return row.with_actions([[0.0] for _ in range(row.num_frames)])
 ```
 
-## Selecting Frames
+## Selecting frames
 
 ```python
 def first_second(row):
@@ -82,7 +82,7 @@ def first_second(row):
 Selecting frames updates the frame table. For `LeRobotRow`, frame indices are
 renumbered when present.
 
-## Related Pages
+## Related pages
 
 - [Frames and Videos](frames-and-videos.md)
 - [Row Transforms](../transforms/row-transforms.md)

--- a/docs/episode-data/frames-and-videos.md
+++ b/docs/episode-data/frames-and-videos.md
@@ -1,16 +1,16 @@
 ---
-title: "Frames and Videos"
+title: "Frames and videos"
 description: "Work with frame tables, video sources, and clips"
 ---
 
-# Frames And Videos
+# Frames and videos
 
 An episode can contain both frame tables and videos:
 
 - frame tables hold aligned values such as timestamp, action, state, and labels
 - videos are lazy media sources that can be decoded, clipped, remuxed, or transcoded
 
-## Frame Tables
+## Frame tables
 
 ```python
 row = pipeline.take(1)[0]
@@ -41,7 +41,7 @@ all_observations = row.observations()
 `observations()` normalizes names: `row.observations("state")` reads
 `observation.state`.
 
-## Video Sources
+## Video sources
 
 ```python
 for key, video in row.videos.items():
@@ -58,7 +58,7 @@ sequences. They share the same core operations:
 | `iter_numpy_frames()` | Decode RGB arrays lazily. |
 | `write_to(...)` | Let a writer copy/remux/transcode media. |
 
-## Clip A Video View
+## Clip a video view
 
 ```python
 def keep_middle(row):
@@ -72,7 +72,7 @@ def keep_middle(row):
 This does not immediately rewrite the media file. The writer later decides
 whether to remux or transcode the selected time range.
 
-## Related Pages
+## Related pages
 
 - [Files and Videos Reader](../reading-data/files-and-videos.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)

--- a/docs/episode-data/index.md
+++ b/docs/episode-data/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Episode Data"
+title: "Episode data"
 description: "How Refiner represents robotics episodes, frames, videos, metadata, tasks, and stats"
 ---
 
-# Episode Data
+# Episode data
 
 Refiner treats robotics data as episode data. An episode row can carry:
 

--- a/docs/episode-data/metadata-tasks-and-stats.md
+++ b/docs/episode-data/metadata-tasks-and-stats.md
@@ -1,9 +1,9 @@
 ---
-title: "Metadata, Tasks, and Stats"
+title: "Metadata, tasks, and stats"
 description: "LeRobot metadata, task labels, feature stats, and when they change"
 ---
 
-# Metadata, Tasks, And Stats
+# Metadata, tasks, and stats
 
 LeRobot datasets carry metadata beside episode and frame data. Refiner reads and
 writes that metadata so downstream training code can understand the dataset.
@@ -48,7 +48,7 @@ Stats are preserved when they are still valid. Operations that change a feature
 should drop stale stats for that feature. For example, motion trimming drops
 video stats for clipped videos so the writer recomputes them.
 
-## Writer Behavior
+## Writer behavior
 
 `write_lerobot` writes:
 
@@ -63,7 +63,7 @@ video stats for clipped videos so the writer recomputes them.
 
 See [Writing LeRobot](../writing-data/lerobot.md).
 
-## Related Pages
+## Related pages
 
 - [LeRobot Reader](../reading-data/lerobot.md)
 - [LeRobot Writer](../writing-data/lerobot.md)

--- a/docs/episode-operations/hand-tracking.md
+++ b/docs/episode-operations/hand-tracking.md
@@ -1,9 +1,9 @@
 ---
-title: "Hand Tracking"
+title: "Hand tracking"
 description: "Runs ego-centric hand tracking over inputed videos"
 ---
 
-# Hand Tracking
+# Hand tracking
 
 `track_hands` relies on the `ego-vision` package to run ego-centric hand
 tracking over episode videos, with settings optimized for the HOT3D
@@ -67,7 +67,7 @@ pip install macrodata-refiner[datasets,hand_tracking]
 Input rows must implement `RoboticsRow` and include the required `video_key` in
 `row.videos`. Pass `video_key` explicitly to `track_hands`.
 
-## How Ego-Vision Works
+## How Ego-Vision works
 
 The default ego-vision stack is:
 
@@ -205,7 +205,7 @@ In Refiner, configure the operation itself with:
 | `output_key` | Output column for the ego-vision payload. Defaults to `hand_tracking`. |
 | `config` | Optional `egovision.HandTrackingConfig`. Defaults to the HOT3D-tuned ego-vision stack above. |
 
-## Output Payload
+## Output payload
 
 By default, the operation writes one episode-level column:
 
@@ -250,7 +250,7 @@ Each hand entry contains:
 `hands_world` is the usual source for action labels because it includes head/camera
 motion through the VGGT world trajectory.
 
-## Action Conversion
+## Action conversion
 
 The raw payload can be converted into training actions with ego-vision helpers:
 
@@ -294,7 +294,7 @@ can increase throughput by setting `EgoVisionConfig.vggt.camera_sample_fps` to
 run VGGT on a lower frame rate and interpolate the camera trajectory back to the
 full timeline.
 
-## Related Pages
+## Related pages
 
 - [Async and Batch Transforms](../transforms/async-and-batch-transforms.md)
 - [Files and Videos](../reading-data/files-and-videos.md)

--- a/docs/episode-operations/index.md
+++ b/docs/episode-operations/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Episode Operations"
+title: "Episode operations"
 description: "Higher-level operations for robotics episode data"
 ---
 
-# Episode Operations
+# Episode operations
 
 Episode operations are reusable workflows built on top of Refiner transforms.
 They operate on robotics episode rows rather than generic table columns.

--- a/docs/episode-operations/motion-trimming.md
+++ b/docs/episode-operations/motion-trimming.md
@@ -1,9 +1,9 @@
 ---
-title: "Motion Trimming"
+title: "Motion trimming"
 description: "Trim inactive frames from robotics episodes"
 ---
 
-# Motion Trimming
+# Motion trimming
 
 `motion_trim` removes inactive frames before and after the motion window of an
 episode. It uses action and state deltas to infer activity.
@@ -16,7 +16,7 @@ pipeline = (
 )
 ```
 
-## What It Updates
+## What it updates
 
 | Data | Behavior |
 | --- | --- |
@@ -43,7 +43,7 @@ timestamps, actions, and state values. `read_lerobot(...)` rows satisfy this
 when the dataset contains those fields. Generic rows should be converted with
 [`to_robot_rows`](../episode-data/converting-to-robot-rows.md).
 
-## Related Pages
+## Related pages
 
 - [Frames and Videos](../episode-data/frames-and-videos.md)
 - [Writing LeRobot](../writing-data/lerobot.md)

--- a/docs/episode-operations/reward-scoring.md
+++ b/docs/episode-operations/reward-scoring.md
@@ -1,9 +1,9 @@
 ---
-title: "Reward Scoring"
+title: "Reward scoring"
 description: "Score episode progress and success with a pooling model"
 ---
 
-# Reward Scoring
+# Reward scoring
 
 `reward_score` samples frames from an episode video and uses a Robometer-style
 pooling model to estimate progress and success.
@@ -30,7 +30,7 @@ pipeline = (
 )
 ```
 
-## Output Columns
+## Output columns
 
 By default, the operation writes:
 
@@ -42,7 +42,7 @@ By default, the operation writes:
 
 Customize names with `output_column`, `success_column`, and `frames_column`.
 
-## Task Text
+## Task text
 
 Beyond the video to score, you must provide a task description. This can be a
 string or a function that takes the row and returns the task description:
@@ -57,7 +57,7 @@ or from the row:
 mdr.robotics.reward_score(task=lambda row: row.task or "; ".join(row.tasks))
 ```
 
-## Inference Backend
+## Inference backend
 
 `reward_score` uses pooling inference through a vLLM provider. See
 [Pooling](../inference/pooling.md) and [Providers and vLLM](../inference/inference_providers.md).

--- a/docs/episode-operations/subtask-annotation.md
+++ b/docs/episode-operations/subtask-annotation.md
@@ -1,9 +1,9 @@
 ---
-title: "Subtask Annotation"
+title: "Subtask annotation"
 description: "Use vision-language models to segment robotics episodes into temporal subtasks"
 ---
 
-# Subtask Annotation
+# Subtask annotation
 
 Use `subtask_annotation` to add temporal subtask labels to robotics episodes.
 The annotator samples an episode video into timestamped contact sheets, sends
@@ -15,7 +15,7 @@ the episode-level task description. They can identify coarse manipulation events
 such as reaching, grasping, moving, opening, pouring, or placing objects without
 manual per-episode labeling.
 
-## Basic Usage
+## Basic usage
 
 Run the following pipeline locally or on Refiner Cloud:
 
@@ -36,7 +36,7 @@ By default, `subtask_annotation` uses Gemini through `GoogleEndpointProvider`.
 Set `GOOGLE_GENERATIVE_AI_API_KEY` before running the pipeline, or pass a
 different provider explicitly.
 
-## Other Readers
+## Other readers
 
 Input rows must implement `RoboticsRow` and expose the selected video through
 `row.videos`. If you start from another reader, convert rows with
@@ -60,7 +60,7 @@ pipeline = (
 )
 ```
 
-## Output Shape
+## Output shape
 
 The output column contains a list of segment dictionaries. Each segment has a
 start time, an end time, and a short action description:
@@ -72,7 +72,7 @@ start time, an end time, and a short action description:
 ]
 ```
 
-## Contact Sheets
+## Contact sheets
 
 Video input is sent as contact sheets: timestamped image grids that preserve
 temporal context without sending the full video. This keeps requests smaller
@@ -99,7 +99,7 @@ The default settings sample one frame every `0.5` seconds, resize each tile to
 | `on_blocked_prompt` | Behavior when the provider blocks an episode prompt. Defaults to `"empty"`, which logs the block and writes an empty segment list. Use `"raise"` to fail the row instead. |
 | `max_concurrent_requests` | Maximum provider requests allowed at once per worker. |
 
-## Related Content
+## Related content
 
 For lower-level inference controls, see [Generate Text](../inference/generate-text.md)
 and [Multimodal and Structured Output](../inference/multimodal-and-structured-output.md).

--- a/docs/examples/annotations/hand-tracking.md
+++ b/docs/examples/annotations/hand-tracking.md
@@ -1,9 +1,9 @@
 ---
-title: "Track Hands"
+title: "Track hands"
 description: "Run ego-centric hand tracking over HomER videos"
 ---
 
-# Track Hands
+# Track hands
 
 ![Hand tracking example output](../../assets/hand-tracking-example-output.jpeg)
 

--- a/docs/examples/annotations/reward-models.md
+++ b/docs/examples/annotations/reward-models.md
@@ -1,9 +1,9 @@
 ---
-title: "Score Rewards"
+title: "Score rewards"
 description: "Add progress and success scores to episode videos"
 ---
 
-# Score Rewards
+# Score rewards
 
 This example uses [Robometer](https://arxiv.org/abs/2603.02115) to compute reward scores over episodes in Libero.
 Each episode will be annotated with `reward_score`, `robometer_success`, and `reward_frames` columns, signaling the reward, tasks completion state for each frame in

--- a/docs/examples/annotations/subtask-annotations.md
+++ b/docs/examples/annotations/subtask-annotations.md
@@ -1,9 +1,9 @@
 ---
-title: "Annotate Subtasks"
+title: "Annotate subtasks"
 description: "Add VLM-generated temporal subtask annotations to episodes"
 ---
 
-# Annotate Subtasks
+# Annotate subtasks
 
 ![Subtask annotation timeline](../../assets/subtask_annotations.png)
 

--- a/docs/examples/datasets/merge-lerobot-datasets.md
+++ b/docs/examples/datasets/merge-lerobot-datasets.md
@@ -1,9 +1,9 @@
 ---
-title: "Merge LeRobot Datasets"
+title: "Merge LeRobot datasets"
 description: "Combine multiple LeRobot roots into one output dataset"
 ---
 
-# Merge LeRobot Datasets
+# Merge LeRobot datasets
 
 Pass multiple LeRobot roots to `read_lerobot` and write one output dataset:
 

--- a/docs/examples/formats/libero-hdf5.md
+++ b/docs/examples/formats/libero-hdf5.md
@@ -67,7 +67,7 @@ output = f"{output_prefix}/{stamp}-full-eval"
 )
 ```
 
-## How It Works
+## How it works
 
 ### Inputs
 
@@ -75,7 +75,7 @@ output = f"{output_prefix}/{stamp}-full-eval"
 dataset root. Passing a list of folders to `read_hdf5(...)` lets Refiner shard
 the conversion across files from all four subsets.
 
-### HDF5 Layout
+### HDF5 layout
 
 Each LIBERO file stores demonstrations under `/data/demo_*`. The reader emits
 one row per matched demo group and loads the arrays needed for LeRobot:
@@ -93,13 +93,13 @@ on the row. `cache_remote_files=True` downloads each remote HDF5 file to worker
 local storage while it is being read, which avoids repeated random reads against
 the remote filesystem.
 
-### Task Labels
+### Task labels
 
 LIBERO task text is encoded in the HDF5 filename. The `.map(...)` step derives a
 readable task label by removing `.hdf5` and `_demo`, then replacing underscores
 with spaces.
 
-### Robot Rows
+### Robot rows
 
 `to_robot_rows(...)` turns each HDF5 demo row into one robotics episode:
 
@@ -112,7 +112,7 @@ with spaces.
 | `state_key=("ee_state", "gripper_state")` | Concatenates end-effector and gripper state into `observation.state`. |
 | `video_keys=...` | Treats the two RGB frame arrays as LeRobot video streams. |
 
-### Writing And Running
+### Writing and running
 
 `write_lerobot(...)` writes LeRobot parquet metadata plus encoded videos. The
 example bounds per-worker video preparation with `max_video_prepare_in_flight=2`

--- a/docs/examples/formats/zarr-replay-buffer.md
+++ b/docs/examples/formats/zarr-replay-buffer.md
@@ -1,9 +1,9 @@
 ---
-title: "Zarr Replay Buffer"
+title: "Zarr replay buffer"
 description: "Convert Zarr replay buffers into robot episode rows"
 ---
 
-# Zarr Replay Buffer
+# Zarr replay buffer
 
 Replay buffers often store frame arrays and cumulative episode boundaries.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Refiner Docs"
+title: "Refiner docs"
 description: "A guide to building, running, and operating robotics data pipelines with Refiner"
 ---
 
-# Refiner Docs
+# Refiner docs
 
 Refiner is a Python framework for robotics data pipelines. It reads episode
 datasets, exposes frames and videos through a consistent row model, transforms
@@ -23,12 +23,12 @@ The docs are organized around the path most teams follow:
 | Call models | [Inference](inference/index.md) | How to use text, multimodal, structured, vLLM, and pooling inference. |
 | Save outputs | [Writing Data](writing-data/index.md) | How writers stage files, media, and reducers. |
 | Follow recipes | [Examples](examples/index.md) | End-to-end dataset conversion and enrichment workflows. |
-| Use Macrodata Cloud | [Platform](platform/index.md) | Workspaces, API keys, manifests, cloud jobs, files, and secrets. |
+| Use the Macrodata Cloud | [Platform](platform/index.md) | Workspaces, API keys, manifests, cloud jobs, files, and secrets. |
 | Use commands | [CLI](cli/index.md) | The `macrodata` command surface. |
 
 For quick API lookup, see [Reference](reference/index.md).
 
-## Recommended Reading Order
+## Recommended reading order
 
 If you are new to Refiner, read:
 

--- a/docs/inference/generate-text.md
+++ b/docs/inference/generate-text.md
@@ -1,9 +1,9 @@
 ---
-title: "Generate Text"
+title: "Generate text"
 description: "Use generate_text inside Refiner async transforms"
 ---
 
-# Generate Text
+# Generate text
 
 `generate_text` turns a function that receives a row and a model-call helper
 into an async transform.
@@ -40,7 +40,7 @@ pipeline = pipeline.map_async(
 )
 ```
 
-## Function Shape
+## Function shape
 
 Your function receives:
 
@@ -51,7 +51,7 @@ Your function receives:
 
 The function returns an updated row.
 
-## Generation Parameters
+## Generation parameters
 
 ```python
 await generate_text(
@@ -71,7 +71,7 @@ mdr.inference.generate_text(
 )
 ```
 
-## Related Pages
+## Related pages
 
 - [Multimodal and Structured Output](multimodal-and-structured-output.md)
 - [Providers and vLLM](inference_providers.md)

--- a/docs/inference/inference_providers.md
+++ b/docs/inference/inference_providers.md
@@ -1,9 +1,9 @@
 ---
-title: "Inference Providers"
+title: "Inference providers"
 description: "Configure model providers for Refiner inference"
 ---
 
-# Inference Providers
+# Inference providers
 
 Providers define where inference requests are sent and how Refiner formats each
 request for that backend. Use them with `generate_text(...)` and other inference
@@ -12,7 +12,7 @@ helpers when you want the same pipeline code to run against hosted APIs or manag
 Refiner supports OpenAI, OpenAI-compatible endpoints, Google Gemini, Anthropic
 Claude, and managed vLLM services.
 
-## OpenAI Responses
+## OpenAI responses
 
 Use `OpenAIResponsesProvider` for OpenAI-hosted models through the Responses
 API. Choose it for OpenAI multimodal, tool-use, or structured-output workloads
@@ -24,7 +24,7 @@ provider = mdr.inference.OpenAIResponsesProvider(
 )
 ```
 
-## OpenAI-Compatible Endpoint
+## OpenAI-compatible endpoint
 
 Use `OpenAIEndpointProvider` for services that expose an OpenAI-compatible
 `/v1/chat/completions` API but are not OpenAI. Choose it for hosted gateways,
@@ -38,7 +38,7 @@ provider = mdr.inference.OpenAIEndpointProvider(
 )
 ```
 
-## Google Endpoint
+## Google endpoint
 
 Use `GoogleEndpointProvider` for Gemini models on Google's Generative Language
 API or compatible Vertex AI endpoints. Choose it for Gemini vision-language
@@ -50,7 +50,7 @@ provider = mdr.inference.GoogleEndpointProvider(
 )
 ```
 
-## Anthropic Endpoint
+## Anthropic endpoint
 
 Use `AnthropicEndpointProvider` for Anthropic-hosted Claude models. Choose it
 when you want Claude's instruction following or long-context behavior while
@@ -88,7 +88,7 @@ another model, contact us through [macrodata.co/contact](https://macrodata.co/co
 | `Qwen/Qwen3.5-4B` | 32,768 tokens | Image + text |
 | `robometer/Robometer-4B` | 4,096 tokens | Image + text, capped at 16 images per prompt |
 
-## Provider Options
+## Provider options
 
 Provider options are typed objects for model-specific request settings. They are
 passed as `provider_options` to `generate_text(...)`.
@@ -96,7 +96,7 @@ passed as `provider_options` to `generate_text(...)`.
 Use provider options sparingly. Keep pipeline code portable unless you need a
 specific model feature.
 
-## Related Pages
+## Related pages
 
 - [Generate Text](generate-text.md)
 - [Resources, GPUs, and Services](../running-pipelines/resources-gpus-and-services.md)

--- a/docs/inference/multimodal-and-structured-output.md
+++ b/docs/inference/multimodal-and-structured-output.md
@@ -1,13 +1,13 @@
 ---
-title: "Multimodal and Structured Output"
+title: "Multimodal and structured output"
 description: "Send media to models and validate structured model responses"
 ---
 
-# Multimodal And Structured Output
+# Multimodal and structured output
 
 Refiner can pass text, images, videos, and files to supported providers.
 
-## Image Content
+## Image content
 
 ```python
 async def describe_first_frame(row, generate_text):
@@ -26,13 +26,13 @@ async def describe_first_frame(row, generate_text):
     return row.update({"description": response.text})
 ```
 
-## Video Content
+## Video content
 
 Some providers accept video content. For providers that do not, use sampled
 frames or contact sheets. The subtask annotation operation uses contact sheets;
 see [Subtask Annotation](../episode-operations/subtask-annotation.md).
 
-## Structured Output
+## Structured output
 
 Use a Pydantic model when you need validated fields:
 
@@ -49,7 +49,7 @@ class Segments(BaseModel):
 
 Then pass `schema=Segments` to `generate_text`.
 
-## Raw Payloads
+## Raw payloads
 
 Use `raw_payload` only when a provider requires options that are not represented
 by the common interface:

--- a/docs/nav.md
+++ b/docs/nav.md
@@ -2,107 +2,108 @@
 
 - [Quickstart](quickstart.md)
 
-## Running Pipelines
+## Running pipelines
 
 - [Overview](running-pipelines/index.md)
-- [In-Process Debugging](running-pipelines/in-process-debugging.md)
-- [Local Launcher](running-pipelines/local-launcher.md)
-- [Cloud Launcher](running-pipelines/cloud-launcher.md)
-- [Resources, GPUs, and Services](running-pipelines/resources-gpus-and-services.md)
+- [In-process debugging](running-pipelines/in-process-debugging.md)
+- [Local launcher](running-pipelines/local-launcher.md)
+- [Cloud launcher](running-pipelines/cloud-launcher.md)
+- [Resources, GPUs, and services](running-pipelines/resources-gpus-and-services.md)
 - [Observability](running-pipelines/observability.md)
 
-## Reading Data
+## Reading data
 
 - [Overview](reading-data/index.md)
-- [Reader Model](reading-data/reader-model.md)
+- [Reader model](reading-data/reader-model.md)
 - [Sharding](reading-data/sharding.md)
 - [LeRobot](reading-data/lerobot.md)
 - [HDF5](reading-data/hdf5.md)
 - [Zarr](reading-data/zarr.md)
 - [MCAP](reading-data/mcap.md)
-- [Tabular Files](reading-data/tabular-files.md)
-- [Files and Videos](reading-data/files-and-videos.md)
+- [Tabular files](reading-data/tabular-files.md)
+- [Files and videos](reading-data/files-and-videos.md)
 - [Hugging Face](reading-data/hugging-face.md)
 - [TensorFlow](reading-data/tensorflow.md)
-- [Custom Readers](reading-data/custom-readers.md)
+- [Custom readers](reading-data/custom-readers.md)
 
-## Episode Data
+## Episode data
 
 - [Overview](episode-data/index.md)
-- [Episode Rows](episode-data/episode-rows.md)
-- [Frames and Videos](episode-data/frames-and-videos.md)
-- [Metadata, Tasks, and Stats](episode-data/metadata-tasks-and-stats.md)
-- [Converting to Robot Rows](episode-data/converting-to-robot-rows.md)
+- [Episode rows](episode-data/episode-rows.md)
+- [Frames and videos](episode-data/frames-and-videos.md)
+- [Metadata, tasks, and stats](episode-data/metadata-tasks-and-stats.md)
+- [Converting to robot rows](episode-data/converting-to-robot-rows.md)
 
 ## Transforms
 
 - [Overview](transforms/index.md)
-- [Row Transforms](transforms/row-transforms.md)
-- [Async and Batch Transforms](transforms/async-and-batch-transforms.md)
-- [Vectorized Transforms](transforms/vectorized-transforms.md)
+- [Row transforms](transforms/row-transforms.md)
+- [Async and batch transforms](transforms/async-and-batch-transforms.md)
+- [Vectorized transforms](transforms/vectorized-transforms.md)
 - [Expressions](transforms/expressions.md)
 - [Schemas and DTypes](transforms/schemas-and-dtypes.md)
 
-## Episode Operations
+## Episode operations
 
 - [Overview](episode-operations/index.md)
-- [Motion Trimming](episode-operations/motion-trimming.md)
-- [Subtask Annotation](episode-operations/subtask-annotation.md)
-- [Reward Scoring](episode-operations/reward-scoring.md)
-- [Hand Tracking](episode-operations/hand-tracking.md)
+- [Motion trimming](episode-operations/motion-trimming.md)
+- [Subtask annotation](episode-operations/subtask-annotation.md)
+- [Reward scoring](episode-operations/reward-scoring.md)
+- [Hand tracking](episode-operations/hand-tracking.md)
 
 ## Inference
 
 - [Overview](inference/index.md)
-- [Generate Text](inference/generate-text.md)
-- [Multimodal and Structured Output](inference/multimodal-and-structured-output.md)
+- [Generate text](inference/generate-text.md)
+- [Multimodal and structured output](inference/multimodal-and-structured-output.md)
 - [Providers and vLLM](inference/inference_providers.md)
 - [Pooling](inference/pooling.md)
 
-## Writing Data
+## Writing data
 
 - [Overview](writing-data/index.md)
-- [Writer Model](writing-data/writer-model.md)
+- [Writer model](writing-data/writer-model.md)
 - [LeRobot](writing-data/lerobot.md)
 - [Zarr](writing-data/zarr.md)
 - [Parquet and JSONL](writing-data/parquet-and-jsonl.md)
-- [Media Assets and Reducers](writing-data/media-assets-and-reducers.md)
+- [Media assets and reducers](writing-data/media-assets-and-reducers.md)
 
 ## Examples
 
 - [Overview](examples/index.md)
 - [ALOHA HDF5](examples/formats/aloha-hdf5.md)
 - [robomimic HDF5](examples/formats/robomimic-hdf5.md)
-- [Zarr Replay Buffer](examples/formats/zarr-replay-buffer.md)
+- [Zarr replay buffer](examples/formats/zarr-replay-buffer.md)
 - [MCAP Franka](examples/formats/mcap-franka.md)
 - [Libero HDF5](examples/formats/libero-hdf5.md)
-- [Merge LeRobot Datasets](examples/datasets/merge-lerobot-datasets.md)
-- [Video Subtask Annotations](examples/annotations/subtask-annotations.md)
-- [Running Reward Models](examples/annotations/reward-models.md)
-- [Hand Tracking](examples/annotations/hand-tracking.md)
+- [Merge LeRobot datasets](examples/datasets/merge-lerobot-datasets.md)
+- [Video subtask annotations](examples/annotations/subtask-annotations.md)
+- [Running reward models](examples/annotations/reward-models.md)
+- [Hand tracking](examples/annotations/hand-tracking.md)
 - [Cloud GPU Job](examples/cloud/cloud-gpu-job.md)
 
 ## Platform
 
 - [Overview](platform/index.md)
 - [Workspaces and API Keys](platform/workspaces-and-api-keys.md)
-- [Submitting to the Platform](platform/submitting-to-the-platform.md)
+- [Submitting to the platform](platform/submitting-to-the-platform.md)
 - [Billing](platform/billing.md)
 - [Services](platform/services.md)
 - [Viewer](platform/viewer.md)
 - [Manifests](platform/manifests.md)
-- [Secrets and Environment](platform/secrets-and-environment.md)
-- [Cloud Jobs and Files](platform/cloud-jobs-and-files.md)
+- [Secrets and environment](platform/secrets-and-environment.md)
+- [Environment variables](platform/environment-variables.md)
+- [Cloud Jobs and files](platform/cloud-jobs-and-files.md)
 
 ## CLI
 
 - [Overview](cli/index.md)
-- [Auth and Run](cli/auth-and-run.md)
-- [Jobs, Logs, and Metrics](cli/jobs-logs-and-metrics.md)
+- [Auth and run](cli/auth-and-run.md)
+- [Jobs, logs, and metrics](cli/jobs-logs-and-metrics.md)
 - [Secrets](cli/secrets.md)
 
 ## Reference
 
 - [Overview](reference/index.md)
-- [Path Formats](reference/path-formats.md)
-- [Optional Dependencies](reference/optional-dependencies.md)
+- [Path formats](reference/path-formats.md)
+- [Optional dependencies](reference/optional-dependencies.md)

--- a/docs/platform/billing.md
+++ b/docs/platform/billing.md
@@ -1,6 +1,6 @@
 ---
 title: "Billing"
-description: "Understand workspace credits, payment state, usage, and invoice breakdowns"
+description: "Understand workspace credits, payment methods, usage, and invoice breakdowns"
 ---
 
 # Billing
@@ -14,25 +14,25 @@ Only workspace owners and admins can manage payment details. Members can use
 billing visibility if they have access to the workspace settings page, but
 payment actions are restricted.
 
-## Billing Page
+## Billing page
 
 The billing page shows:
 
 | Area | What it means |
 | --- | --- |
-| Billing Period Spend | Current usage for the selected billing period. |
+| Billing period spend | Current usage for the selected billing period. |
 | Billing cycle selector | Prior and current billing periods when more than one is available. |
 | Included or remaining credits | Credits available in the billing period. |
 | Additional usage | Usage beyond included credits. |
-| Payment Information | Card/setup state and Stripe actions. |
-| Invoice Breakdown | Usage grouped by job, with worker and service rows. |
+| Payment information | Card status and Stripe actions. |
+| Invoice breakdown | Usage grouped by Job, with worker and service rows. |
 
 The invoice breakdown links each job line back to the job detail page when the
 job is known. Use that link to explain where spend came from: the job graph,
 worker count, service usage, logs, metrics, and manifest are all on the job
 detail page.
 
-## Credits And Additional Usage
+## Credits and additional usage
 
 The platform separates usage into included credits and additional usage.
 
@@ -43,25 +43,25 @@ The platform separates usage into included credits and additional usage.
 | Billing period spend | Total usage in the selected period. |
 | Additional usage | Spend above included credits. |
 
-Adding a card raises monthly credits to $25 and lets jobs keep running after
+Adding a card raises monthly credits to $30 and lets Jobs keep running after
 included credits run out. Without a usable card, cloud jobs can be blocked when
 credits are exhausted.
 
-## Payment States
+## Payment status
 
-Workspace cloud execution is gated by payment state and available credits.
+Workspace cloud execution depends on available credits and payment status.
 
-| State | What it means | What to do |
+| What you see | What it means | What to do |
 | --- | --- | --- |
-| `free_only` | No card is configured. The workspace can use included credits only. | Add a card before credits run out. |
-| `paid_allowed` | A card is configured and paid usage is allowed. | Monitor current-period spend. |
-| `payment_required` | The workspace needs a card to continue paid usage. | Click **Add Card** on the billing page. |
-| `delinquent` | A previous payment failed. New cloud jobs are blocked. | Click **Manage Billing Details** and resolve payment in Stripe. |
+| No card is configured | The workspace can use included credits only. | Add a card before credits run out. |
+| Card is configured | Jobs can continue into paid usage after included credits run out. | Monitor current-period spend. |
+| Payment method required | The workspace needs a card before it can continue paid usage. | Click **Add Card** on the billing page. |
+| Payment overdue | An overdue payment needs attention before new paid Jobs can run. | Click **Manage Billing Details** and resolve the issue in Stripe. |
 
-The payment panel explains the current state. Depending on state and role, it
+The payment panel explains the current status. Depending on status and role, it
 shows **Add Card** and/or **Manage Billing Details**.
 
-## Add Or Manage A Card
+## Add or manage a card
 
 1. Open [Settings > Billing](/settings/billing).
 2. In **Payment Information**, click **Add Card** if no card is configured.
@@ -70,25 +70,20 @@ shows **Add Card** and/or **Manage Billing Details**.
 5. Use **Manage Billing Details** later to update card, invoice, or billing
    information through Stripe.
 
-If the page says payment services are unavailable, billing provider setup is not
-configured for the deployment. Contact the Macrodata team.
+## Submission rules
 
-## Submission Rules
-
-Cloud job submission checks billing before work starts. Submission can be
+Cloud Job submission checks billing before work starts. Submission can be
 blocked when:
 
 - the workspace has no remaining included credits
 - the workspace needs a payment method for additional usage
-- the workspace is delinquent
-- billing is unavailable for the workspace
-- paid usage has reached the billing-period cap
+- a payment is overdue
+- workspace paid usage has reached its billing-period limit
 
-The current paid-usage cap is $200 of paid overage for the billing period. A
-workspace that reaches that cap cannot submit more paid jobs until the next
-period or until the account is adjusted.
+When a workspace reaches its billing-period limit, new paid Jobs wait until the
+next period or until the account is adjusted.
 
-## Invoice Breakdown
+## Invoice breakdown
 
 The invoice breakdown groups usage by job. Each job group can include:
 
@@ -102,7 +97,7 @@ Use the arrow on a job row to open the job detail page. If a service row is
 large, open the job and the [Services](services.md) page to see the service
 instantiations and logs.
 
-## Billing Cycles
+## Billing cycles
 
 When prior periods are available, the billing page shows a billing cycle
 selector. Pick a period to see spend and invoice breakdown for that period.
@@ -110,7 +105,7 @@ selector. Pick a period to see spend and invoice breakdown for that period.
 Active periods can change while jobs run. Closed periods reflect the finalized
 usage reported by the billing provider.
 
-## Services And Billing
+## Services and billing
 
 Runtime services are billed separately from worker compute but remain grouped
 under the job that started them when possible. This matters for inference-heavy
@@ -126,7 +121,7 @@ If jobs stop submitting:
 
 1. Open [Settings > Billing](/settings/billing).
 2. Check whether credits are exhausted.
-3. Check **Payment Information** for `payment_required` or `delinquent` copy.
+3. Check **Payment Information** for card setup or overdue payment copy.
 4. Add or update the card through Stripe.
 5. Retry the launch.
 
@@ -137,7 +132,7 @@ If spend looks surprising:
 3. Open that job.
 4. Check worker count, runtime services, duration, logs, metrics, and manifest.
 
-## Related Pages
+## Related pages
 
 - [Submitting to the Platform](submitting-to-the-platform.md)
 - [Cloud Jobs and Files](cloud-jobs-and-files.md)

--- a/docs/platform/cloud-jobs-and-files.md
+++ b/docs/platform/cloud-jobs-and-files.md
@@ -1,9 +1,9 @@
 ---
-title: "Cloud Jobs and Files"
+title: "Cloud Jobs and files"
 description: "Track cloud jobs and understand file staging from the user perspective"
 ---
 
-# Cloud Jobs And Files
+# Cloud Jobs and files
 
 A cloud job is a submitted Refiner run owned by a workspace. Jobs have stages,
 workers, logs, metrics, manifests, resource settings, optional services, and
@@ -11,7 +11,7 @@ output references.
 
 Open jobs from [Jobs](/jobs).
 
-## Job Lifecycle
+## Job lifecycle
 
 | State | Meaning |
 | --- | --- |
@@ -25,7 +25,7 @@ The jobs list shows status, progress, duration, starter, and an action to open
 the job. The job detail page shows the graph, selected-stage detail, worker
 observability, logs, metrics, manifest, and job metadata.
 
-## Stages, Workers, And Shards
+## Stages, workers, and shards
 
 Refiner breaks a cloud run into stages. Each stage can have workers. Workers
 claim shards, process rows or episodes, emit logs and metrics, and report
@@ -46,12 +46,12 @@ a user perspective, this matters because:
 - outputs should be written to durable paths you control, such as S3, GCS, or
   Hugging Face repositories
 - private input or output locations require credentials through
-  [Secrets and Environment](secrets-and-environment.md)
+  [Secrets and environment](secrets-and-environment.md)
 - manifests can show which code and file references were submitted with a job
 - the [Viewer](viewer.md) can inspect produced Parquet, JSON, and CSV outputs
   from workspace-accessible storage
 
-## Inspect Jobs In The CLI
+## Inspect Jobs in the CLI
 
 ```bash
 macrodata jobs list
@@ -69,7 +69,7 @@ macrodata jobs get job_123 --json
 
 See [CLI Jobs, Logs, and Metrics](../cli/jobs-logs-and-metrics.md).
 
-## Links To Other Platform Surfaces
+## Links to other platform surfaces
 
 | Surface | URL |
 | --- | --- |
@@ -79,7 +79,7 @@ See [CLI Jobs, Logs, and Metrics](../cli/jobs-logs-and-metrics.md).
 | Viewer | [Viewer](/viewer) |
 | Secrets | [Settings > Secrets](/settings/secrets) |
 
-## Related Pages
+## Related pages
 
 - [Submitting to the Platform](submitting-to-the-platform.md)
 - [Observability](../running-pipelines/observability.md)

--- a/docs/platform/environment-variables.md
+++ b/docs/platform/environment-variables.md
@@ -1,0 +1,79 @@
+---
+title: "Environment variables"
+description: "Predefined variables that affect Refiner, the CLI, and local workers"
+---
+
+# Environment variables
+
+This page lists predefined environment variables that Refiner reads directly.
+For arbitrary non-secret variables passed to cloud workers, use
+[`launch_cloud(env=...)`](secrets-and-environment.md#non-secret-environment).
+For tokens and credentials, use
+[Secrets and environment](secrets-and-environment.md) when submitting cloud
+jobs.
+
+## Platform and authentication
+
+| Variable | Effect |
+| --- | --- |
+| `MACRODATA_API_KEY` | Authenticates the CLI and Python cloud launcher. Refiner checks this before the local credentials file written by `macrodata login`. |
+| `MACRODATA_BASE_URL` | Overrides the Macrodata API base URL. The default is `https://macrodata.co`. |
+| `XDG_CONFIG_HOME` | Changes where `macrodata login` stores and reads the local API key file. |
+
+Use `MACRODATA_API_KEY` for CI, agent runs, or any environment where writing a
+local credentials file is not desirable:
+
+```bash
+export MACRODATA_API_KEY="md_..."
+macrodata whoami
+```
+
+## CLI run behavior
+
+| Variable | Values | Effect |
+| --- | --- | --- |
+| `REFINER_ATTACH` | `auto`, `attach`, `detach` | Controls whether cloud launches attach to live output or return after submission. |
+| `REFINER_LOGS` | `all`, `none`, `one`, `errors` | Controls worker log output for run/attach flows. |
+
+Command-line flags can override these values for a single run.
+
+## Local execution
+
+| Variable | Effect |
+| --- | --- |
+| `REFINER_WORKDIR` | Sets the local worker run directory. The path must be absolute. |
+| `XDG_CACHE_HOME` | Changes the default local work directory when `REFINER_WORKDIR` is not set. |
+| `CUDA_VISIBLE_DEVICES` | Restricts or defines GPU IDs visible to local workers. Refiner also sets this for worker processes after assigning GPUs. |
+
+Without `REFINER_WORKDIR`, local worker files go under
+`$XDG_CACHE_HOME/macrodata/refiner` or `~/.cache/macrodata/refiner`.
+
+## Cloud launch dependency fallback
+
+| Variable | Values | Effect |
+| --- | --- | --- |
+| `MACRODATA_FALLBACK_TO_LATEST_PYPI` | `1`, `true`, `yes`, `on` | Allows non-interactive cloud launch to fall back to the latest PyPI package when the captured local Refiner ref is not available remotely. |
+
+Leave this unset unless you intentionally want that fallback.
+
+## Provider and data credentials
+
+These variables are read by specific Refiner readers or inference providers
+when an API key is not passed directly:
+
+| Variable | Used by |
+| --- | --- |
+| `HF_TOKEN` | Hugging Face HTTP paths. |
+| `OPENAI_API_KEY` | OpenAI and OpenAI-compatible inference providers. |
+| `ANTHROPIC_API_KEY` | Anthropic inference provider. |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Google inference provider. |
+
+For cloud jobs, pass these as secrets instead of plain environment variables so
+their values are redacted from logs and manifests.
+
+## Related pages
+
+- [Submitting to the platform](submitting-to-the-platform.md)
+- [Secrets and environment](secrets-and-environment.md)
+- [Cloud launcher](../running-pipelines/cloud-launcher.md)
+- [Auth and run](../cli/auth-and-run.md)

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Platform"
-description: "Use Macrodata Cloud to run, track, share, and inspect Refiner work"
+description: "Use the Macrodata Cloud to run, track, share, and inspect Refiner work"
 ---
 
 # Platform
@@ -14,7 +14,7 @@ Use it when a laptop run becomes team infrastructure: converting robot episodes
 at scale, running GPU annotation, refreshing datasets, checking failed shards,
 or handing a run to another engineer without losing the execution context.
 
-## Platform Overview
+## Platform overview
 
 The platform keeps track of every job submitted to a workspace. Each job page
 keeps the run inspectable after submission:
@@ -59,7 +59,7 @@ Workspace-specific settings are under:
 | Secrets | [Settings > Secrets](/settings/secrets) |
 | Members | [Settings > Members](/settings/members) |
 
-## Submitting to the Platform
+## Submitting to the platform
 
 Cloud submission starts with an API key scoped to the workspace that should own
 the job. Create one from [Settings > API Keys](/settings/api-keys), copy it
@@ -108,11 +108,11 @@ runtime services both show up in the invoice breakdown, so a robotics
 annotation run can be traced from billing line item back to the job that
 started it.
 
-Payment state affects cloud execution. A workspace with remaining included
-credits can submit jobs. Adding a card raises monthly credits to $25 and allows
-paid usage after included credits run out. New paid jobs are blocked when a
-workspace needs a payment method, is delinquent, or hits the paid-usage cap for
-the billing period.
+Payment status affects cloud execution. A workspace with remaining included
+credits can submit Jobs. Adding a card raises monthly credits to $30 and allows
+paid usage after included credits run out. New paid Jobs are blocked when a
+workspace needs a payment method, has an overdue payment, or hits the paid-usage
+limit for the billing period.
 
 See [Billing](billing.md).
 
@@ -143,7 +143,7 @@ Hugging Face repos.
 
 See [Viewer](viewer.md).
 
-## Platform Docs
+## Platform docs
 
 | Page | Use it for |
 | --- | --- |
@@ -153,5 +153,6 @@ See [Viewer](viewer.md).
 | [Services](services.md) | Runtime service groups, instantiations, logs, and job links. |
 | [Viewer](viewer.md) | Inspecting Parquet, JSON, CSV, media cells, and private storage. |
 | [Manifests](manifests.md) | Reproducing exactly what a cloud job ran. |
-| [Secrets and Environment](secrets-and-environment.md) | Passing credentials and configuration to jobs and the viewer. |
+| [Secrets and environment](secrets-and-environment.md) | Passing credentials and configuration to jobs and the viewer. |
+| [Environment variables](environment-variables.md) | Predefined variables that affect Refiner, the CLI, and local workers. |
 | [Cloud Jobs and Files](cloud-jobs-and-files.md) | Job lifecycle and file staging behavior. |

--- a/docs/platform/manifests.md
+++ b/docs/platform/manifests.md
@@ -11,7 +11,7 @@ resource settings, and secret references.
 
 Open a job from [Jobs](/jobs), then click the **Manifest** tab.
 
-## What A Manifest Answers
+## What a manifest answers
 
 Use a manifest to answer:
 
@@ -24,7 +24,7 @@ Use a manifest to answer:
 
 Manifest records should not contain secret values.
 
-## Inspect From The CLI
+## Inspect from the CLI
 
 ```bash
 macrodata jobs manifest job_123
@@ -36,7 +36,7 @@ macrodata jobs manifest job_123 --json
 Use `--deps` to show dependencies and `--code` to show captured script text.
 Use `--json` for an agent, notebook, or CI job.
 
-## Dependency Entries
+## Dependency entries
 
 Built-in Refiner blocks automatically add the
 [optional dependency groups](../reference/optional-dependencies.md) they need to
@@ -75,7 +75,7 @@ transformers>=4.55
 ```
 
 Environment markers are not preserved. Do not include markers in
-`dependencies`; list the package as it should install on Macrodata Cloud.
+`dependencies`; list the package as it should install on the Macrodata Cloud.
 For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
 
 Finally, if `sync_local_dependencies=True`, Refiner tries to sync packages from
@@ -84,7 +84,7 @@ pairs in the manifest. Explicit `dependencies` take precedence over synced
 packages with the same package name. If any synced package cannot be resolved
 from PyPI during cloud image setup, the job will fail.
 
-## What To Look For
+## What to look for
 
 | Field | Why it matters |
 | --- | --- |
@@ -95,7 +95,7 @@ from PyPI during cloud image setup, the job will fail.
 | Resources | Confirms worker count, CPU, memory, GPU, and services. |
 | Refiner version | Confirms which package version workers used. |
 
-## Debugging With Manifests
+## Debugging with manifests
 
 Use the manifest when:
 
@@ -109,7 +109,7 @@ Use the manifest when:
 For billing investigations, open the job from the invoice breakdown, then open
 the manifest to see worker count, GPU settings, and service configuration.
 
-## Related Pages
+## Related pages
 
 - [Submitting to the Platform](submitting-to-the-platform.md)
 - [Cloud Launcher](../running-pipelines/cloud-launcher.md)

--- a/docs/platform/secrets-and-environment.md
+++ b/docs/platform/secrets-and-environment.md
@@ -1,9 +1,9 @@
 ---
-title: "Secrets and Environment"
+title: "Secrets and environment"
 description: "Pass credentials and configuration to cloud jobs and the viewer"
 ---
 
-# Secrets And Environment
+# Secrets and environment
 
 Cloud jobs and the viewer often need credentials for storage, model providers,
 or private datasets. Store those values as workspace secrets instead of
@@ -11,7 +11,7 @@ hard-coding them in pipeline code.
 
 Open [Settings > Secrets](/settings/secrets).
 
-## Secret Environments
+## Secret environments
 
 Secrets are grouped by environment. Use environments to keep separate versions
 of the same key:
@@ -25,7 +25,7 @@ of the same key:
 The secrets page has an **Environment** selector. Choose an existing
 environment or choose **Add environment** to create a new environment name.
 
-## Add A Secret In The UI
+## Add a secret in the UI
 
 1. Open [Settings > Secrets](/settings/secrets).
 2. Select the environment, such as `production`.
@@ -38,7 +38,7 @@ updated time, and actions. It does not show values.
 
 Use **Overwrite** to replace a value and **Delete** to remove it permanently.
 
-## Add A Secret From The CLI
+## Add a secret from the CLI
 
 ```bash
 printf '%s' "$HF_TOKEN" | macrodata secrets set HF_TOKEN --env production --value-stdin
@@ -47,7 +47,7 @@ macrodata secrets list --env production
 
 See [CLI Secrets](../cli/secrets.md).
 
-## Pass Secrets In Code
+## Pass secrets in code
 
 Use `mdr.Secrets.dict(...)` when the value is available in Python at submission
 time:
@@ -70,7 +70,7 @@ pipeline.launch_cloud(
 )
 ```
 
-## Submit Local Environment Values
+## Submit local environment values
 
 Use this when the secret value exists on your submitting machine and should be
 sent with this job:
@@ -85,7 +85,7 @@ pipeline.launch_cloud(
 `None` means Refiner reads `HF_TOKEN` from your local environment at submission
 time and passes the value as a secret for the job.
 
-## Load A Dotenv File
+## Load a dotenv file
 
 Use `mdr.Secrets.dotenv(...)` to load job secrets from a local dotenv file at
 submission time:
@@ -107,7 +107,7 @@ WANDB_API_KEY=...
 The dotenv file is read locally when you submit the job. The file itself is not
 uploaded.
 
-## Use Stored Workspace Secrets
+## Use stored workspace secrets
 
 Use stored secrets for shared workflows:
 
@@ -121,7 +121,7 @@ pipeline.launch_cloud(
 The job references the `production` environment and the `HF_TOKEN` name. The
 manifest records the reference, not the value.
 
-## Non-Secret Environment
+## Non-secret environment
 
 Use `env` for configuration that is not sensitive:
 
@@ -135,7 +135,7 @@ pipeline.launch_cloud(
 Use secrets for tokens, credentials, private keys, and passwords. Use `env` for
 labels, feature flags, batch sizes, or other non-sensitive values.
 
-## Viewer Secrets
+## Viewer secrets
 
 The [Viewer](viewer.md) uses the selected workspace secret environment to open
 private S3, GCS, and Hugging Face files.
@@ -151,9 +151,10 @@ Use these names:
 Open [Viewer](/viewer), choose the same environment, paste the file path, and
 click **Load**.
 
-## Related Pages
+## Related pages
 
 - [Submitting to the Platform](submitting-to-the-platform.md)
+- [Environment variables](environment-variables.md)
 - [Viewer](viewer.md)
 - [CLI Secrets](../cli/secrets.md)
 - [Cloud Launcher](../running-pipelines/cloud-launcher.md)

--- a/docs/platform/services.md
+++ b/docs/platform/services.md
@@ -11,7 +11,7 @@ workloads such as vLLM-backed inference.
 
 Open [Services](/services), which redirects to the active workspace.
 
-## Why Services Exist
+## Why services exist
 
 Some robotics data workflows need expensive model processes: VLM annotation,
 reward scoring, captioning, embedding, or policy-evaluation helpers. Loading
@@ -23,7 +23,7 @@ plan. Workers then call the service while processing shards.
 See [Resources, GPUs, and Services](../running-pipelines/resources-gpus-and-services.md)
 and [Providers and vLLM](../inference/inference_providers.md).
 
-## Services List
+## Services list
 
 The services list is split into **Running** and **Stopped** sections.
 
@@ -40,7 +40,7 @@ Each row shows:
 If no job has started a runtime service in the workspace, the page says that no
 services have been instantiated yet.
 
-## Service Detail
+## Service detail
 
 Click **View** from [Services](/services).
 
@@ -83,7 +83,7 @@ To investigate service spend:
 
 See [Billing](billing.md).
 
-## Related Pages
+## Related pages
 
 - [Resources, GPUs, and Services](../running-pipelines/resources-gpus-and-services.md)
 - [Providers and vLLM](../inference/inference_providers.md)

--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -1,16 +1,16 @@
 ---
-title: "Submitting to the Platform"
+title: "Submitting to the platform"
 description: "Authenticate, launch cloud jobs, and inspect submitted Refiner runs"
 ---
 
-# Submitting To The Platform
+# Submitting to the platform
 
-Submitting a Refiner pipeline to Macrodata Cloud creates a workspace-owned job
-record. The platform stores the run metadata, starts workers, tracks progress,
-collects logs and metrics, preserves the manifest, and exposes the job in the
-browser and CLI.
+Submitting a Refiner pipeline to the Macrodata Cloud creates a workspace-owned
+job record. The platform stores the run metadata, starts workers, tracks
+progress, collects logs and metrics, preserves the manifest, and exposes the
+job in the browser and CLI.
 
-## Before You Submit
+## Before you submit
 
 You need:
 
@@ -49,7 +49,7 @@ export MACRODATA_API_KEY="md_..."
 macrodata whoami
 ```
 
-## Launch A Cloud Job
+## Launch a Cloud Job
 
 Use `launch_cloud()` on the same pipeline object you would launch locally:
 
@@ -84,13 +84,13 @@ Common launch settings:
 | `dependencies` | Additional pip requirement strings to install on workers. |
 | `sync_local_dependencies` | Ask Refiner to try syncing packages from the submitting environment. Defaults to `False`. |
 | `secrets` | Secret values or workspace secret references passed to workers. |
-| `env` | Non-secret environment variables. |
+| `env` | Non-secret [environment variables](environment-variables.md). |
 | `continue_from_job` | Reuse compatible outputs from a prior cloud job. |
 
 See [Cloud Launcher](../running-pipelines/cloud-launcher.md) and
 [Resources, GPUs, and Services](../running-pipelines/resources-gpus-and-services.md).
 
-### Dependency Overrides
+### Dependency overrides
 
 Built-in Refiner readers, writers, and operations automatically declare the
 extras they require. For example, `read_hf_dataset(...)` adds `datasets`, Hugging
@@ -121,7 +121,7 @@ Dependency entries are pip requirement strings. Exact pins, versionless
 requirements, ranges, and package extras are supported.
 
 Environment markers are not preserved. Do not include markers in
-`dependencies`; list the package as it should install on Macrodata Cloud.
+`dependencies`; list the package as it should install on the Macrodata Cloud.
 For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
 
 Finally, if you would like Refiner to try syncing the packages installed in
@@ -130,7 +130,7 @@ your current Python environment, set `sync_local_dependencies=True`. Explicit
 If one of those packages cannot be resolved from PyPI during cloud image setup,
 the job will fail.
 
-## What Gets Submitted
+## What gets submitted
 
 A cloud submission includes:
 
@@ -150,7 +150,7 @@ macrodata jobs manifest job_123 --deps --code
 
 See [Manifests](manifests.md).
 
-## Find The Job
+## Find the Job
 
 After submission, open [Jobs](/jobs). The jobs list shows name, status,
 progress, duration, starter, and an action to open the job. Use **Load more**
@@ -169,7 +169,7 @@ Use `--json` when another program needs to parse the result:
 macrodata jobs get job_123 --json
 ```
 
-## Inspect A Job
+## Inspect a Job
 
 Open the job from [Jobs](/jobs). The job detail page has:
 
@@ -185,7 +185,7 @@ Open the job from [Jobs](/jobs). The job detail page has:
 Cloud jobs stream progress and observability while they run. Local jobs can
 appear in the platform, but advanced real-time observability is for cloud jobs.
 
-## Logs And Metrics
+## Logs and metrics
 
 Use the job page for interactive debugging. Use the CLI for terminal workflows:
 
@@ -200,7 +200,7 @@ macrodata jobs resource-metrics job_123 0 --range 15m
 See [Observability](../running-pipelines/observability.md) and
 [CLI Jobs, Logs, and Metrics](../cli/jobs-logs-and-metrics.md).
 
-## Cancel A Job
+## Cancel a Job
 
 Cancel from the job detail page when the header exposes cancellation, or use:
 
@@ -211,7 +211,7 @@ macrodata jobs cancel job_123
 Cancellation requests stop active work for that job. Use `jobs get` afterward
 to confirm the terminal state.
 
-## Billing And Submission Gates
+## Billing and submission gates
 
 Cloud submission checks workspace billing state. A workspace can submit while
 it has available included credits, or after a payment method is configured for
@@ -219,17 +219,17 @@ paid usage.
 
 Submissions are blocked when:
 
-- billing is not configured for the workspace
-- the workspace is delinquent
+- a workspace payment is overdue
 - a workspace without a usable payment method has exhausted included credits
-- the workspace reaches the paid-usage cap for the billing period
+- the workspace reaches its paid-usage limit for the billing period
 
 Open [Settings > Billing](/settings/billing) to add a card, manage billing
 details, inspect usage, or choose a prior billing cycle. See [Billing](billing.md).
 
-## Related Pages
+## Related pages
 
 - [Workspaces and API Keys](workspaces-and-api-keys.md)
-- [Secrets and Environment](secrets-and-environment.md)
+- [Secrets and environment](secrets-and-environment.md)
+- [Environment variables](environment-variables.md)
 - [Cloud Jobs and Files](cloud-jobs-and-files.md)
 - [CLI](../cli/index.md)

--- a/docs/platform/viewer.md
+++ b/docs/platform/viewer.md
@@ -10,7 +10,7 @@ open public files or private files resolved with workspace secrets.
 
 Open [Viewer](/viewer), which redirects to the active workspace.
 
-## What It Can Open
+## What it can open
 
 The viewer accepts:
 
@@ -25,7 +25,7 @@ Supported file types are **Auto**, **Parquet**, **JSON**, and **CSV**. Auto
 uses the file extension. Choose the type explicitly when the extension is
 ambiguous.
 
-## Load A File
+## Load a file
 
 1. Open [Viewer](/viewer).
 2. Pick a secrets environment from the **Environment** selector.
@@ -37,7 +37,7 @@ For public files, choose **Environment: None**. For private buckets or private
 Hugging Face repositories, choose the workspace secret environment that contains
 the credentials.
 
-## Private Storage
+## Private storage
 
 Secrets are managed in [Settings > Secrets](/settings/secrets).
 
@@ -52,7 +52,7 @@ Use these secret names:
 The viewer uses the selected workspace secret environment to resolve storage
 paths into browser-fetchable URLs. Secret values are not exposed in the UI.
 
-## How It Works
+## How it works
 
 For `http://` and `https://` paths, the viewer uses the URL directly.
 
@@ -64,7 +64,7 @@ browser-fetchable URL plus the canonical source path.
 The browser then queries the file with DuckDB-Wasm. The data file is fetched by
 the browser for preview, search, sort, and pagination.
 
-## Table Controls
+## Table controls
 
 After loading a file, the viewer shows:
 
@@ -81,7 +81,7 @@ String cells that look like media or file URLs are rendered as links or previews
 S3, GCS, and Hugging Face cell values can also resolve through the same
 workspace secret environment.
 
-## CORS And Browser Fetching
+## CORS and browser fetching
 
 The viewer fetches data client-side. For private files, the platform may return
 a signed URL, but the browser still needs permission to read it.
@@ -130,8 +130,8 @@ deployment or local preview.
 | CORS or browser access error | Configure bucket CORS for the app origin. |
 | Invalid file type | The selected file type does not match the file contents. |
 
-## Related Pages
+## Related pages
 
-- [Secrets and Environment](secrets-and-environment.md)
+- [Secrets and environment](secrets-and-environment.md)
 - [Path Formats](../reference/path-formats.md)
 - [Writing Data](../writing-data/index.md)

--- a/docs/platform/workspaces-and-api-keys.md
+++ b/docs/platform/workspaces-and-api-keys.md
@@ -1,9 +1,9 @@
 ---
-title: "Workspaces and API Keys"
+title: "Workspaces and API keys"
 description: "Organize platform resources and authenticate Refiner jobs"
 ---
 
-# Workspaces And API Keys
+# Workspaces and API keys
 
 A workspace owns the platform resources created by Refiner: jobs, logs, metrics,
 manifests, files, secrets, API keys, services, viewer access, billing, and
@@ -13,7 +13,7 @@ Everyone starts with a personal workspace. Create shared workspaces for team
 datasets, production workflows, lab projects, or anything where other users
 need access to the same jobs and secrets.
 
-## Manage Workspaces
+## Manage workspaces
 
 Open [Settings > Workspaces](/settings/workspaces). The page shows your
 workspaces, the active workspace, pending invitations, and actions for shared
@@ -42,7 +42,7 @@ redirect to the active workspace:
 
 You can create up to 3 workspaces by default. Contact the team if you need more.
 
-## Personal And Shared Workspaces
+## Personal and shared workspaces
 
 Personal workspaces are private to your user. They are the default place for
 first runs and individual experiments.
@@ -77,7 +77,7 @@ Role changes to elevated permissions require confirmation in the UI. Member
 management is not available for personal workspaces; create a shared workspace
 first.
 
-## Workspace Settings
+## Workspace settings
 
 Open [Settings](/settings) to see account and workspace controls. The sidebar
 has a workspace selector and these workspace tabs:
@@ -90,7 +90,7 @@ has a workspace selector and these workspace tabs:
 | Secrets | [Settings > Secrets](/settings/secrets) | Store encrypted environment secrets for jobs and the viewer. |
 | Members | [Settings > Members](/settings/members) | Invite users, change roles, revoke invitations, and remove members. |
 
-## Create An API Key
+## Create an API key
 
 API keys authenticate the CLI and Python cloud launcher. They are scoped to the
 workspace where they are created.
@@ -104,7 +104,7 @@ workspace where they are created.
 The API key table shows name, masked value, last-used time, created time, and a
 delete action. Workspace owners and admins can also see member API keys.
 
-## Log In Locally
+## Log in locally
 
 Use the copied key with the CLI:
 
@@ -122,7 +122,7 @@ macrodata whoami
 
 Environment credentials take precedence over locally saved credentials.
 
-## Delete Or Rotate Keys
+## Delete or rotate keys
 
 Delete old keys from [Settings > API Keys](/settings/api-keys). Deleting a key
 immediately prevents future CLI and cloud-launch requests with that key.
@@ -130,9 +130,9 @@ immediately prevents future CLI and cloud-launch requests with that key.
 Rotate keys by creating a new key, updating local machines or CI secrets, then
 deleting the old key after the new one has been used successfully.
 
-## Related Pages
+## Related pages
 
 - [Submitting to the Platform](submitting-to-the-platform.md)
 - [CLI Auth and Run](../cli/auth-and-run.md)
 - [Cloud Launcher](../running-pipelines/cloud-launcher.md)
-- [Secrets and Environment](secrets-and-environment.md)
+- [Secrets and environment](secrets-and-environment.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ Refiner is an open-source library for building robotics data pipelines. A
 [inspect pipelines locally](running-pipelines/in-process-debugging.md) while you
 develop. When you do not want to manage infrastructure, run the same code with
 [local workers](running-pipelines/local-launcher.md) or submit it to
-[Macrodata Cloud](running-pipelines/cloud-launcher.md).
+the [Macrodata Cloud](running-pipelines/cloud-launcher.md).
 
 Readers and writers are [sharded](reading-data/sharding.md), so most pipelines
 do not need to download or materialize the entire dataset before doing useful
@@ -36,10 +36,10 @@ The `hf` and `video` extras are optional, but the example below uses them for
 [video data](episode-data/frames-and-videos.md). To install every optional
 dependency, use `pip install macrodata-refiner[all]`.
 
-Create an account from the [Get started](/auth/register) page, then
-authenticate once with the [Macrodata CLI](cli/auth-and-run.md). This is
-optional for local development, but it lets you keep track of local runs in your
-workspace. The same credentials will also be used to submit cloud runs:
+[Create an account](/auth/register), then authenticate once with the
+[Macrodata CLI](cli/auth-and-run.md). This is optional for local development,
+but it lets you keep track of local runs in your workspace. The same
+credentials will also be used to submit cloud runs:
 
 ```bash
 macrodata login
@@ -85,7 +85,7 @@ inspect rows with methods like `take()`, launch
 [local workers](running-pipelines/local-launcher.md), or submit a
 [cloud job](running-pipelines/cloud-launcher.md).
 
-## Inspect A Pipeline
+## Inspect a pipeline
 
 Start by inspecting a small amount of data
 [in process](running-pipelines/in-process-debugging.md). This block is
@@ -130,7 +130,7 @@ the fastest way to check [schemas](transforms/schemas-and-dtypes.md),
 [media references](episode-data/frames-and-videos.md), and transform outputs
 before launching a full job.
 
-## Run Locally
+## Run locally
 
 ```python
 import refiner as mdr
@@ -153,7 +153,7 @@ your machine. Use it when you want the same
 using cloud resources. If you are [logged in](cli/auth-and-run.md), local runs
 are also tracked in the platform interface.
 
-## Run On Macrodata Cloud
+## Run on the Macrodata Cloud
 
 This example converts the public LIBERO spatial HDF5 subset to LeRobot using
 cloud workers. It reads one demo group per row, derives the task label from the
@@ -217,7 +217,7 @@ output = "hf://buckets/macrodata/test_bucket/libero-spatial"
 The input dataset is public, but the cloud workers need `HF_TOKEN` to write back
 to your Hugging Face bucket. You can also safely store reusable secrets directly
 on the platform and reference them with `mdr.Secrets.env(...)`. See
-[Secrets and Environment](platform/secrets-and-environment.md).
+[Secrets and environment](platform/secrets-and-environment.md).
 
 After submission, follow the run from [Jobs](/jobs). Once scheduled, this
 example should only take a couple of minutes. The job page shows live status,
@@ -230,7 +230,7 @@ the compute they actually use; see [Billing](platform/billing.md) or
 For the full four-suite LIBERO conversion, see
 [Libero HDF5](examples/formats/libero-hdf5.md).
 
-## Where To Go Next
+## Where to go next
 
 - Learn the execution options in [Running Pipelines](running-pipelines/index.md).
 - Learn readers in [Reading Data](reading-data/index.md).

--- a/docs/reading-data/custom-readers.md
+++ b/docs/reading-data/custom-readers.md
@@ -1,15 +1,15 @@
 ---
-title: "Custom Readers"
+title: "Custom readers"
 description: "Create custom Refiner sources for data systems not covered by built-in readers"
 ---
 
-# Custom Readers
+# Custom readers
 
 Use a custom source when your data cannot be described by a built-in reader.
 Custom sources are most useful for internal databases, generated tasks, or
 special storage layouts.
 
-## Minimal Source
+## Minimal source
 
 ```python
 from collections.abc import Iterator
@@ -36,12 +36,12 @@ pipeline = mdr.from_source(EpisodesSource())
 
 The exact shard descriptor you use depends on how your source can be divided.
 
-## Keep Planning Cheap
+## Keep planning cheap
 
 `list_shards()` should not download the dataset or decode media. It should do
 only the work needed to create units that workers can read independently.
 
-## Describe The Source
+## Describe the source
 
 If your source appears in cloud job plans, implement a useful `describe()`
 method:
@@ -53,7 +53,7 @@ def describe(self) -> dict[str, object]:
 
 Descriptions should help users understand the job. Do not include secrets.
 
-## Related Pages
+## Related pages
 
 - [Reader Model](reader-model.md)
 - [Sharding](sharding.md)

--- a/docs/reading-data/files-and-videos.md
+++ b/docs/reading-data/files-and-videos.md
@@ -1,14 +1,14 @@
 ---
-title: "Files and Videos"
+title: "Files and videos"
 description: "Read file inventories, raw bytes, and video paths"
 ---
 
-# Files And Videos
+# Files and videos
 
 Use `read_files` to list files or read bytes. Use `read_videos` when the files
 are video sources that should be typed as video assets.
 
-## File Inventory
+## File inventory
 
 ```python
 pipeline = mdr.read_files(
@@ -21,7 +21,7 @@ pipeline = mdr.read_files(
 
 This emits one row per file without reading file contents.
 
-## File Bytes
+## File bytes
 
 ```python
 pipeline = mdr.read_files(
@@ -34,7 +34,7 @@ pipeline = mdr.read_files(
 Use `content_column` only when the contents are small enough to process as row
 values. For large media, keep paths and let media-aware APIs stream the data.
 
-## Video Files
+## Video files
 
 ```python
 pipeline = (
@@ -46,7 +46,7 @@ pipeline = (
 `read_videos` creates a video-typed column, which lets `to_robot_rows` expose it
 through `row.videos`.
 
-## Related Pages
+## Related pages
 
 - [Video Sources](../episode-data/frames-and-videos.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)

--- a/docs/reading-data/hdf5.md
+++ b/docs/reading-data/hdf5.md
@@ -1,14 +1,14 @@
 ---
-title: "HDF5 Reader"
+title: "HDF5 reader"
 description: "Read HDF5 robotics datasets and convert them into episode rows"
 ---
 
-# HDF5 Reader
+# HDF5 reader
 
 Use `read_hdf5` for robotics datasets stored as HDF5 files, including ALOHA-like
 files and robomimic-style grouped demonstrations.
 
-## One File Per Episode
+## One file per episode
 
 ALOHA-style data often stores one episode per HDF5 file:
 
@@ -40,7 +40,7 @@ pipeline = (
 `datasets` maps output column names to HDF5 dataset paths relative to the
 matched group.
 
-## Grouped Demonstrations
+## Grouped demonstrations
 
 robomimic-style files often store many demos in one file:
 
@@ -68,7 +68,7 @@ pipeline = (
 
 `groups` can be a single glob string or exact group paths.
 
-## Missing Data Policy
+## Missing data policy
 
 ```python
 pipeline = mdr.read_hdf5(
@@ -84,7 +84,7 @@ pipeline = mdr.read_hdf5(
 | `"drop_row"` | Skip rows with missing selected values. |
 | `"set_null"` | Emit `None` for missing selected values. |
 
-## Related Pages
+## Related pages
 
 - [Converting to Robot Rows](../episode-data/converting-to-robot-rows.md)
 - [HDF5 Conversion Example](../examples/formats/aloha-hdf5.md)

--- a/docs/reading-data/hugging-face.md
+++ b/docs/reading-data/hugging-face.md
@@ -10,7 +10,7 @@ Refiner supports two common Hugging Face patterns:
 1. Dataset roots and files accessed through `hf://...` paths.
 2. Hugging Face datasets loaded through `read_hf_dataset`.
 
-## HF Paths
+## HF paths
 
 Most file-based readers can use `hf://` paths:
 
@@ -27,7 +27,7 @@ pipeline.launch_cloud(
 )
 ```
 
-## Dataset Tables
+## Dataset tables
 
 Use `read_hf_dataset` when you want the Hugging Face datasets library to load a
 split:
@@ -45,7 +45,7 @@ automatically when the pipeline uses `read_hf_dataset(...)`.
 Use this for table-style datasets. For LeRobot dataset roots, prefer
 [`read_lerobot`](lerobot.md).
 
-## Related Pages
+## Related pages
 
 - [Path Formats](../reference/path-formats.md)
-- [Secrets and Environment](../platform/secrets-and-environment.md)
+- [Secrets and environment](../platform/secrets-and-environment.md)

--- a/docs/reading-data/index.md
+++ b/docs/reading-data/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Reading Data"
+title: "Reading data"
 description: "Choose and configure Refiner readers for robotics data"
 ---
 
-# Reading Data
+# Reading data
 
 Readers create the source of a Refiner pipeline. A reader is responsible for
 finding input files, planning shards, and emitting rows or table blocks.
@@ -14,7 +14,7 @@ import refiner as mdr
 pipeline = mdr.read_lerobot("hf://datasets/lerobot/aloha_sim_transfer_cube_human")
 ```
 
-## Reader Selection
+## Reader selection
 
 | Your data looks like | Use | Read |
 | --- | --- | --- |
@@ -28,7 +28,7 @@ pipeline = mdr.read_lerobot("hf://datasets/lerobot/aloha_sim_transfer_cube_human
 | TFRecord files or TensorFlow Datasets | `read_tfrecords`, `read_tfds` | [TensorFlow](tensorflow.md) |
 | Your own source system | `from_source` | [Custom Readers](custom-readers.md) |
 
-## Core Ideas
+## Core ideas
 
 - Readers plan **shards**, the units workers execute.
 - Readers emit **rows** or **tabular blocks**.

--- a/docs/reading-data/lerobot.md
+++ b/docs/reading-data/lerobot.md
@@ -1,9 +1,9 @@
 ---
-title: "LeRobot Reader"
+title: "LeRobot reader"
 description: "Read LeRobot datasets as episode rows"
 ---
 
-# LeRobot Reader
+# LeRobot reader
 
 Use `read_lerobot` when your input is already a LeRobot dataset root.
 
@@ -18,7 +18,7 @@ pipeline = mdr.read_lerobot(
 Each output row is a `LeRobotRow`: one episode with metadata, frame data, and
 video references attached.
 
-## What Gets Loaded
+## What gets loaded
 
 `read_lerobot` reads:
 
@@ -34,7 +34,7 @@ video references attached.
 Videos are not decoded when the dataset is read. They are decoded or
 copied when a transform or writer needs frames.
 
-## Multiple Inputs
+## Multiple inputs
 
 Pass multiple roots to combine datasets:
 
@@ -50,14 +50,14 @@ pipeline = mdr.read_lerobot(
 The reader merges metadata and remaps task indices so row tasks stay consistent.
 For a full recipe, see [Merge LeRobot Datasets](../examples/datasets/merge-lerobot-datasets.md).
 
-## Malformed Episodes
+## Malformed episodes
 
 `read_lerobot` validates that each episode's declared frame count matches the
 frames loaded from its frame parquet. Mismatches raise by default. To drop those
 episodes instead, pass `skip_malformed_rows=True`; the reader warns once and
 records `malformed_lerobot_episodes_skipped`.
 
-## Inspecting Rows
+## Inspecting rows
 
 ```python
 row = pipeline.take(1)[0]
@@ -71,7 +71,7 @@ print(list(row.videos))
 Read [Episode Rows](../episode-data/episode-rows.md) and
 [Frames and Videos](../episode-data/frames-and-videos.md) for the row API.
 
-## Sharding Options
+## Sharding options
 
 ```python
 pipeline = mdr.read_lerobot(
@@ -83,7 +83,7 @@ pipeline = mdr.read_lerobot(
 
 The shard options apply to episode parquet files under `meta/episodes`.
 
-## Related Pages
+## Related pages
 
 - [Writing LeRobot](../writing-data/lerobot.md)
 - [Motion Trimming](../episode-operations/motion-trimming.md)

--- a/docs/reading-data/mcap.md
+++ b/docs/reading-data/mcap.md
@@ -1,9 +1,9 @@
 ---
-title: "MCAP Reader"
+title: "MCAP reader"
 description: "Read MCAP robotics logs as episode rows"
 ---
 
-# MCAP Reader
+# MCAP reader
 
 Use `read_mcap` for robotics or autonomy logs stored as MCAP files.
 
@@ -36,7 +36,7 @@ Install `macrodata-refiner[mcap]` to use this reader.
 Directory inputs are filtered to paths ending in `.mcap`. Explicit file paths
 and glob patterns are honored as written.
 
-## Output Rows
+## Output rows
 
 `read_mcap` emits one row per episode. By default, each input file is one
 episode. Use `episode_splitting` to split a file into multiple episodes; the
@@ -52,7 +52,7 @@ Each row includes:
 | `videos` | Mapping of selected video names to video source values, when `videos` is set. |
 | `fps` | Explicit fps, or inferred fps when possible. |
 
-## Episode Splitting
+## Episode splitting
 
 `read_mcap` always emits episode rows. By default, each input MCAP file becomes
 one episode:
@@ -93,7 +93,7 @@ splitting and are not included as default record columns.
 If there are no messages, no time gaps, or no marker messages, the reader falls
 back to one episode for the file.
 
-## Selecting Fields
+## Selecting fields
 
 `fields` maps output records table columns to MCAP sources:
 
@@ -141,7 +141,7 @@ the same timestamps. `read_mcap` supports these synchronization choices:
 | Field sync-primary aligned | Set `sync_primary` to a selected field name, topic, or dotted source path. | One records table row for each sync-primary field timestamp. Other fields and videos are aligned with `sync_method`. | Robot state or action streams that define the trajectory clock. |
 | Video sync-primary aligned | Set `sync_primary` to a selected video name, video topic, or dotted video source path. | One records table row for each sync-primary video frame timestamp. Fields and other videos are aligned with `sync_method`. | Camera-driven datasets where image frames define the output rows. |
 
-### Unsynchronized Mode
+### Unsynchronized mode
 
 Use unsynchronized mode by leaving `sync_primary` unset:
 
@@ -174,7 +174,7 @@ rows so no message is dropped:
 | `1.0` | `[1, 2]` |
 | `1.0` | `[3, 4]` |
 
-### Sync-Primary-Aligned Mode
+### Sync-Primary-Aligned mode
 
 Use sync-primary-aligned mode by setting `sync_primary` to the source that
 should define the output frame rate:
@@ -325,7 +325,7 @@ For non-seekable streams without an MCAP summary, explicit dotted selections may
 still require scanning all topics because the reader cannot resolve source
 strings to exact MCAP topics before reading.
 
-## Conversion Examples
+## Conversion examples
 
 Convert the Franka MCAP sample from Hugging Face to LeRobot and Zarr. The
 camera topic is the sync primary, so each output row corresponds to one decoded
@@ -493,7 +493,7 @@ For non-robotics event logs, write the record fields directly:
 | `include_skew` | `True` | Add alignment timestamp/skew columns in sync-primary-aligned mode. |
 | `fps` | `None` | Positive explicit frame rate. Overrides inferred fps. |
 
-## Related Pages
+## Related pages
 
 - [Reader Model](reader-model.md)
 - [Files and Videos](files-and-videos.md)

--- a/docs/reading-data/reader-model.md
+++ b/docs/reading-data/reader-model.md
@@ -1,9 +1,9 @@
 ---
-title: "Reader Model"
+title: "Reader model"
 description: "How Refiner readers plan shards and emit rows"
 ---
 
-# Reader Model
+# Reader model
 
 A Refiner reader has two jobs:
 
@@ -13,7 +13,7 @@ A Refiner reader has two jobs:
 That separation is important. Planning should be lightweight enough to run at
 submission time. Reading can do the expensive I/O inside workers.
 
-## Rows And Blocks
+## Rows and blocks
 
 Most user code sees rows:
 
@@ -33,7 +33,7 @@ You usually do not need to choose. Refiner converts blocks to rows when a row
 transform needs them and keeps Arrow tables when vectorized transforms can run
 directly.
 
-## Reader Arguments You See Often
+## Reader arguments you see often
 
 | Argument | Meaning |
 | --- | --- |
@@ -45,7 +45,7 @@ directly.
 
 See [Sharding](sharding.md) for how these options affect worker work.
 
-## Path Inputs
+## Path inputs
 
 Readers accept local paths and fsspec-backed URLs. Refiner commonly uses:
 
@@ -58,7 +58,7 @@ Readers accept local paths and fsspec-backed URLs. Refiner commonly uses:
 
 See [Path Formats](../reference/path-formats.md).
 
-## Related Pages
+## Related pages
 
 - [Sharding](sharding.md)
 - [Episode Rows](../episode-data/episode-rows.md)

--- a/docs/reading-data/sharding.md
+++ b/docs/reading-data/sharding.md
@@ -8,7 +8,7 @@ description: "How Refiner divides source data across workers"
 A shard is a unit of input work. In launched runs, workers claim shards and
 process them independently.
 
-## Why Shards Matter
+## Why shards matter
 
 Shard boundaries affect:
 
@@ -18,7 +18,7 @@ Shard boundaries affect:
 - progress reporting
 - reducer work after writer stages
 
-## Common Shard Strategies
+## Common shard strategies
 
 | Input type | Typical shard strategy |
 | --- | --- |
@@ -28,7 +28,7 @@ Shard boundaries affect:
 | HDF5 demos | Plan files, then emit matched groups. |
 | Zarr replay buffers | Plan row ranges from episode boundaries or leading-axis rows. |
 
-## Tuning Shards
+## Tuning shards
 
 Use `target_shard_bytes` when the reader can estimate byte size:
 
@@ -51,13 +51,13 @@ pipeline = mdr.read_lerobot(
 Do not overfit shard count before measuring. Too few shards leave workers idle;
 too many shards add scheduling and output overhead.
 
-## Shards And Writers
+## Shards and writers
 
 Writers usually write shard-local files first. Some writers add a reducer stage
 to merge or finalize metadata. For example, the LeRobot writer stages per-shard
 chunks and then reduces metadata; see [Writing LeRobot](../writing-data/lerobot.md).
 
-## Related Pages
+## Related pages
 
 - [Reader Model](reader-model.md)
 - [Local Launcher](../running-pipelines/local-launcher.md)

--- a/docs/reading-data/tabular-files.md
+++ b/docs/reading-data/tabular-files.md
@@ -1,9 +1,9 @@
 ---
-title: "Tabular Files"
+title: "Tabular files"
 description: "Read Parquet, JSON, JSONL, and CSV files"
 ---
 
-# Tabular Files
+# Tabular files
 
 Use tabular readers when your input already has row-shaped records.
 
@@ -19,7 +19,7 @@ pipeline = mdr.read_parquet(
 Parquet is the best general-purpose tabular format when you control the data.
 It preserves schema information and works well with vectorized transforms.
 
-## JSON And JSONL
+## JSON and JSONL
 
 ```python
 json_pipeline = mdr.read_json("/data/episodes/*.json")
@@ -54,7 +54,7 @@ pipeline = mdr.read_parquet(
 
 See [Schemas and DTypes](../transforms/schemas-and-dtypes.md).
 
-## Related Pages
+## Related pages
 
 - [Vectorized Transforms](../transforms/vectorized-transforms.md)
 - [Parquet and JSONL Writers](../writing-data/parquet-and-jsonl.md)

--- a/docs/reading-data/tensorflow.md
+++ b/docs/reading-data/tensorflow.md
@@ -14,7 +14,7 @@ uv add "macrodata-refiner[tfds]"
 Use `macrodata-refiner[tensorflow]` if you only need TFRecord files and do not
 need the TensorFlow Datasets catalog.
 
-## TFRecord Files
+## TFRecord files
 
 Use `read_tfrecords(...)` when you already have TFRecord files and know the
 `tf.io` feature spec:
@@ -64,7 +64,7 @@ By default, Refiner adds a `file_path` column with the source TFRecord path. Set
 `file_path_column=None` to omit it. If your parsed features already include the
 same column name, Refiner leaves the parsed value unchanged.
 
-### TFRecord Options
+### TFRecord options
 
 | Option | Default | Meaning |
 | --- | --- | --- |
@@ -81,7 +81,7 @@ same column name, Refiner leaves the parsed value unchanged.
 | `prefetch` | `1` | TensorFlow prefetch depth. Set to `None` to disable prefetching. |
 | `file_path_column` | `"file_path"` | Source file column name. Set to `None` to omit it. Existing parsed feature names are not overwritten. |
 
-## TensorFlow Datasets
+## TensorFlow datasets
 
 Use `read_tfds(...)` for datasets available through TensorFlow Datasets, a
 local TFDS `data_dir`, or prepared TFDS directories. Prepared TFDS directories
@@ -146,7 +146,7 @@ For RLDS-style datasets, `videos` lifts image sequences from nested `steps`
 datasets into lazy `VideoFrameSequence` values and removes those frame arrays
 from the per-step table.
 
-### TFDS Options
+### TFDS options
 
 | Option | Default | Meaning |
 | --- | --- | --- |
@@ -165,7 +165,7 @@ from the per-step table.
 | `videos` | `None` | Video-name to nested dataset frame path mapping, such as `{"front": "steps/observation/image"}`. |
 | `fps` | `30.0` | Frame rate used for `videos`. |
 
-## Performance Trade-Offs
+## Performance trade-offs
 
 - TFRecord files are read through `tf.data.TFRecordDataset`, batched, parsed, and
   converted to Arrow-backed `Tabular` blocks.
@@ -189,7 +189,7 @@ from the per-step table.
 - `num_parallel_calls` and `prefetch` apply to TFRecord parsing. Higher values
   can improve throughput when parsing is CPU-bound, at the cost of more memory.
 
-## Related Pages
+## Related pages
 
 - [Reader Model](reader-model.md)
 - [Sharding](sharding.md)

--- a/docs/reading-data/zarr.md
+++ b/docs/reading-data/zarr.md
@@ -1,13 +1,13 @@
 ---
-title: "Zarr Reader"
+title: "Zarr reader"
 description: "Read Zarr replay buffers and episode ranges"
 ---
 
-# Zarr Reader
+# Zarr reader
 
 Use `read_zarr` for replay buffers stored as Zarr groups or zipped Zarr stores.
 
-## Episode Ranges
+## Episode ranges
 
 Many robotics replay buffers store frame-aligned arrays and cumulative episode
 ends:
@@ -39,7 +39,7 @@ pipeline = (
 With `row_ends`, each emitted row contains one episode range. Refiner never
 splits a row across episode boundaries.
 
-## Leading-Axis Rows
+## Leading-axis rows
 
 For arrays where each leading-axis item is one row:
 
@@ -53,7 +53,7 @@ pipeline = mdr.read_zarr(
 
 Use this for non-episode arrays or precomputed feature tables.
 
-## Selected Arrays And Attributes
+## Selected arrays and attributes
 
 `arrays` and `attrs` can be mappings from output column name to Zarr path:
 
@@ -65,9 +65,8 @@ pipeline = mdr.read_zarr(
 )
 ```
 
-## Related Pages
+## Related pages
 
 - [Converting to Robot Rows](../episode-data/converting-to-robot-rows.md)
 - [Zarr Replay Buffer Example](../examples/formats/zarr-replay-buffer.md)
 - [Writing Zarr](../writing-data/zarr.md)
-

--- a/docs/reference/optional-dependencies.md
+++ b/docs/reference/optional-dependencies.md
@@ -1,9 +1,9 @@
 ---
-title: "Optional Dependencies"
+title: "Optional dependencies"
 description: "Install Refiner extras for specific readers and workflows"
 ---
 
-# Optional Dependencies
+# Optional dependencies
 
 Install extras based on the data and operations you use.
 

--- a/docs/reference/path-formats.md
+++ b/docs/reference/path-formats.md
@@ -1,9 +1,9 @@
 ---
-title: "Path Formats"
+title: "Path formats"
 description: "Path and URL formats accepted by Refiner readers and writers"
 ---
 
-# Path Formats
+# Path formats
 
 Refiner uses fsspec-backed paths for many readers and writers.
 
@@ -16,5 +16,4 @@ Refiner uses fsspec-backed paths for many readers and writers.
 | Other fsspec filesystems | Depends on the installed filesystem package. |
 
 Private remote paths usually require secrets such as `HF_TOKEN` or cloud
-provider credentials. See [Secrets and Environment](../platform/secrets-and-environment.md).
-
+provider credentials. See [Secrets and environment](../platform/secrets-and-environment.md).

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -1,12 +1,12 @@
 ---
-title: "Cloud Launcher"
-description: "Submit Refiner pipelines to Macrodata Cloud"
+title: "Cloud launcher"
+description: "Submit Refiner pipelines to the Macrodata Cloud"
 ---
 
-# Cloud Launcher
+# Cloud launcher
 
-Cloud launch submits a pipeline to Macrodata Cloud, where workers claim shards,
-run transforms, write outputs, and report logs and metrics.
+Cloud launch submits a pipeline to the Macrodata Cloud, where workers claim
+shards, run transforms, write outputs, and report logs and metrics.
 
 ```python
 pipeline.launch_cloud(
@@ -18,7 +18,7 @@ pipeline.launch_cloud(
 )
 ```
 
-## What Gets Submitted
+## What gets submitted
 
 A cloud submission includes:
 
@@ -27,12 +27,12 @@ A cloud submission includes:
 | Pipeline plan | Describes the reader, transforms, writer, and stages. |
 | Code snapshot | Lets workers run the same code you submitted. |
 | Dependency manifest | Helps reproduce the Python environment. |
-| Secrets/env mapping | Supplies credentials without hard-coding them in code. |
+| Secrets/env mapping | Supplies credentials and runtime configuration without hard-coding them in code. |
 
 You can inspect submitted metadata through the platform and CLI. See
 [Manifests](../platform/manifests.md) and [CLI Jobs](../cli/jobs-logs-and-metrics.md).
 
-## Runtime Dependencies
+## Runtime dependencies
 
 Built-in Refiner readers, writers, and operations automatically declare the
 [optional dependency groups](../reference/optional-dependencies.md) they need.
@@ -65,7 +65,7 @@ pipeline.launch_cloud(
 ```
 
 Environment markers are not preserved. Do not include markers in
-`dependencies`; list the package as it should install on Macrodata Cloud.
+`dependencies`; list the package as it should install on the Macrodata Cloud.
 For example, write `uvloop`, not `uvloop; sys_platform != "win32"`.
 
 Finally, if you would like Refiner to try syncing the packages installed in
@@ -94,9 +94,9 @@ pipeline.launch_cloud(
 )
 ```
 
-See [Secrets and Environment](../platform/secrets-and-environment.md).
+See [Secrets and environment](../platform/secrets-and-environment.md).
 
-## Continue From A Prior Job
+## Continue from a prior Job
 
 Use continuation when earlier stages already produced reusable outputs:
 
@@ -110,7 +110,7 @@ pipeline.launch_cloud(
 `"infer"` asks Refiner to find a compatible prior job. Use explicit job IDs when
 you need deterministic behavior.
 
-## Related Pages
+## Related pages
 
 - [Resources, GPUs, and Services](resources-gpus-and-services.md)
 - [Observability](observability.md)

--- a/docs/running-pipelines/in-process-debugging.md
+++ b/docs/running-pipelines/in-process-debugging.md
@@ -1,15 +1,15 @@
 ---
-title: "In-Process Debugging"
+title: "In-process debugging"
 description: "Inspect Refiner pipelines directly in the current Python process"
 ---
 
-# In-Process Debugging
+# In-process debugging
 
 In-process execution is the fastest way to validate a reader, inspect row shape,
 or test a transform. It does not create a cloud job and does not use the local
 launcher worker supervisor.
 
-## Inspect One Row
+## Inspect one row
 
 ```python
 import refiner as mdr
@@ -25,7 +25,7 @@ print(row.to_frame_table().names)
 Use this before writing transforms. It answers the most important question:
 "What keys and semantic properties does my row actually expose?"
 
-## Iterate Lazily
+## Iterate lazily
 
 ```python
 for row in pipeline.iter_rows():
@@ -36,7 +36,7 @@ for row in pipeline.iter_rows():
 `iter_rows()` streams rows from the source through all transforms. It is useful
 for long datasets because it does not materialize the whole pipeline.
 
-## Materialize Small Fixtures
+## Materialize small fixtures
 
 ```python
 rows = pipeline.take(5)
@@ -45,7 +45,7 @@ rows = pipeline.take(5)
 Prefer `take()` over `materialize()` unless the dataset is intentionally tiny.
 `materialize()` computes every output row into memory.
 
-## Debug A Transform
+## Debug a transform
 
 ```python
 def show_shape(row):
@@ -57,7 +57,7 @@ pipeline.map(show_shape).take(3)
 
 Keep debug transforms small and remove them before launching real jobs.
 
-## Sinks In Process
+## Sinks in process
 
 Sinks do not write through in-process inspection methods like `take()` or
 `iter_rows()`. Inspect the pipeline before attaching the sink:
@@ -75,7 +75,7 @@ Attach the writer when you are ready to launch the pipeline:
 pipeline = trimmed.write_lerobot("hf://buckets/acme-robotics/aloha_trimmed")
 ```
 
-## Related Pages
+## Related pages
 
 - [Episode Rows](../episode-data/episode-rows.md)
 - [Row Transforms](../transforms/row-transforms.md)

--- a/docs/running-pipelines/index.md
+++ b/docs/running-pipelines/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Running Pipelines"
-description: "How Refiner pipelines execute locally and on Macrodata Cloud"
+title: "Running pipelines"
+description: "How Refiner pipelines execute locally and on the Macrodata Cloud"
 ---
 
-# Running Pipelines
+# Running pipelines
 
 A Refiner pipeline can be evaluated three ways:
 
@@ -16,7 +16,7 @@ A Refiner pipeline can be evaluated three ways:
 Start with [In-Process Debugging](in-process-debugging.md), then move to
 [Local Launcher](local-launcher.md) or [Cloud Launcher](cloud-launcher.md).
 
-## Execution Terms
+## Execution terms
 
 | Term | Meaning |
 | --- | --- |
@@ -29,11 +29,10 @@ Start with [In-Process Debugging](in-process-debugging.md), then move to
 For input planning details, see [Reader Model](../reading-data/reader-model.md)
 and [Sharding](../reading-data/sharding.md).
 
-## Related Pages
+## Related pages
 
 - [In-Process Debugging](in-process-debugging.md)
 - [Local Launcher](local-launcher.md)
 - [Cloud Launcher](cloud-launcher.md)
 - [Resources, GPUs, and Services](resources-gpus-and-services.md)
 - [Observability](observability.md)
-

--- a/docs/running-pipelines/local-launcher.md
+++ b/docs/running-pipelines/local-launcher.md
@@ -1,12 +1,12 @@
 ---
-title: "Local Launcher"
+title: "Local launcher"
 description: "Run Refiner pipelines with local worker processes"
 ---
 
-# Local Launcher
+# Local launcher
 
 Use the local launcher when you want worker and shard behavior without submitting
-to Macrodata Cloud.
+to the Macrodata Cloud.
 
 ```python
 pipeline.launch_local(
@@ -21,7 +21,7 @@ The local launcher is useful for:
 - checking that a transform is safe across multiple shards
 - debugging resource assumptions before a cloud launch
 
-## Run Directory
+## Run directory
 
 Local runs write run metadata under a local run directory. Pass `rundir` when
 you want a stable location:
@@ -53,7 +53,7 @@ Local GPU assignment controls `CUDA_VISIBLE_DEVICES` for worker processes. Cloud
 GPU scheduling has additional options; see
 [Resources, GPUs, and Services](resources-gpus-and-services.md).
 
-## When To Use Cloud Instead
+## When to use Cloud instead
 
 Use [Cloud Launcher](cloud-launcher.md) when you need:
 

--- a/docs/running-pipelines/observability.md
+++ b/docs/running-pipelines/observability.md
@@ -12,7 +12,7 @@ signals to answer three questions:
 2. Which stage or worker is slow or failing?
 3. Are custom pipeline metrics behaving as expected?
 
-## User Metrics
+## User metrics
 
 Transforms can emit counters, gauges, and histograms:
 
@@ -43,7 +43,7 @@ def transform(row):
     return row
 ```
 
-## CLI Inspection
+## CLI inspection
 
 ```bash
 macrodata jobs list
@@ -55,7 +55,7 @@ macrodata jobs resource-metrics job_123 0
 
 See [CLI Jobs, Logs, and Metrics](../cli/jobs-logs-and-metrics.md).
 
-## Related Pages
+## Related pages
 
 - [Cloud Launcher](cloud-launcher.md)
 - [Platform Jobs and Files](../platform/cloud-jobs-and-files.md)

--- a/docs/running-pipelines/resources-gpus-and-services.md
+++ b/docs/running-pipelines/resources-gpus-and-services.md
@@ -1,14 +1,14 @@
 ---
-title: "Resources, GPUs, and Services"
+title: "Resources, GPUs, and services"
 description: "CPU, memory, GPU, and runtime service configuration for launched Refiner jobs"
 ---
 
-# Resources, GPUs, and Services
+# Resources, GPUs, and services
 
 Resource settings belong on launch calls, not inside transform functions. This
 keeps the pipeline logic portable between local debugging and cloud execution.
 
-## CPU And Memory
+## CPU and memory
 
 ```python
 pipeline.launch_cloud(
@@ -36,7 +36,7 @@ GPU requests apply per worker. If your transform uses a model directly inside
 the worker, make sure the worker count and GPU count match the model loading
 pattern you want.
 
-## Runtime Services
+## Runtime services
 
 Some inference workloads are better served by a runtime service, such as vLLM,
 instead of loading a model inside every transform worker.
@@ -51,7 +51,7 @@ provider = mdr.inference.VLLMProvider(
 When a provider requires a service, Refiner can include that service in the
 cloud runtime plan. See [Providers and vLLM](../inference/inference_providers.md).
 
-## Choosing Worker Count
+## Choosing worker count
 
 | Workload | Worker count guidance |
 | --- | --- |
@@ -60,7 +60,7 @@ cloud runtime plan. See [Providers and vLLM](../inference/inference_providers.md
 | VLM/API calls | Match worker count to provider rate limits and `max_in_flight`. |
 | Local GPU inference | Avoid more workers than available GPUs unless the model can share. |
 
-## Related Pages
+## Related pages
 
 - [Async and Batch Transforms](../transforms/async-and-batch-transforms.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)

--- a/docs/transforms/async-and-batch-transforms.md
+++ b/docs/transforms/async-and-batch-transforms.md
@@ -1,9 +1,9 @@
 ---
-title: "Async and Batch Transforms"
+title: "Async and batch transforms"
 description: "Use map_async and batch_map for concurrent I/O and batched model work"
 ---
 
-# Async And Batch Transforms
+# Async and batch transforms
 
 Use async and batch transforms when a row transform would be too slow one row at
 a time.
@@ -28,7 +28,7 @@ pipeline = pipeline.map_async(
 Use `max_in_flight` to match provider rate limits, memory limits, or open file
 limits.
 
-## Inference Helpers
+## Inference helpers
 
 Most model calls should use Refiner's inference helpers instead of calling an
 API directly:
@@ -61,7 +61,7 @@ pipeline = pipeline.batch_map(add_batch_rank, batch_size=32)
 
 Use this for perception pipelines or model APIs that naturally process batches.
 
-## Order And Backpressure
+## Order and backpressure
 
 | Setting | Effect |
 | --- | --- |
@@ -70,7 +70,7 @@ Use this for perception pipelines or model APIs that naturally process batches.
 | Smaller `max_in_flight` | Lower memory and lower external pressure. |
 | Larger `max_in_flight` | More concurrency, but easier to hit rate limits. |
 
-## Related Pages
+## Related pages
 
 - [Subtask Annotation](../episode-operations/subtask-annotation.md)
 - [Hand Tracking](../episode-operations/hand-tracking.md)

--- a/docs/transforms/expressions.md
+++ b/docs/transforms/expressions.md
@@ -14,7 +14,7 @@ mdr.col("episode_id")
 mdr.lit("train")
 ```
 
-## Boolean Logic
+## Boolean logic
 
 Use `&`, `|`, and `~`. Do not use Python `and` or `or`.
 
@@ -24,7 +24,7 @@ pipeline = pipeline.filter(
 )
 ```
 
-## Conditional Values
+## Conditional values
 
 ```python
 pipeline = pipeline.with_columns(
@@ -32,7 +32,7 @@ pipeline = pipeline.with_columns(
 )
 ```
 
-## Null Handling
+## Null handling
 
 ```python
 pipeline = pipeline.with_columns(
@@ -40,7 +40,7 @@ pipeline = pipeline.with_columns(
 )
 ```
 
-## String And Datetime Helpers
+## String and datetime helpers
 
 Expression objects include namespaces for common string and datetime operations
 when supported by the underlying Arrow execution.
@@ -49,7 +49,7 @@ when supported by the underlying Arrow execution.
 pipeline = pipeline.filter(mdr.col("episode_id").str.contains("pick"))
 ```
 
-## Related Pages
+## Related pages
 
 - [Vectorized Transforms](vectorized-transforms.md)
 - [Schemas and DTypes](schemas-and-dtypes.md)

--- a/docs/transforms/row-transforms.md
+++ b/docs/transforms/row-transforms.md
@@ -1,9 +1,9 @@
 ---
-title: "Row Transforms"
+title: "Row transforms"
 description: "Use map, flat_map, and filters over episode rows"
 ---
 
-# Row Transforms
+# Row transforms
 
 Use row transforms when each episode can be handled independently in Python.
 
@@ -47,7 +47,7 @@ pipeline = pipeline.flat_map(split_by_camera)
 
 Use this when one episode naturally becomes several examples.
 
-## DType Hints
+## DType hints
 
 When a transform creates a column that a writer should treat as an asset or
 media value, pass `dtypes`:
@@ -61,7 +61,7 @@ pipeline = pipeline.map(
 
 See [Schemas and DTypes](schemas-and-dtypes.md).
 
-## Related Pages
+## Related pages
 
 - [Episode Rows](../episode-data/episode-rows.md)
 - [Motion Trimming](../episode-operations/motion-trimming.md)

--- a/docs/transforms/schemas-and-dtypes.md
+++ b/docs/transforms/schemas-and-dtypes.md
@@ -3,13 +3,13 @@ title: "Schemas and DTypes"
 description: "Use dtype metadata for assets, media, and writer schemas"
 ---
 
-# Schemas And DTypes
+# Schemas and DTypes
 
 DTypes attach semantic metadata to columns. This matters most for assets and
 media, where a string or bytes column needs to be treated as a file, image,
 audio, video, or PDF.
 
-## Video Columns
+## Video columns
 
 ```python
 pipeline = mdr.read_parquet(
@@ -28,7 +28,7 @@ pipeline = pipeline.to_robot_rows(
 )
 ```
 
-## Asset Types
+## Asset types
 
 | Helper | Use it for |
 | --- | --- |
@@ -39,7 +39,7 @@ pipeline = pipeline.to_robot_rows(
 | `video_frame_array()` | In-memory RGB frame arrays. |
 | `pdf_path()` / `pdf_bytes()` | PDFs. |
 
-## Transform Output DTypes
+## Transform output DTypes
 
 ```python
 def add_clip(row):
@@ -52,7 +52,7 @@ pipeline = pipeline.map(
 )
 ```
 
-## Related Pages
+## Related pages
 
 - [Files and Videos](../reading-data/files-and-videos.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)

--- a/docs/transforms/vectorized-transforms.md
+++ b/docs/transforms/vectorized-transforms.md
@@ -1,14 +1,14 @@
 ---
-title: "Vectorized Transforms"
+title: "Vectorized transforms"
 description: "Use Arrow-backed columnar transforms in Refiner"
 ---
 
-# Vectorized Transforms
+# Vectorized transforms
 
 Vectorized transforms operate on columns instead of Python row objects. Refiner
 fuses adjacent vectorized operations so data can stay in Arrow tables longer.
 
-## Select, Drop, Rename
+## Select, drop, rename
 
 ```python
 pipeline = (
@@ -19,7 +19,7 @@ pipeline = (
 )
 ```
 
-## Computed Columns
+## Computed columns
 
 ```python
 pipeline = pipeline.with_columns(
@@ -27,7 +27,7 @@ pipeline = pipeline.with_columns(
 )
 ```
 
-## Vectorized Filter
+## Vectorized filter
 
 ```python
 pipeline = pipeline.filter(mdr.col("num_frames") > 30)
@@ -46,7 +46,7 @@ pipeline = pipeline.cast(
 
 Use casts when the storage format cannot fully represent asset/media semantics.
 
-## When Not To Use Vectorized Transforms
+## When not to use vectorized transforms
 
 Use row transforms when you need:
 
@@ -59,7 +59,7 @@ Use row transforms when you need:
 Use vectorized transforms for simple column-level changes before or after row
 operations.
 
-## Related Pages
+## Related pages
 
 - [Expressions](expressions.md)
 - [Schemas and DTypes](schemas-and-dtypes.md)

--- a/docs/writing-data/index.md
+++ b/docs/writing-data/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Writing Data"
+title: "Writing data"
 description: "Write robotics datasets and pipeline outputs from Refiner"
 ---
 
-# Writing Data
+# Writing data
 
 Writers attach a sink to the end of a pipeline. Launched execution runs the
 reader, transforms, and writer stages.
@@ -15,7 +15,7 @@ reader, transforms, and writer stages.
 | [Parquet and JSONL](parquet-and-jsonl.md) | Tabular outputs and logs. |
 | [Media Assets and Reducers](media-assets-and-reducers.md) | Asset uploads, video handling, and reducer stages. |
 
-## Writer Pattern
+## Writer pattern
 
 ```python
 pipeline = (

--- a/docs/writing-data/lerobot.md
+++ b/docs/writing-data/lerobot.md
@@ -1,9 +1,9 @@
 ---
-title: "LeRobot Writer"
+title: "LeRobot writer"
 description: "Write Refiner episode rows as LeRobot datasets"
 ---
 
-# LeRobot Writer
+# LeRobot writer
 
 Use `write_lerobot` to write `LeRobotRow` or generic `RoboticsRow` values as a
 LeRobot dataset.
@@ -16,7 +16,7 @@ pipeline = (
 )
 ```
 
-## Input Requirements
+## Input requirements
 
 Rows must be one of:
 
@@ -30,7 +30,7 @@ Plain rows should be adapted before writing; see
 If a generic `RoboticsRow` has no episode id, the writer generates one from the
 shard id and row position.
 
-## Output Layout
+## Output layout
 
 The writer creates LeRobot-compatible data:
 
@@ -43,7 +43,7 @@ The writer creates LeRobot-compatible data:
 | `meta/info.json` | Dataset metadata. |
 | `meta/stats.json` | Feature statistics after reducer finalization. |
 
-## Video Behavior
+## Video behavior
 
 The writer can remux compatible clipped videos instead of decoding and
 re-encoding them. It transcodes when required by format, clipping, stale stats,
@@ -55,7 +55,7 @@ pipeline.write_lerobot(
 )
 ```
 
-## Performance Knobs
+## Performance knobs
 
 | Option | Use it for |
 | --- | --- |
@@ -67,7 +67,7 @@ pipeline.write_lerobot(
 | `quantile_bins` | Accuracy/cost tradeoff for video stats quantiles. |
 | `force_recompute_video_stats` | Recompute stats even when existing stats could be reused. |
 
-## Related Pages
+## Related pages
 
 - [Metadata, Tasks, and Stats](../episode-data/metadata-tasks-and-stats.md)
 - [Media Assets and Reducers](media-assets-and-reducers.md)

--- a/docs/writing-data/media-assets-and-reducers.md
+++ b/docs/writing-data/media-assets-and-reducers.md
@@ -1,14 +1,14 @@
 ---
-title: "Media Assets and Reducers"
+title: "Media assets and reducers"
 description: "How Refiner writers handle media files, assets, and reducer stages"
 ---
 
-# Media Assets And Reducers
+# Media assets and reducers
 
 Robotics datasets often contain large media values. Refiner distinguishes the
 row value from the asset storage behavior through dtypes and video source APIs.
 
-## Asset Columns
+## Asset columns
 
 Use dtypes to mark media columns:
 
@@ -21,7 +21,7 @@ pipeline = mdr.read_parquet(
 
 Writers can then copy or upload assets instead of treating them as plain strings.
 
-## Missing Asset Policy
+## Missing asset policy
 
 Parquet and JSONL writers support `missing_asset_policy`:
 

--- a/docs/writing-data/parquet-and-jsonl.md
+++ b/docs/writing-data/parquet-and-jsonl.md
@@ -1,9 +1,9 @@
 ---
-title: "Parquet and JSONL Writers"
+title: "Parquet and JSONL writers"
 description: "Write tabular and line-delimited Refiner outputs"
 ---
 
-# Parquet And JSONL Writers
+# Parquet and JSONL writers
 
 Use Parquet for typed tabular output and JSONL for simple line-delimited rows.
 
@@ -26,7 +26,7 @@ pipeline.write_jsonl("/tmp/output-jsonl")
 
 JSONL is useful for logs, model responses, or lightweight inspection output.
 
-## Asset Columns
+## Asset columns
 
 Both writers can upload asset columns:
 

--- a/docs/writing-data/writer-model.md
+++ b/docs/writing-data/writer-model.md
@@ -1,14 +1,14 @@
 ---
-title: "Writer Model"
+title: "Writer model"
 description: "How Refiner writer sinks run and finalize outputs"
 ---
 
-# Writer Model
+# Writer model
 
 A writer is a sink attached to a pipeline. It receives output blocks from
 workers and writes files, media, metadata, or reducer inputs.
 
-## Common Writer Behavior
+## Common writer behavior
 
 | Behavior | Why it matters |
 | --- | --- |
@@ -17,7 +17,7 @@ workers and writes files, media, metadata, or reducer inputs.
 | Asset handling | Media columns can be copied, uploaded, remuxed, or transcoded. |
 | Reducer stage | Some formats need a final merge or metadata pass. |
 
-## Attaching A Writer
+## Attaching a writer
 
 ```python
 pipeline = pipeline.write_parquet("/tmp/output")
@@ -37,7 +37,7 @@ or:
 pipeline.launch_cloud(name="write-cloud", num_workers=16)
 ```
 
-## Related Pages
+## Related pages
 
 - [LeRobot Writer](lerobot.md)
 - [Media Assets and Reducers](media-assets-and-reducers.md)

--- a/docs/writing-data/zarr.md
+++ b/docs/writing-data/zarr.md
@@ -1,9 +1,9 @@
 ---
-title: "Zarr Writer"
+title: "Zarr writer"
 description: "Write episode arrays and replay-buffer-style outputs to Zarr"
 ---
 
-# Zarr Writer
+# Zarr writer
 
 Use `write_zarr` when you want array-oriented output.
 
@@ -34,7 +34,7 @@ pipeline.write_zarr(
 
 Disable this only when you intentionally want per-shard stores.
 
-## Related Pages
+## Related pages
 
 - [Zarr Reader](../reading-data/zarr.md)
 - [Media Assets and Reducers](media-assets-and-reducers.md)


### PR DESCRIPTION
## Summary
- normalize docs headings and nav labels toward sentence case while preserving acronyms and product concepts
- clean billing docs so they avoid backend state names and reflect the current card credit amount
- update quickstart wording around account creation and the Macrodata Cloud
- add a predefined environment variables reference page

## Validation
- git diff --check
- targeted docs string scan for removed billing/quickstart wording
- commit hook: ty