### PR TITLE
Add automatic worker sizing

### DIFF
--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -83,7 +83,7 @@ Common launch settings:
 | Setting | Meaning |
 | --- | --- |
 | `name` | Display name in [Jobs](/jobs). |
-| `num_workers` | Number of workers that claim shards. |
+| `num_workers` | Number of workers that claim shards, or `"auto"` for one worker per planned shard. |
 | `cpus_per_worker` | CPU allocation per worker. |
 | `mem_mb_per_worker` | Memory allocation per worker. |
 | `gpu` | GPU type/count per worker. |

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -24,6 +24,21 @@ pipeline.launch_cloud(
 )
 ```
 
+Pass `num_workers="auto"` to request one worker per planned shard. Cloud
+resource and workspace limits still apply:
+
+```python
+pipeline.launch_cloud(
+    name="aloha-trim",
+    num_workers="auto",
+)
+```
+
+Cloud auto-sizing plans shards on the submission machine before uploading the
+pipeline. The submitting environment therefore needs enough access to list the
+source shards. Use an explicit integer when source metadata is accessible only
+inside the cloud runtime.
+
 ## What gets submitted
 
 A cloud submission includes:

--- a/docs/running-pipelines/local-launcher.md
+++ b/docs/running-pipelines/local-launcher.md
@@ -15,6 +15,20 @@ pipeline.launch_local(
 )
 ```
 
+Pass `num_workers="auto"` to use one worker per planned shard, capped by the
+CPU and GPU capacity visible on the local machine:
+
+```python
+pipeline.launch_local(
+    name="debug-local",
+    num_workers="auto",
+)
+```
+
+An explicit integer remains useful when you want a lower concurrency limit.
+One worker may process multiple shards; `"auto"` changes concurrency, not the
+reader's shard layout.
+
 The local launcher is useful for:
 
 - verifying a writer on a small dataset

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -14,6 +14,7 @@ from refiner.pipeline.planning import (
     plan_pipeline_stages,
 )
 from refiner.pipeline.resources import GPU
+from refiner.launchers.types import WorkerCount
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
@@ -25,7 +26,7 @@ class BaseLauncher(ABC):
         *,
         pipeline: RefinerPipeline,
         name: str,
-        num_workers: int = 1,
+        num_workers: WorkerCount = 1,
         cpus_per_worker: int | None = None,
         gpu: GPU | None = None,
     ):
@@ -33,8 +34,12 @@ class BaseLauncher(ABC):
             raise ValueError("name must be non-empty")
         self.pipeline = pipeline
         self.name = name
-        if num_workers <= 0:
-            raise ValueError("num_workers must be > 0")
+        if num_workers != "auto" and (
+            not isinstance(num_workers, int)
+            or isinstance(num_workers, bool)
+            or num_workers <= 0
+        ):
+            raise ValueError("num_workers must be 'auto' or an integer > 0")
         self.num_workers = num_workers
         if cpus_per_worker is not None and cpus_per_worker <= 0:
             raise ValueError("cpus_per_worker must be > 0")
@@ -56,6 +61,9 @@ class BaseLauncher(ABC):
             default_num_workers=default_num_workers,
         )
 
+    def _auto_num_workers(self, stage: PlannedStage) -> int:
+        return max(1, len(stage.pipeline.list_shards()))
+
     def _compiled_plan(
         self,
         stages: list[PlannedStage] | None = None,
@@ -71,10 +79,18 @@ class BaseLauncher(ABC):
         self,
         stages: list[PlannedStage] | None = None,
     ) -> list[PlannedStage]:
