### PR TITLE
feat: Add limit option to read_lerobot for smoke jobs

### DIFF
--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1306,6 +1306,7 @@ def read_lerobot(
     num_shards: int | None = None,
     split_row_groups: bool = True,
     skip_malformed_rows: bool = False,
+    limit: int | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline with an episode-granular LeRobot reader source.
 
@@ -1316,6 +1317,9 @@ def read_lerobot(
     unchanged. By default, malformed episode rows whose declared frame count
     does not match loaded frames raise an error; `skip_malformed_rows=True`
     skips them with a warning and metric.
+
+    For smoke jobs, use `mdr.read_lerobot(path, limit=1)` to emit only the
+    first episode before downstream transforms run.
     """
     return RefinerPipeline(
         source=LeRobotEpisodeReader(
@@ -1326,6 +1330,7 @@ def read_lerobot(
             num_shards=num_shards,
             split_row_groups=split_row_groups,
             skip_malformed_rows=skip_malformed_rows,
+            limit=limit,
         )
     )
 

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -57,12 +57,15 @@ class LeRobotEpisodeReader(BaseSource):
         arrow_batch_size: int = 65536,
         split_row_groups: bool = True,
         skip_malformed_rows: bool = False,
+        limit: int | None = None,
     ) -> None:
         """Create a LeRobot episode reader over one or more dataset roots.
 
         The shard-planning arguments apply to the episode parquet files under
         each dataset root's `meta/episodes` directory.
         """
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be >= 0")
         self._root_fileset = DataFileSet.resolve(
             inputs,
             fs=fs,
@@ -81,26 +84,50 @@ class LeRobotEpisodeReader(BaseSource):
         self._last_frame_table: tuple[tuple[int, Any, Any], pa.Table] | None = None
         self.skip_malformed_rows = skip_malformed_rows
         self._warned_malformed_row = False
+        self._limit = limit
+        self._emitted_rows = 0
 
     def describe(self) -> dict[str, Any]:
         inputs = [entry.abs_path() for entry in self._root_fileset.entries]
-        return {"path": ", ".join(inputs), "inputs": inputs}
+        description: dict[str, Any] = {"path": ", ".join(inputs), "inputs": inputs}
+        if self._limit is not None:
+            description["limit"] = self._limit
+        return description
 
     def list_shards(self) -> list[Shard]:
+        if self._limit == 0:
+            return []
         return self._parquet_reader().list_shards()
+
+    def read(self) -> Iterator[SourceUnit]:
+        self._emitted_rows = 0
+        yield from super().read()
 
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         """Read one planned episode shard and emit `LeRobotTabular` blocks."""
+        if self._remaining_limit() == 0:
+            return
         descriptor = shard.descriptor
         assert isinstance(descriptor, FilePartsDescriptor)
         metadata, remaps = self._metadata_bundle
         for part in descriptor.parts:
+            if self._remaining_limit() == 0:
+                return
             part_shard = Shard.from_file_parts((part,))
             for batch in self._parquet_reader().read_shard(part_shard):
+                remaining = self._remaining_limit()
+                if remaining == 0:
+                    return
                 if not isinstance(batch, Tabular):
                     raise TypeError(
                         "LeRobotEpisodeReader requires Tabular batches from ParquetReader"
                     )
+                if (
+                    remaining is not None
+                    and not self.skip_malformed_rows
+                    and batch.num_rows > remaining
+                ):
+                    batch = batch.with_table(batch.table.slice(0, remaining))
 
                 root = self.roots[part.source_index]
                 metadata_for_source = metadata[part.source_index]
@@ -163,6 +190,14 @@ class LeRobotEpisodeReader(BaseSource):
                     if batch.num_rows == 0:
                         continue
 
+                remaining = self._remaining_limit()
+                if remaining == 0:
+                    return
+                if remaining is not None and batch.num_rows > remaining:
+                    batch = batch.with_table(batch.table.slice(0, remaining))
+                    frames_by_row = frames_by_row[:remaining]
+
+                self._emitted_rows += batch.num_rows
                 yield LeRobotTabular(
                     batch,
                     metadata_by_row=(metadata_for_source,) * batch.num_rows,
@@ -197,6 +232,11 @@ class LeRobotEpisodeReader(BaseSource):
 
     def _io_refiner_extras(self) -> tuple[str, ...]:
         return self._root_fileset.required_refiner_extras()
+
+    def _remaining_limit(self) -> int | None:
+        if self._limit is None:
+            return None
+        return max(0, self._limit - self._emitted_rows)
 
     @cached_property
     def _metadata_bundle(

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -12,7 +12,7 @@ from typing import cast
 import refiner as mdr
 from refiner.io import DataFolder
 from refiner.pipeline.data.row import DictRow
-from refiner.video import VideoFile
+from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.robotics.lerobot_format import (
@@ -25,6 +25,7 @@ from refiner.robotics.lerobot_format import (
     LeRobotVideoInfo,
     remap_task_index_table,
 )
+from refiner.video import VideoFile
 
 
 def _write_parquet(path: Path, rows: list[dict]) -> None:
@@ -156,6 +157,67 @@ def _build_sample_dataset(
     )
 
 
+def _build_multi_part_sample_dataset(root: Path) -> None:
+    _build_sample_dataset(root)
+    _write_parquet(
+        root / "meta" / "episodes" / "part-000.parquet",
+        [
+            {
+                "episode_index": episode_index,
+                "length": 2,
+                "dataset_from_index": episode_index * 2,
+                "dataset_to_index": episode_index * 2 + 2,
+                "data/chunk_index": 0,
+                "data/file_index": 0,
+                "meta/episodes/chunk_index": 0,
+                "meta/episodes/file_index": 0,
+                "stats/observation.state/min": [-999.0],
+                "tasks": ["pick" if episode_index % 2 == 0 else "place"],
+                "videos/observation.images.main/chunk_index": 0,
+                "videos/observation.images.main/file_index": episode_index,
+                "videos/observation.images.main/from_timestamp": float(episode_index),
+                "videos/observation.images.main/to_timestamp": float(episode_index + 1),
+            }
+            for episode_index in range(2)
+        ],
+    )
+    _write_parquet(
+        root / "meta" / "episodes" / "part-001.parquet",
+        [
+            {
+                "episode_index": episode_index,
+                "length": 2,
+                "dataset_from_index": episode_index * 2,
+                "dataset_to_index": episode_index * 2 + 2,
+                "data/chunk_index": 0,
+                "data/file_index": 0,
+                "meta/episodes/chunk_index": 0,
+                "meta/episodes/file_index": 1,
+                "stats/observation.state/min": [-999.0],
+                "tasks": ["pick" if episode_index % 2 == 0 else "place"],
+                "videos/observation.images.main/chunk_index": 0,
+                "videos/observation.images.main/file_index": episode_index,
+                "videos/observation.images.main/from_timestamp": float(episode_index),
+                "videos/observation.images.main/to_timestamp": float(episode_index + 1),
+            }
+            for episode_index in range(2, 4)
+        ],
+    )
+    _write_parquet(
+        root / "data" / "chunk-000" / "file-000.parquet",
+        [
+            {
+                "index": index,
+                "episode_index": index // 2,
+                "frame_index": index % 2,
+                "timestamp": float(index) / 10.0,
+                "task_index": (index // 2) % 2,
+            }
+            for index in range(8)
+        ],
+    )
+
+
 def test_lerobot_reader_emits_episode_rows(tmp_path: Path) -> None:
     root = tmp_path / "lerobot"
     _build_sample_dataset(root)
@@ -188,6 +250,86 @@ def test_lerobot_reader_emits_episode_rows(tmp_path: Path) -> None:
     assert video.uri.endswith("/videos/observation.images.main/chunk-000/file-000.mp4")
     assert video.from_timestamp_s == 0.0
     assert video.to_timestamp_s == 1.0
+
+
+def test_read_lerobot_limit_emits_first_row_with_aligned_frames(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = mdr.read_lerobot(str(root), limit=1).materialize()
+
+    assert len(rows) == 1
+    row = cast(LeRobotRow, rows[0])
+    assert int(row["episode_index"]) == 0
+    frame_rows = row["frames"].to_rows()
+    assert [int(frame["episode_index"]) for frame in frame_rows] == [0, 0]
+    assert [int(frame["index"]) for frame in frame_rows] == [0, 1]
+
+
+def test_read_lerobot_limit_larger_than_dataset_returns_all_rows(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = mdr.read_lerobot(str(root), limit=10).materialize()
+
+    assert [int(row["episode_index"]) for row in rows] == [0, 1]
+
+
+def test_read_lerobot_limit_none_preserves_full_scan(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    rows = mdr.read_lerobot(str(root), limit=None).materialize()
+
+    assert [int(row["episode_index"]) for row in rows] == [0, 1]
+
+
+def test_read_lerobot_limit_zero_yields_no_rows(tmp_path: Path) -> None:
+    root = tmp_path / "lerobot"
+    _build_sample_dataset(root)
+
+    assert mdr.read_lerobot(str(root), limit=0).materialize() == []
+
+
+def test_lerobot_reader_limit_spans_parts_and_truncates_partial_block(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "lerobot"
+    _build_multi_part_sample_dataset(root)
+
+    reader = LeRobotEpisodeReader(str(root), limit=3, arrow_batch_size=2)
+    shards = [
+        Shard.from_file_parts(
+            (
+                FilePart(
+                    path=str(root / "meta" / "episodes" / filename),
+                    start=0,
+                    end=-1,
+                ),
+            ),
+            global_ordinal=idx,
+        )
+        for idx, filename in enumerate(("part-000.parquet", "part-001.parquet"))
+    ]
+    blocks = [
+        block
+        for shard in shards
+        for block in reader.read_shard(shard)
+        if isinstance(block, Tabular)
+    ]
+
+    assert [block.num_rows for block in blocks] == [2, 1]
+    rows = [cast(LeRobotRow, row) for block in blocks for row in block.to_rows()]
+    assert [int(row["episode_index"]) for row in rows] == [0, 1, 2]
+    assert [int(frame["episode_index"]) for frame in rows[2]["frames"].to_rows()] == [
+        2,
+        2,
+    ]
+    assert [int(frame["index"]) for frame in rows[2]["frames"].to_rows()] == [4, 5]
 
 
 def test_lerobot_reader_raises_on_malformed_frame_count(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
For cloud/dev smoke jobs there is no cheap way to read only the first few LeRobot samples without dataset-specific filters or predicates. The requested API is mdr.read_lerobot(path, limit=1), emitting at most the first `limit` rows/samples at the reader level before downstream transforms run.

## Changes
Add a `limit: int | None = None` keyword to read_lerobot in pipeline.py (line 1300) and thread it into LeRobotEpisodeReader.__init__ in sources/readers/lerobot.py (line 49), storing self._limit. In read_shard (line 92), maintain a running emitted-row counter and stop yielding LeRobotTabular blocks once `limit` is reached, truncating the final block (table plus its aligned frames_by_row tuple) so side data stays consistent.

Fixes #142
