### PR TITLE
[codex] Bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.3.3"
+version = "0.3.4"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2055,7 +2055,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bumps `macrodata-refiner` from `0.3.3` to `0.3.4`.

Updated:

- `pyproject.toml` project version
- `uv.lock` editable package version

## Validation

- `uv run python - <<PY ...` confirmed installed package metadata reports `macrodata-refiner 0.3.4`