### PR TITLE
[codex] bump refiner version to 0.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.3.6"
+version = "0.3.7"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2055,7 +2055,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump `macrodata-refiner` from `0.3.6` to `0.3.7` in `pyproject.toml`.
- Keep the editable package entry in `uv.lock` in sync.

## Validation
- Commit hook ran Ruff, which skipped because no Python files changed.
- Commit hook ran `ty check --respect-ignore-files`, which passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the package version metadata. The main changes are:

- `pyproject.toml` now declares `macrodata-refiner` version `0.3.7`.
- `uv.lock` keeps the editable package entry in sync at `0.3.7`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Updates the static project version from `0.3.6` to `0.3.7`. |
| uv.lock | Updates the editable `macrodata-refiner` package version to match `pyproject.toml`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["bump refiner version to 0.3.7"](https://github.com/macrodata-labs/refiner/commit/ff817b932ba0bda44493b6245a89ce0e223f3327) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41332907)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/macrodata/github/macrodata-labs/refiner/-/custom-context?memory=e7c4c38a-45da-4cff-adde-c5bea17aff5b))

<!-- /greptile_comment -->