-        return [
-            replace(stage, compute=self._stage_compute_requirements(stage.compute))
-            for stage in (stages or self._planned_stages())
-        ]
+        resolved: list[PlannedStage] = []
+        for stage in stages or self._planned_stages():
+            compute = stage.compute
+            if self.num_workers == "auto" and compute.inherit_launcher_resources:
+                compute = replace(
+                    compute,
+                    num_workers=self._auto_num_workers(stage),
+                )
+            resolved.append(
+                replace(stage, compute=self._stage_compute_requirements(compute))
+            )
+        return resolved
 
     def _stage_compute_requirements(
         self, compute: StageComputeRequirements

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -36,6 +36,7 @@ from refiner.services.discovery import collect_pipeline_services
 
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
+from refiner.launchers.types import WorkerCount
 
 if TYPE_CHECKING:
     from refiner.pipeline import RefinerPipeline
@@ -117,7 +118,7 @@ class CloudLauncher(BaseLauncher):
         *,
         pipeline: "RefinerPipeline",
         name: str,
-        num_workers: int = 1,
+        num_workers: WorkerCount = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,

--- a/src/refiner/launchers/local.py
+++ b/src/refiner/launchers/local.py
@@ -21,6 +21,7 @@ from refiner.cli.run.local import (
 from refiner.cli.ui.terminal import stdout_is_interactive
 from refiner.job_urls import build_job_tracking_url
 from refiner.launchers.base import BaseLauncher
+from refiner.launchers.types import WorkerCount
 from refiner.pipeline.planning import PlannedStage
 from refiner.pipeline.resources import GPU
 from refiner.platform.auth import MacrodataCredentialsError, current_api_key
@@ -33,7 +34,7 @@ from refiner.services.discovery import (
 from refiner.worker.context import logger
 from refiner.worker.lifecycle import read_finalized_workers
 from refiner.worker.resources.cpu import available_cpu_ids
-from refiner.worker.resources.gpu import build_gpu_sets
+from refiner.worker.resources.gpu import available_gpu_ids, build_gpu_sets
 from refiner.worker.workdir import resolve_workdir
 
 if TYPE_CHECKING:
@@ -52,7 +53,7 @@ class LocalLauncher(BaseLauncher):
         *,
         pipeline: RefinerPipeline,
         name: str,
-        num_workers: int = 1,
+        num_workers: WorkerCount = 1,
         rundir: str | None = None,
         gpu: GPU | None = None,
     ):
@@ -68,6 +69,18 @@ class LocalLauncher(BaseLauncher):
         )
         self.job_tracking_url: str | None = None
         self._total_stages = 1
+
+    def _auto_num_workers(self, stage: PlannedStage) -> int:
+        capacity = len(available_cpu_ids())
+        gpu = stage.compute.gpu if stage.compute.gpu is not None else self.gpu
+        if gpu is not None:
+            capacity = min(
+                capacity,
+                len(available_gpu_ids()) // gpu.count,
+            )
+        if capacity <= 0:
+            raise ValueError("No local worker capacity is available for this stage")
+        return min(super()._auto_num_workers(stage), capacity)
 
     def _collect_worker_results(
         self,
@@ -381,7 +394,7 @@ class LocalLauncher(BaseLauncher):
         if attach_mode_override() == "detach":
             raise SystemExit("--detach is only supported for cloud launches.")
         available_cpus = len(available_cpu_ids())
-        if self.num_workers > available_cpus:
+        if isinstance(self.num_workers, int) and self.num_workers > available_cpus:
             logger.warning(
                 f"launch requested {self.num_workers} workers, but only {available_cpus} CPUs are available on this machine."
             )

--- a/src/refiner/launchers/types.py
+++ b/src/refiner/launchers/types.py
@@ -1,0 +1,5 @@
+from typing import Literal, TypeAlias
+
+WorkerCount: TypeAlias = int | Literal["auto"]
+
+__all__ = ["WorkerCount"]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from fsspec import AbstractFileSystem
 
 from refiner.io.datafolder import DataFolderLike
+from refiner.launchers.types import WorkerCount
 from refiner.pipeline.expressions import Expr, lit
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.resources import GPU
@@ -712,7 +713,7 @@ class RefinerPipeline:
         self,
         *,
         name: str,
-        num_workers: int = 1,
+        num_workers: WorkerCount = 1,
         rundir: str | None = None,
         gpu: GPU | None = None,
     ) -> "LaunchStats":
@@ -720,7 +721,8 @@ class RefinerPipeline:
 
         Args:
             name: Human-readable run name.
-            num_workers: Number of local worker processes.
+            num_workers: Number of local worker processes, or ``"auto"`` to use
+                one worker per shard up to the machine's CPU and GPU capacity.
             rundir: Optional explicit local run directory. Reuse it to resume a prior local run.
             gpu: Optional GPU devices exposed per worker. `cuda_version` is accepted
                 for API consistency but ignored by local launch.
@@ -740,7 +742,7 @@ class RefinerPipeline:
         self,
         *,
         name: str,
-        num_workers: int = 1,
+        num_workers: WorkerCount = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
@@ -756,7 +758,8 @@ class RefinerPipeline:
 
         Args:
             name: Human-readable run name.
-            num_workers: Requested logical worker count.
+            num_workers: Requested logical worker count, or ``"auto"`` to
+                request one worker per planned shard.
             cpus_per_worker: Optional requested CPU cores per worker.
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
             gpu: Optional structured GPU request.

--- a/tests/launchers/test_base_launcher.py
+++ b/tests/launchers/test_base_launcher.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
+
+import pytest
 
 from refiner.job_urls import build_job_tracking_url
 from refiner.platform.client import MacrodataClient
-from refiner.pipeline import RefinerPipeline
+from refiner.pipeline import RefinerPipeline, from_items
 from refiner.launchers.base import BaseLauncher
 from refiner.pipeline.planning import (
     PlannedStage,
@@ -27,6 +29,49 @@ class _ResourceHintLauncher(_DummyLauncher):
             cpus_per_worker=1,
             gpu=GPU(count=2, type="h100", cuda_version="12.4"),
         )
+
+
+def test_launcher_auto_workers_follow_shard_count() -> None:
+    pipeline = from_items([{"x": 1}, {"x": 2}, {"x": 3}], items_per_shard=1)
+    launcher = _DummyLauncher(
+        pipeline=pipeline,
+        name="auto-workers",
+        num_workers="auto",
+    )
+
+    stages = launcher._resolved_stages(
+        [
+            PlannedStage(
+                index=0,
+                name="map",
+                pipeline=pipeline,
+                compute=StageComputeRequirements(num_workers=1),
+            ),
+            PlannedStage(
+                index=1,
+                name="reduce",
+                pipeline=pipeline,
+                compute=StageComputeRequirements(
+                    num_workers=1,
+                    inherit_launcher_resources=False,
+                ),
+            ),
+        ]
+    )
+
+    assert [stage.compute.num_workers for stage in stages] == [3, 1]
+
+
+def test_launcher_rejects_invalid_worker_count() -> None:
+    pipeline = from_items([{"x": 1}])
+
+    for value in (0, -1, True, "all"):
+        with pytest.raises(ValueError, match="num_workers"):
+            _DummyLauncher(
+                pipeline=pipeline,
+                name="invalid-workers",
+                num_workers=cast(Any, value),
+            )
 
 
 def test_job_tracking_url_sanitizes_terminal_control_characters() -> None:

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -258,6 +258,22 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert captured["events"] == ["upload-urls", "upload", "complete", "submit"]
 
 
+def test_pipeline_launch_cloud_auto_workers_follow_shard_count(monkeypatch) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+    pipeline = mdr.from_items(list(range(4)), items_per_shard=1)
+
+    pipeline.launch_cloud(name="cloud-auto-workers", num_workers="auto")
+
+    request = cast(CloudRunCreateRequest, captured["submit_request"])
+    assert request.plan["stages"][0]["requested_num_workers"] == 4
+    assert request.stage_payloads[0].runtime is not None
+    assert request.stage_payloads[0].runtime.num_workers == 4
+
+
 def test_pipeline_launch_cloud_embeds_runtime_services(monkeypatch) -> None:
     captured = _stub_cloud_submit(monkeypatch)
     monkeypatch.setattr(

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -25,7 +25,7 @@ from refiner.cli.ui.console import (
     stream_stage_logs,
 )
 from refiner.pipeline.data.shard import FilePart, Shard
-from refiner.pipeline import RefinerPipeline, read_csv, read_jsonl
+from refiner.pipeline import RefinerPipeline, from_items, read_csv, read_jsonl
 from refiner.pipeline.resources import GPU
 from refiner.launchers.local import LaunchStats, LocalLauncher
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
@@ -1515,6 +1515,45 @@ def test_launch_local_runs_planned_stages_sequentially(
     assert stats.output_rows == 3
     assert (rundir / "stage-0").exists()
     assert (rundir / "stage-1").exists()
+
+
+def test_local_auto_workers_are_capped_by_available_cpus(monkeypatch) -> None:
+    pipeline = from_items(list(range(5)), items_per_shard=1)
+    launcher = LocalLauncher(
+        pipeline=pipeline,
+        name="local-auto-workers",
+        num_workers="auto",
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.local.available_cpu_ids",
+        lambda: [0, 1],
+    )
+
+    stages = launcher._resolved_stages()
+
+    assert stages[0].compute.num_workers == 2
+
+
+def test_local_auto_workers_are_capped_by_launcher_gpu_request(monkeypatch) -> None:
+    pipeline = from_items(list(range(5)), items_per_shard=1)
+    launcher = LocalLauncher(
+        pipeline=pipeline,
+        name="local-auto-gpu-workers",
+        num_workers="auto",
+        gpu=GPU(count=2, type="h100"),
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.local.available_cpu_ids",
+        lambda: list(range(8)),
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.local.available_gpu_ids",
+        lambda: ["0", "1", "2", "3"],
+    )
+
+    stages = launcher._resolved_stages()
+
+    assert stages[0].compute.num_workers == 2
 
 
 def test_launch_local_uses_explicit_rundir(tmp_path) -> None:


### PR DESCRIPTION
## What changed

- accept `num_workers="auto"` in local and cloud launch APIs
- size inherited map stages from their planned shard count while leaving fixed reducer stages at one worker
- cap local auto-sizing by visible CPU capacity and requested GPU capacity
- document local and cloud behavior, including cloud submission-time shard discovery

## Why

Shard layout belongs to readers, while execution concurrency belongs to launchers. This keeps the same separation used by Spark, Beam/Dataflow, Ray Data, Daft, and Hugging Face-style dataset sharding: sources define partitions, and the runtime decides how many workers consume them.

The feature is opt-in, so the existing default of one worker and all explicit integer worker counts remain unchanged.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest tests/launchers/test_base_launcher.py tests/launchers/test_local_launcher.py tests/launchers/test_cloud_launcher.py -q` (`111 passed`)
- full local suite reached 71% without failures, then encountered the existing idle reader-test stall seen on macOS; GitHub CI will rerun the full suite on Linux
