### PR TITLE
refactor: Extract built-in metadata helpers into a dependency-light module

### DIFF
--- a/src/refiner/inference/generate_text.py
+++ b/src/refiner/inference/generate_text.py
@@ -40,7 +40,7 @@ from refiner.inference.types import (
     ProviderOptions,
 )
 from refiner.pipeline.data.row import Row
-from refiner.pipeline.planning import describe_builtin
+from refiner.pipeline.builtins import describe_builtin
 from refiner.pipeline.steps import MapResult
 
 

--- a/src/refiner/inference/internal/runtime.py
+++ b/src/refiner/inference/internal/runtime.py
@@ -18,13 +18,12 @@ from refiner.inference.providers.openai import (
     _OpenAIResponsesClient,
 )
 from refiner.inference.types import InferenceProvider
+from refiner.pipeline.builtins import _REFINER_BUILTIN_CALL_ATTR
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.steps import MapResult
 from refiner.services import VLLMRuntimeServiceBinding
 from refiner.worker.context import get_active_service_manager
 from refiner.worker.metrics.api import register_gauge
-
-_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
 
 RequestFn: TypeAlias = Callable[[Mapping[str, Any]], Awaitable[Any]]
 MapFn: TypeAlias = Callable[[Row, RequestFn], Awaitable[MapResult] | MapResult]

--- a/src/refiner/pipeline/builtins.py
+++ b/src/refiner/pipeline/builtins.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from refiner.services.base import RuntimeServiceSpec
+
+_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
+
+
+def _builtin_description(fn: Any) -> dict[str, Any] | None:
+    spec = getattr(fn, _REFINER_BUILTIN_CALL_ATTR, None)
+    if not isinstance(spec, dict):
+        return None
+    name = spec.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    args = spec.get("args")
+    if not isinstance(args, dict):
+        return None
+    services = spec.get("services", ())
+    if not isinstance(services, (list, tuple)):
+        return None
+    parsed_services: list[RuntimeServiceSpec] = []
+    for service in services:
+        if not isinstance(service, RuntimeServiceSpec):
+            return None
+        parsed_services.append(service)
+    return {"name": name, "args": args, "services": tuple(parsed_services)}
+
+
+def describe_builtin(
+    name: str, *, refiner_extras: tuple[str, ...] = (), **args: Any
+) -> Any:
+    def _decorate(fn: Any) -> Any:
+        setattr(
+            fn,
+            _REFINER_BUILTIN_CALL_ATTR,
+            {
+                "name": name,
+                "args": args,
+                "services": (),
+                "refiner_extras": refiner_extras,
+            },
+        )
+        return fn
+
+    return _decorate
+
+
+__all__ = [
+    "_REFINER_BUILTIN_CALL_ATTR",
+    "_builtin_description",
+    "describe_builtin",
+]

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -22,10 +22,14 @@ from refiner.pipeline.steps import (
     VectorizedSegmentStep,
     WithColumnsStep,
 )
+from refiner.pipeline.builtins import (
+    _REFINER_BUILTIN_CALL_ATTR,
+    _builtin_description,
+    describe_builtin,
+)
 from refiner.pipeline.data.datatype import dtype_to_plan
 from refiner.pipeline.resources import GPU
 from refiner.platform.manifest import _redact_captured_text
