### PR TITLE
[codex] defer hand tracking helper imports

### DIFF
--- a/docs/examples/annotations/hand-tracking.md
+++ b/docs/examples/annotations/hand-tracking.md
@@ -17,7 +17,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from egovision.pipelines import to_joint_actions, to_mano_actions
 import refiner as mdr
 
 INPUT_DATASET = "toloka/HomER"
@@ -27,6 +26,8 @@ OUTPUT_DATASET = f"{OUTPUT_ROOT}/{RUN_ID}"
 
 
 def hand_tracking_annotation(row: Any) -> dict[str, Any]:
+    from egovision.pipelines import to_joint_actions, to_mano_actions
+
     hand_tracking = row["hand_tracking"]
     return {
         "video_id": row["video_id"],

--- a/examples/hand_tracking.py
+++ b/examples/hand_tracking.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from egovision.pipelines import to_joint_actions, to_mano_actions  # type: ignore[unresolved-import]
 import refiner as mdr
 
 INPUT_DATASET = "toloka/HomER"
@@ -13,6 +12,8 @@ OUTPUT_DATASET = f"{OUTPUT_ROOT}/{RUN_ID}"
 
 
 def hand_tracking_annotation(row: Any) -> dict[str, Any]:
+    from egovision.pipelines import to_joint_actions, to_mano_actions  # type: ignore[unresolved-import]
+
     hand_tracking = row["hand_tracking"]
     return {
         "video_id": row["video_id"],


### PR DESCRIPTION
## Summary

Defer the `egovision.pipelines` helper import in the hand-tracking example until `hand_tracking_annotation` runs on the worker.

This keeps `macrodata run examples/hand_tracking.py` from failing during local submission when the submitter does not have the heavy `ego-vision` dependency installed locally. The cloud worker still installs the required `hand_tracking` extra because `mdr.robotics.track_hands(...)` declares it in the pipeline manifest.

The docs example now matches the runnable script.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" git commit -m "defer hand tracking helper imports"` ran pre-commit hooks: Ruff, Ruff format, Ty
- `uv run pytest tests/platform/test_manifest.py`
- Launched the example after adding `HF_TOKEN` to Macrodata secrets: https://macrodata.co/jobs/aaaaaa/019edbb5-c125-7680-9987-58d1e5b44fca

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR defers the `egovision.pipelines` import in the hand-tracking example from module scope into the `hand_tracking_annotation` function body, preventing an `ImportError` when running `macrodata run examples/hand_tracking.py` on a machine that does not have the optional `ego-vision` dependency installed locally. The docs code block is also updated to stay in sync with the runnable script.

- **`examples/hand_tracking.py`**: `from egovision.pipelines import ...` moved inside `hand_tracking_annotation`; the `# type: ignore[unresolved-import]` suppression is preserved on the deferred import line.
- **`docs/examples/annotations/hand-tracking.md`**: The embedded code block mirrors the same deferred-import pattern (no type-ignore comment needed in docs).

</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal, focused import deferral with no logic changes.

The only change is moving the `egovision.pipelines` import from module scope into the function body. Python caches imports in `sys.modules` after the first call, so there is no per-row overhead. The docs example is kept in sync. No logic, interfaces, or data flow are altered.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/hand_tracking.py | Moves `egovision.pipelines` import from module-level to inside `hand_tracking_annotation`; Python's module cache means no runtime overhead on repeated calls. |
| docs/examples/annotations/hand-tracking.md | Docs code block updated to match the runnable script; deferred import is now consistent between the two. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Local as Local Machine
    participant Worker as Cloud Worker

    Local->>Local: macrodata run examples/hand_tracking.py
    Note over Local: module-level import of egovision no longer attempted here
    Local->>Worker: serialise + submit pipeline
    Worker->>Worker: install hand_tracking extra (ego-vision)
    Worker->>Worker: execute hand_tracking_annotation(row)
    Worker->>Worker: from egovision.pipelines import ... (deferred import, resolved here)
    Worker->>Worker: to_mano_actions / to_joint_actions
    Worker-->>Local: job result / JSONL output
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Local as Local Machine
    participant Worker as Cloud Worker

    Local->>Local: macrodata run examples/hand_tracking.py
    Note over Local: module-level import of egovision no longer attempted here
    Local->>Worker: serialise + submit pipeline
    Worker->>Worker: install hand_tracking extra (ego-vision)
    Worker->>Worker: execute hand_tracking_annotation(row)
    Worker->>Worker: from egovision.pipelines import ... (deferred import, resolved here)
    Worker->>Worker: to_mano_actions / to_joint_actions
    Worker-->>Local: job result / JSONL output
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["defer hand tracking helper imports"](https://github.com/macrodata-labs/refiner/commit/e1402c3d9f583e18cc6889b0d8aa2b727d88f26c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38461238)</sub>

<!-- /greptile_comment -->