### PR TITLE
[codex] Fix inference import cycle

### DIFF
--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -22,7 +22,6 @@ from refiner.pipeline.steps import (
     VectorizedSegmentStep,
     WithColumnsStep,
 )
-from refiner.pipeline.sources.task import TaskStep
 from refiner.pipeline.data.datatype import dtype_to_plan
 from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import _redact_captured_text
@@ -157,6 +156,8 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
             "filter",
             _callable_step_args(step.predicate),
         )
+    from refiner.pipeline.sources.task import TaskStep
+
     if isinstance(step, FnFlatMapStep | TaskStep):
         inferred_name = (
             explicit_name

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_inference_import_does_not_cycle() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import refiner as mdr; mdr.inference"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Fixes a circular import that prevented `mdr.inference` from being imported from a fresh Python process. `planning.py` imported `TaskStep` at module import time, which initialized `refiner.pipeline.sources` and eventually imported robotics built-ins before `planning.describe_builtin` had been defined.

This defers the `TaskStep` import until planning inspects a step, preserving behavior while avoiding the partial-initialization cycle.

## Validation

- `uv run ruff check --force-exclude --fix src/refiner/pipeline/planning.py tests/test_imports.py`
- `uv run ruff format --force-exclude src/refiner/pipeline/planning.py tests/test_imports.py`
- `uv run pytest tests/test_imports.py tests/platform/test_manifest.py -q`
- `uv run ty check --respect-ignore-files`

I also started `uv run pytest -q`; it progressed green through 71% but stopped producing output, so I terminated that run rather than leaving a background process.