-from refiner.services import RuntimeServiceSpec
 from refiner.services.discovery import (
     collect_pipeline_services,
     runtime_service_specs_to_dicts,
@@ -33,9 +37,6 @@ from refiner.services.discovery import (
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
-
-
-_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
 
 
 @dataclass(frozen=True, slots=True)
@@ -310,46 +311,6 @@ def _callable_source(fn: Any) -> str:
     return repr(fn)
 
 
-def _builtin_description(fn: Any) -> dict[str, Any] | None:
-    spec = getattr(fn, _REFINER_BUILTIN_CALL_ATTR, None)
-    if not isinstance(spec, dict):
-        return None
-    name = spec.get("name")
-    if not isinstance(name, str) or not name:
-        return None
-    args = spec.get("args")
-    if not isinstance(args, dict):
-        return None
-    services = spec.get("services", ())
-    if not isinstance(services, (list, tuple)):
-        return None
-    parsed_services: list[RuntimeServiceSpec] = []
-    for service in services:
-        if not isinstance(service, RuntimeServiceSpec):
-            return None
-        parsed_services.append(service)
-    return {"name": name, "args": args, "services": tuple(parsed_services)}
-
-
-def describe_builtin(
-    name: str, *, refiner_extras: tuple[str, ...] = (), **args: Any
-) -> Any:
-    def _decorate(fn: Any) -> Any:
-        setattr(
-            fn,
-            _REFINER_BUILTIN_CALL_ATTR,
-            {
-                "name": name,
-                "args": args,
-                "services": (),
-                "refiner_extras": refiner_extras,
-            },
-        )
-        return fn
-
-    return _decorate
-
-
 def _step_payload(
     *,
     name: str,
@@ -551,9 +512,11 @@ def compile_pipeline_plan(
 
 
 __all__ = [
+    "_REFINER_BUILTIN_CALL_ATTR",
     "PlannedStage",
     "StageComputeRequirements",
     "compile_pipeline_plan",
     "compile_planned_stages",
+    "describe_builtin",
     "plan_pipeline_stages",
 ]

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -18,10 +18,10 @@ if TYPE_CHECKING:
     from refiner.pipeline.planning import PlannedStage
 
 from packaging.requirements import InvalidRequirement, Requirement
+from refiner.pipeline.builtins import _REFINER_BUILTIN_CALL_ATTR
 
 _REDACTION_PLACEHOLDER = "REDACTED_SECRET"
 _NORMALIZED_DEPENDENCY_SEPARATOR_PATTERN = re.compile(r"[-_.]+")
-_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
 
 
 def _redact_captured_text(text: str, *, secret_values: Sequence[str]) -> str:

--- a/src/refiner/robotics/hand_tracking.py
+++ b/src/refiner/robotics/hand_tracking.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from refiner.execution.asyncio.runtime import submit
 from refiner.pipeline.data.row import Row
-from refiner.pipeline.planning import describe_builtin
+from refiner.pipeline.builtins import describe_builtin
 from refiner.pipeline.steps import BatchFn
 from refiner.robotics.row import RoboticsRow
 from refiner.utils import check_required_dependencies

--- a/src/refiner/robotics/motion.py
+++ b/src/refiner/robotics/motion.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
-from refiner.pipeline.planning import describe_builtin
+from refiner.pipeline.builtins import describe_builtin
 from refiner.robotics.row import RoboticsRow
 
 

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+from refiner.pipeline.builtins import _builtin_description
 from refiner.pipeline.steps import (
     FnAsyncRowStep,
     FnBatchStep,
@@ -15,30 +16,6 @@ from refiner.services.base import RuntimeServiceSpec
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
-
-
-_REFINER_BUILTIN_CALL_ATTR = "__refiner_builtin_call__"
-
-
-def _builtin_description(fn: Any) -> dict[str, Any] | None:
-    spec = getattr(fn, _REFINER_BUILTIN_CALL_ATTR, None)
-    if not isinstance(spec, dict):
-        return None
-    name = spec.get("name")
-    if not isinstance(name, str) or not name:
-        return None
-    args = spec.get("args")
-    if not isinstance(args, dict):
-        return None
-    services = spec.get("services", ())
-    if not isinstance(services, (list, tuple)):
-        return None
-    parsed_services: list[RuntimeServiceSpec] = []
-    for service in services:
-        if not isinstance(service, RuntimeServiceSpec):
-            return None
-        parsed_services.append(service)
-    return {"name": name, "args": args, "services": tuple(parsed_services)}
 
 
 def collect_pipeline_services(

--- a/tests/pipeline/test_planning.py
+++ b/tests/pipeline/test_planning.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from collections.abc import Iterator
 
 import refiner as rf
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner import col
+from refiner.pipeline.builtins import (
+    _REFINER_BUILTIN_CALL_ATTR,
+    _builtin_description,
+    describe_builtin,
+)
 from refiner.pipeline import RefinerPipeline, from_items
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.pipeline.sinks.base import BaseSink
 from refiner.pipeline.planning import (
+    _REFINER_BUILTIN_CALL_ATTR as PLANNING_REFINER_BUILTIN_CALL_ATTR,
     _extract_lambda_source,
     compile_pipeline_plan,
+    describe_builtin as planning_describe_builtin,
     plan_pipeline_stages,
 )
 from refiner.robotics import motion_trim
@@ -39,6 +48,45 @@ class UndescribedSink(BaseSink):
     def write_block(self, block):
         del block
         return {}, 0
+
+
+def test_import_refiner_inference_in_fresh_interpreter() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import refiner as mdr; mdr.inference"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_describe_builtin_records_centralized_metadata() -> None:
+    @describe_builtin(
+        "unit.test",
+        refiner_extras=("hand_tracking",),
+        value=42,
+    )
+    def _fn(row: Row) -> Row:
+        return row
+
+    assert getattr(_fn, _REFINER_BUILTIN_CALL_ATTR) == {
+        "name": "unit.test",
+        "args": {"value": 42},
+        "services": (),
+        "refiner_extras": ("hand_tracking",),
+    }
+    assert _builtin_description(_fn) == {
+        "name": "unit.test",
+        "args": {"value": 42},
+        "services": (),
+    }
+
+
+def test_planning_reexports_builtin_metadata_helpers() -> None:
+    assert planning_describe_builtin is describe_builtin
+    assert PLANNING_REFINER_BUILTIN_CALL_ATTR == _REFINER_BUILTIN_CALL_ATTR
+    assert _REFINER_BUILTIN_CALL_ATTR == "__refiner_builtin_call__"
 
 
 def _score_filter_lambda():


### PR DESCRIPTION
## Summary
PR #214 hotfixed an import cycle (mdr.inference -> ... -> refiner.robotics.motion -> refiner.pipeline.planning.describe_builtin) by deferring an import, but the underlying smell remains: inference and robotics built-ins import describe_builtin from the heavyweight refiner.pipeline.planning module just to tag a callable as a built-in.

## Changes
Create src/refiner/pipeline/builtins.py owning _REFINER_BUILTIN_CALL_ATTR, describe_builtin, and the _builtin_description helper (currently planning.py lines 38, 313-352). Update the three describe_builtin importers (robotics/motion.py:11, robotics/hand_tracking.py:10, inference/generate_text.py:43) to import from refiner.pipeline.builtins, and replace the duplicated attr-string literals in inference/internal/runtime.py:27, services/discovery.py:20, and platform/manifest.py:24 with an import of the centralized constant.

Fixes #215
