### PR TITLE
chore(examples): use ethz food101 dataset

### DIFF
--- a/examples/inference/anthropic_image_descriptions.py
+++ b/examples/inference/anthropic_image_descriptions.py
@@ -52,7 +52,7 @@ async def describe_image(row, generate_text):
 if __name__ == "__main__":
     (
         mdr.read_hf_dataset(
-            "food101",
+            "ethz/food101",
             split="train",
             columns_to_read=["image", "label"],
             num_shards=1,

--- a/examples/inference/gemini_image_descriptions.py
+++ b/examples/inference/gemini_image_descriptions.py
@@ -57,7 +57,7 @@ async def describe_image(row, generate_text):
 if __name__ == "__main__":
     (
         mdr.read_hf_dataset(
-            "food101",
+            "ethz/food101",
             split="train",
             columns_to_read=["image", "label"],
             num_shards=1,

--- a/examples/inference/inference_endpoint.py
+++ b/examples/inference/inference_endpoint.py
@@ -53,7 +53,7 @@ async def describe_image(row, generate_text):
 if __name__ == "__main__":
     (
         mdr.read_hf_dataset(
-            "food101",
+            "ethz/food101",
             split="train",
             columns_to_read=["image", "label"],
             num_shards=1,

--- a/examples/inference/inference_service.py
+++ b/examples/inference/inference_service.py
@@ -52,7 +52,7 @@ async def describe_image(row, generate_text):
 if __name__ == "__main__":
     (
         mdr.read_hf_dataset(
-            "food101",
+            "ethz/food101",
             split="train",
             columns_to_read=["image", "label"],
             num_shards=1,

--- a/examples/inference/openai_image_descriptions.py
+++ b/examples/inference/openai_image_descriptions.py
@@ -52,7 +52,7 @@ async def describe_image(row, generate_text):
 if __name__ == "__main__":
     (
         mdr.read_hf_dataset(
-            "food101",
+            "ethz/food101",
             split="train",
             columns_to_read=["image", "label"],
             num_shards=1,


### PR DESCRIPTION
## Summary
- update Food101 inference examples to read `ethz/food101`
- keep job names and output paths unchanged

## Verification
- `python3 -m py_compile examples/inference/inference_endpoint.py examples/inference/inference_service.py examples/inference/gemini_image_descriptions.py examples/inference/anthropic_image_descriptions.py examples/inference/openai_image_descriptions.py`