### PR TITLE
Fix subtask annotation on multi-episode-per-file (LeRobot v3) videos: clip-relative frame timestamps

### DIFF
--- a/src/refiner/video/decode.py
+++ b/src/refiner/video/decode.py
@@ -119,14 +119,17 @@ async def iter_encoded_frames(
             seek=True,
         )
         for index, frame in enumerate(frames):
-            # Report timestamps relative to the clip start so sub-clips (a LeRobot
-            # v3 episode inside a packed video file) begin at 0.
+            # Rebase pts/timestamp_s to the clip start so sub-clips begin at 0,
+            # clamping to non-negative for frames yielded just before clip_from.
             timestamp_s = _frame_timestamp_s(frame)
             if timestamp_s is not None:
-                timestamp_s -= clip_from
+                timestamp_s = max(0.0, timestamp_s - clip_from)
+            pts = None if frame.pts is None else int(frame.pts)
+            if pts is not None and frame.time_base is not None:
+                pts = max(0, pts - round(clip_from / float(frame.time_base)))
             yield DecodedVideoFrame(
                 index=index,
-                pts=None if frame.pts is None else int(frame.pts),
+                pts=pts,
                 timestamp_s=timestamp_s,
                 width=int(frame.width),
                 height=int(frame.height),

--- a/src/refiner/video/decode.py
+++ b/src/refiner/video/decode.py
@@ -110,18 +110,24 @@ async def iter_encoded_frames(
 ) -> AsyncIterator[DecodedVideoFrame]:
     prepared = await prepare_video_source(video=video)
     try:
+        clip_from = video_from_timestamp_s(prepared.video)
         frames = _iter_selected_frames(
             container=prepared.container,
             stream=prepared.stream,
-            clip_from=video_from_timestamp_s(prepared.video),
+            clip_from=clip_from,
             clip_to=video_to_timestamp_s(prepared.video),
             seek=True,
         )
         for index, frame in enumerate(frames):
+            # Report timestamps relative to the clip start so sub-clips (a LeRobot
+            # v3 episode inside a packed video file) begin at 0.
+            timestamp_s = _frame_timestamp_s(frame)
+            if timestamp_s is not None:
+                timestamp_s -= clip_from
             yield DecodedVideoFrame(
                 index=index,
                 pts=None if frame.pts is None else int(frame.pts),
-                timestamp_s=_frame_timestamp_s(frame),
+                timestamp_s=timestamp_s,
                 width=int(frame.width),
                 height=int(frame.height),
                 frame=frame,

--- a/tests/test_video_decode.py
+++ b/tests/test_video_decode.py
@@ -66,6 +66,10 @@ def test_iter_frames_respects_clip_bounds(tmp_path) -> None:
 
     assert [frame.index for frame in frames] == [0, 1, 2]
     assert [frame.timestamp_s for frame in frames] == pytest.approx([0.0, 0.2, 0.4])
+    # pts is rebased to the clip start too, in sync with timestamp_s.
+    assert [frame.pts for frame in frames] == [0, 2048, 4096]
+    assert all(frame.pts >= 0 for frame in frames)
+    assert all(frame.timestamp_s >= 0.0 for frame in frames)
 
 
 def test_video_frame_array_clip_returns_frame_view() -> None:

--- a/tests/test_video_decode.py
+++ b/tests/test_video_decode.py
@@ -65,7 +65,7 @@ def test_iter_frames_respects_clip_bounds(tmp_path) -> None:
     frames = asyncio.run(_collect_frames(video))
 
     assert [frame.index for frame in frames] == [0, 1, 2]
-    assert [frame.timestamp_s for frame in frames] == [0.2, 0.4, 0.6]
+    assert [frame.timestamp_s for frame in frames] == pytest.approx([0.0, 0.2, 0.4])
 
 
 def test_video_frame_array_clip_returns_frame_view() -> None:


### PR DESCRIPTION
## Behavior
When a `VideoFile` is decoded with a clip window (`from_timestamp_s` /
`to_timestamp_s`), `iter_encoded_frames` returns timestamps relative to the
**whole video file**, not to the clip.

This is what `test_iter_frames_respects_clip_bounds` asserts today: a clip
starting at `from_timestamp_s=0.2` yields frame timestamps `[0.2, 0.4, 0.6]`
instead of `[0.0, 0.2, 0.4]`.

```python
def test_iter_frames_respects_clip_bounds(tmp_path) -> None:
    path = tmp_path / "video.mp4"
    _write_video(path, num_frames=5, fps=5)
    video = mdr.video.VideoFile(
        DataFile.resolve(path),
        from_timestamp_s=0.2,
        to_timestamp_s=0.7,
    )

    frames = asyncio.run(_collect_frames(video))

    assert [frame.index for frame in frames] == [0, 1, 2]
    assert [frame.timestamp_s for frame in frames] == [0.2, 0.4, 0.6]
```

## Impact
A LeRobot **v3** dataset bundles multiple episodes into one video file, so each
episode is a clip with `from_timestamp > 0`. With the current behavior, decoding
an episode returns **video-wide timestamps, not episode timestamps**.

`robotics.subtask_annotation` relies on episode-relative time, so on v3 datasets
it produces segments on the video clock (which don't match the episode's
`timestamp` column) — dropping segments for every episode except the first one
in each video file.

## Fix
Rebase yielded timestamps to the clip start in `iter_encoded_frames` (subtract
`clip_from` once). `_frame_timestamp_s` stays absolute. No-op for unclipped videos
(`clip_from == 0`), and brings `VideoFile` in line with the in-memory sources.

Updated `test_iter_frames_respects_clip_bounds` to expect `[0.0, 0.2, 0.4]`.

## Question

Is this behavior expected? That a segmented video would return absolute timestamp instead of relative timestamps?