### PR TITLE
[codex] Allow task callbacks to emit flexible results

### DIFF
--- a/docs/examples/cloud/cloud-gpu-job.md
+++ b/docs/examples/cloud/cloud-gpu-job.md
@@ -13,10 +13,9 @@ import refiner as mdr
 from refiner.worker.context import logger
 
 
-def log_nvidia_smi(task_rank: int, num_tasks: int) -> int:
+def log_nvidia_smi(_task_rank: int, _num_tasks: int) -> None:
     logger.info("{}", subprocess.check_output(["nvidia-smi"], text=True).rstrip())
     # Some GPU heavy job (running BERT, ViT or anything you need)
-    return task_rank
 
 
 pipeline = mdr.task(log_nvidia_smi, num_tasks=1)
@@ -29,7 +28,7 @@ pipeline.launch_cloud(
 ```
 
 This example requests one H100 GPU for a single cloud worker and logs the raw output of `nvidia-smi` to the worker logs.
-The scalar return value is emitted as the task row's `result` field.
+Because the callback is side-effect-only, it does not need to return anything.
 
 For real GPU workloads, use `gpu=mdr.GPU(...)` to specify the required GPU type and count based on your model's needs. Increase the number of tasks if you need to improve parallelization.
 

--- a/docs/examples/cloud/cloud-gpu-job.md
+++ b/docs/examples/cloud/cloud-gpu-job.md
@@ -29,6 +29,7 @@ pipeline.launch_cloud(
 ```
 
 This example requests one H100 GPU for a single cloud worker and logs the raw output of `nvidia-smi` to the worker logs.
+The scalar return value is emitted as the task row's `result` field.
 
 For real GPU workloads, use `gpu=mdr.GPU(...)` to specify the required GPU type and count based on your model's needs. Increase the number of tasks if you need to improve parallelization.
 

--- a/examples/gpu/cloud_gpu_job.py
+++ b/examples/gpu/cloud_gpu_job.py
@@ -8,7 +8,7 @@ from refiner.worker.context import logger
 
 def log_nvidia_smi(task_rank: int, num_tasks: int) -> int:
     logger.info("{}", subprocess.check_output(["nvidia-smi"], text=True).rstrip())
-    # Some gpu heavy job (running BERT, ViT or anything you need)
+    # Some GPU heavy job (running BERT, ViT or anything you need)
     return task_rank
 
 

--- a/examples/gpu/cloud_gpu_job.py
+++ b/examples/gpu/cloud_gpu_job.py
@@ -6,10 +6,9 @@ import refiner as mdr
 from refiner.worker.context import logger
 
 
-def log_nvidia_smi(task_rank: int, num_tasks: int) -> int:
+def log_nvidia_smi(_task_rank: int, _num_tasks: int) -> None:
     logger.info("{}", subprocess.check_output(["nvidia-smi"], text=True).rstrip())
     # Some GPU heavy job (running BERT, ViT or anything you need)
-    return task_rank
 
 
 def main() -> None:

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1496,7 +1496,9 @@ def task(
         if isinstance(result, Mapping):
             yield dict(result)
             return
-        if isinstance(result, Iterable) and not isinstance(result, (str, bytes)):
+        if isinstance(result, Iterable) and not isinstance(
+            result, (str, bytes, bytearray, memoryview)
+        ):
             for item in result:
                 if isinstance(item, Row):
                     yield item

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -23,6 +23,7 @@ from refiner.pipeline.steps import (
     FnRowStep,
     FnTableStep,
     MapFn,
+    MapResult,
     RenameStep,
     RefinerStep,
     SelectStep,
@@ -1483,10 +1484,33 @@ def task(
     integer rank in ``range(num_tasks)``. This is useful for jobs that perform
     side effects or generate work without reading an input dataset.
     """
+
+    def apply_task(row: Row) -> Iterator[MapResult]:
+        result = fn(row["task_rank"], num_tasks)
+
+        if result is None:
+            return
+        if isinstance(result, Row):
+            yield result
+            return
+        if isinstance(result, Mapping):
+            yield dict(result)
+            return
+        if isinstance(result, Iterable) and not isinstance(result, (str, bytes)):
+            for item in result:
+                if isinstance(item, Row):
+                    yield item
+                elif isinstance(item, Mapping):
+                    yield dict(item)
+                else:
+                    yield {"result": item}
+            return
+        yield {"result": result}
+
     source = TaskSource(num_tasks=num_tasks)
     return RefinerPipeline(source=source).add_step(
-        FnRowStep(
-            fn=lambda row: fn(row["task_rank"], num_tasks),
+        FnFlatMapStep(
+            fn=apply_task,
             index=1,
             op_name="task",
         )

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -23,7 +23,6 @@ from refiner.pipeline.steps import (
     FnRowStep,
     FnTableStep,
     MapFn,
-    MapResult,
     RenameStep,
     RefinerStep,
     SelectStep,
@@ -50,7 +49,7 @@ from refiner.pipeline.sources.readers.hdf5 import MissingPolicy
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.pipeline.sources.readers.mcap import SyncMethod
 from refiner.pipeline.sources.items import ItemsSource
-from refiner.pipeline.sources.task import TaskSource
+from refiner.pipeline.sources.task import TaskSource, TaskStep
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.datatype import DTypeLike, DTypeMapping
 from refiner.pipeline.data.row import Row
@@ -1484,36 +1483,7 @@ def task(
     integer rank in ``range(num_tasks)``. This is useful for jobs that perform
     side effects or generate work without reading an input dataset.
     """
-
-    def apply_task(row: Row) -> Iterator[MapResult]:
-        result = fn(row["task_rank"], num_tasks)
-
-        if result is None:
-            return
-        if isinstance(result, Row):
-            yield result
-            return
-        if isinstance(result, Mapping):
-            yield dict(result)
-            return
-        if isinstance(result, Iterable) and not isinstance(
-            result, (str, bytes, bytearray, memoryview)
-        ):
-            for item in result:
-                if isinstance(item, Row):
-                    yield item
-                elif isinstance(item, Mapping):
-                    yield dict(item)
-                else:
-                    yield {"result": item}
-            return
-        yield {"result": result}
-
     source = TaskSource(num_tasks=num_tasks)
     return RefinerPipeline(source=source).add_step(
-        FnFlatMapStep(
-            fn=apply_task,
-            index=1,
-            op_name="task",
-        )
+        TaskStep(fn=fn, num_tasks=num_tasks, index=1)
     )

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -22,6 +22,7 @@ from refiner.pipeline.steps import (
     VectorizedSegmentStep,
     WithColumnsStep,
 )
+from refiner.pipeline.sources.task import TaskStep
 from refiner.pipeline.data.datatype import dtype_to_plan
 from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import _redact_captured_text
@@ -156,7 +157,7 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
             "filter",
             _callable_step_args(step.predicate),
         )
-    if isinstance(step, FnFlatMapStep):
+    if isinstance(step, FnFlatMapStep | TaskStep):
         inferred_name = (
             explicit_name
             if explicit_name and explicit_name != "flat_map"

--- a/src/refiner/pipeline/sources/task.py
+++ b/src/refiner/pipeline/sources/task.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
 
 from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
 from refiner.pipeline.sources.base import BaseSource
 from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.steps import FlatMapStep, MapResult
 
 
 class TaskSource(BaseSource):
@@ -36,4 +39,38 @@ class TaskSource(BaseSource):
         return {"num_tasks": self._num_tasks}
 
 
-__all__ = ["TaskSource"]
+@dataclass(frozen=True, slots=True)
+class TaskStep(FlatMapStep):
+    """Apply a task callback and normalize zero, one, or many output rows."""
+
+    fn: Callable[[int, int], Any]
+    num_tasks: int
+    index: int
+    op_name: str | None = "task"
+
+    def apply_row_many(self, row: Row) -> Iterator[MapResult]:
+        result = self.fn(row["task_rank"], self.num_tasks)
+
+        if result is None:
+            return
+        if isinstance(result, Row):
+            yield result
+            return
+        if isinstance(result, Mapping):
+            yield dict(result)
+            return
+        if isinstance(result, Iterable) and not isinstance(
+            result, (str, bytes, bytearray, memoryview)
+        ):
+            for item in result:
+                if isinstance(item, Row):
+                    yield item
+                elif isinstance(item, Mapping):
+                    yield dict(item)
+                else:
+                    yield {"result": item}
+            return
+        yield {"result": result}
+
+
+__all__ = ["TaskSource", "TaskStep"]

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -11,6 +11,7 @@ from refiner.pipeline.steps import (
     FnRowStep,
     FnTableStep,
 )
+from refiner.pipeline.sources.task import TaskStep
 from refiner.services.base import RuntimeServiceSpec
 
 if TYPE_CHECKING:
@@ -49,7 +50,13 @@ def collect_pipeline_services(
     for step in pipeline.pipeline_steps:
         candidates: list[Any] = []
         if isinstance(
-            step, FnRowStep | FnAsyncRowStep | FnBatchStep | FnFlatMapStep | FnTableStep
+            step,
+            FnRowStep
+            | FnAsyncRowStep
+            | FnBatchStep
+            | FnFlatMapStep
+            | TaskStep
+            | FnTableStep,
         ):
             candidates.append(step.fn)
 

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -11,7 +11,6 @@ from refiner.pipeline.steps import (
     FnRowStep,
     FnTableStep,
 )
-from refiner.pipeline.sources.task import TaskStep
 from refiner.services.base import RuntimeServiceSpec
 
 if TYPE_CHECKING:
@@ -51,14 +50,11 @@ def collect_pipeline_services(
         candidates: list[Any] = []
         if isinstance(
             step,
-            FnRowStep
-            | FnAsyncRowStep
-            | FnBatchStep
-            | FnFlatMapStep
-            | TaskStep
-            | FnTableStep,
+            FnRowStep | FnAsyncRowStep | FnBatchStep | FnFlatMapStep | FnTableStep,
         ):
             candidates.append(step.fn)
+        elif (fn := getattr(step, "fn", None)) is not None:
+            candidates.append(fn)
 
         for candidate in candidates:
             builtin = _builtin_description(candidate)

--- a/tests/pipeline/test_pipeline_task.py
+++ b/tests/pipeline/test_pipeline_task.py
@@ -28,6 +28,16 @@ def test_task_wraps_scalar_return_as_result() -> None:
     assert [int(row["result"]) for row in out] == [0, 1, 2]
 
 
+def test_task_treats_binary_buffers_as_scalar_results() -> None:
+    for value in (bytearray(b"ok"), memoryview(b"ok")):
+        pipeline = task(lambda _rank, _world_size, value=value: value, num_tasks=1)
+
+        out = list(pipeline.iter_rows())
+
+        assert len(out) == 1
+        assert out[0]["result"] == value
+
+
 def test_task_allows_no_return_for_side_effect_only_work() -> None:
     seen: list[int] = []
 

--- a/tests/pipeline/test_pipeline_task.py
+++ b/tests/pipeline/test_pipeline_task.py
@@ -19,6 +19,44 @@ def test_task_invokes_fn_with_rank_and_world_size() -> None:
     assert all(int(row["world_size"]) == 4 for row in out)
 
 
+def test_task_wraps_scalar_return_as_result() -> None:
+    pipeline = task(lambda rank, _world_size: rank, num_tasks=3)
+
+    out = list(pipeline.iter_rows())
+
+    assert [int(row["task_rank"]) for row in out] == [0, 1, 2]
+    assert [int(row["result"]) for row in out] == [0, 1, 2]
+
+
+def test_task_allows_no_return_for_side_effect_only_work() -> None:
+    seen: list[int] = []
+
+    def worker_fn(rank: int, _world_size: int) -> None:
+        seen.append(rank)
+
+    pipeline = task(worker_fn, num_tasks=3)
+
+    assert list(pipeline.iter_rows()) == []
+    assert seen == [0, 1, 2]
+
+
+def test_task_allows_yielding_multiple_rows() -> None:
+    def worker_fn(rank: int, world_size: int):
+        yield {"rank": rank, "phase": "start"}
+        yield {"rank": rank, "phase": "done", "world_size": world_size}
+
+    pipeline = task(worker_fn, num_tasks=2)
+
+    out = [row.to_dict() for row in pipeline.iter_rows()]
+
+    assert out == [
+        {"task_rank": 0, "rank": 0, "phase": "start"},
+        {"task_rank": 0, "rank": 0, "phase": "done", "world_size": 2},
+        {"task_rank": 1, "rank": 1, "phase": "start"},
+        {"task_rank": 1, "rank": 1, "phase": "done", "world_size": 2},
+    ]
+
+
 def test_task_compiles_source_and_task_step_plan() -> None:
     pipeline = task(lambda rank, world_size: {"ok": rank < world_size}, num_tasks=3)
     payload = compile_pipeline_plan(pipeline)
@@ -26,6 +64,6 @@ def test_task_compiles_source_and_task_step_plan() -> None:
     assert steps[0]["name"] == "task"
     assert steps[0]["args"]["num_tasks"] == 3
     assert steps[1]["name"] == "task_2"
-    assert steps[1]["type"] == "row_map"
+    assert steps[1]["type"] == "flat_map"
     assert "fn" in steps[1]["args"]
     assert steps[1]["args"]["__meta"]["fn"] == "code"


### PR DESCRIPTION
## Summary

Allow `mdr.task()` callbacks to behave like task-style work units instead of strict row maps.

- switch `task()` from a row-map wrapper to a flat-map wrapper
- support side-effect-only callbacks by emitting zero rows for `None`
- support scalar returns by emitting them as `result`
- support yielded / iterable task outputs as multiple rows
- keep existing `dict` and `Row` return behavior
- document the scalar return behavior in the GPU example docs

## Root Cause

`mdr.task()` was typed as accepting callbacks that return `Any`, and the GPU example returned an `int`, but the implementation passed that value directly through a normal row-map step. Row maps only accept `dict` or `Row`, so scalar task returns failed with `Unsupported map() result type: <class 'int'>`.

## Validation

- `uv run pytest tests/pipeline/test_pipeline_task.py`
- `uv run ruff format --check src/refiner/pipeline/pipeline.py tests/pipeline/test_pipeline_task.py examples/gpu/cloud_gpu_job.py`
- `uv run ruff check src/refiner/pipeline/pipeline.py tests/pipeline/test_pipeline_task.py examples/gpu/cloud_gpu_job.py`
- `uv run ty check src/refiner/pipeline/pipeline.py tests/pipeline/test_pipeline_task.py`
- local `launch_local()` scalar-return smoke completed with `output_rows=1`