### PR TITLE
fix(runtime): address task shard lifecycle follow-ups

### DIFF
--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -27,7 +27,11 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.execution.buffer import RowBuffer
-from refiner.execution.operators.row import ShardDeltaFn, execute_row_steps
+from refiner.execution.operators.row import (
+    AsyncWindowRegistry,
+    ShardDeltaFn,
+    execute_row_steps,
+)
 from refiner.execution.operators.vectorized import (
     apply_vectorized_ops,
 )
@@ -75,6 +79,7 @@ def execute_segments(
     max_vectorized_block_bytes: int | None = None,
     on_shard_delta: ShardDeltaFn | None = None,
     input_schema: pa.Schema | None = None,
+    async_window_registry: AsyncWindowRegistry | None = None,
 ) -> Iterator[Block]:
     """Execute segments and yield row or tabular blocks."""
     current: Iterable[Block] = _normalize_blocks(
@@ -104,6 +109,7 @@ def execute_segments(
                 and max_vectorized_block_bytes is None,
                 on_shard_delta=on_shard_delta,
                 output_schema=output_schema,
+                async_window_registry=async_window_registry,
             )
             current_schema = output_schema
     yield from current
@@ -199,11 +205,17 @@ def _execute_row_segment(
     output_tabular: bool,
     on_shard_delta: ShardDeltaFn | None,
     output_schema: pa.Schema | None,
+    async_window_registry: AsyncWindowRegistry | None,
 ) -> Iterator[Block]:
     # Row/UDF execution consumes row views and emits row blocks for downstream
     # vectorized segments (or final row iteration).
     rows = iter_rows(stream)
-    step_out = execute_row_steps(rows, steps, on_shard_delta=on_shard_delta)
+    step_out = execute_row_steps(
+        rows,
+        steps,
+        on_shard_delta=on_shard_delta,
+        async_window_registry=async_window_registry,
+    )
     if not output_tabular:
         yield from _chunk_output_rows(step_out, output_block_rows)
         return

--- a/src/refiner/execution/operators/row.py
+++ b/src/refiner/execution/operators/row.py
@@ -22,6 +22,11 @@ from refiner.worker.context import set_active_step_index
 from refiner.worker.metrics.api import register_gauge
 
 AsyncCloseFn = Callable[[], Coroutine[object, object, None]]
+AsyncWindowRegistry = dict[int, AsyncWindow[Row]]
+
+
+class AsyncStepTeardownError(RuntimeError):
+    """Raised when an async pipeline callable fails to close."""
 
 
 def close_async_steps(steps: Sequence[RefinerStep]) -> None:
@@ -35,7 +40,10 @@ def close_async_steps(steps: Sequence[RefinerStep]) -> None:
         if close is not None:
             close_fns.append(cast(AsyncCloseFn, close))
     for close in close_fns:
-        submit(close()).result()
+        try:
+            submit(close()).result()
+        except Exception as e:
+            raise AsyncStepTeardownError(str(e)) from e
 
 
 def execute_row_steps(
@@ -43,6 +51,7 @@ def execute_row_steps(
     steps: Sequence[RefinerStep],
     *,
     on_shard_delta: ShardDeltaFn | None = None,
+    async_window_registry: AsyncWindowRegistry | None = None,
 ) -> Iterator[Row]:
     """Execute row/batch/flatmap steps using per-step queues.
 
@@ -55,24 +64,32 @@ def execute_row_steps(
         return
 
     queues: list[RowBuffer] = [RowBuffer() for _ in range(len(ordered) + 1)]
-    async_windows: list[AsyncWindow[Row] | None] = [
-        AsyncWindow[Row](
-            max_in_flight=step.max_in_flight,
-            preserve_order=step.preserve_order,
+
+    def _async_window(step: AsyncRowStep) -> AsyncWindow[Row]:
+        window = (
+            async_window_registry.get(step.index)
+            if async_window_registry is not None
+            else None
         )
-        if isinstance(step, AsyncRowStep)
-        else None
-        for step in ordered
-    ]
-    for i, step in enumerate(ordered):
-        window = async_windows[i]
-        if window is not None:
+        if window is None:
+            window = AsyncWindow[Row](
+                max_in_flight=step.max_in_flight,
+                preserve_order=step.preserve_order,
+            )
+            if async_window_registry is not None:
+                async_window_registry[step.index] = window
             register_gauge(
                 "in_flight",
                 lambda window=window: len(window),
                 unit="rows",
                 step_index=step.index,
             )
+        return window
+
+    async_windows = [
+        _async_window(step) if isinstance(step, AsyncRowStep) else None
+        for step in ordered
+    ]
 
     async def _run_async_step(*, step: AsyncRowStep, row: Row) -> Row:
         with set_active_step_index(step.index):
@@ -211,4 +228,10 @@ def execute_row_steps(
                 window.cancel_pending()
 
 
-__all__ = ["close_async_steps", "execute_row_steps", "ShardDeltaFn"]
+__all__ = [
+    "AsyncWindowRegistry",
+    "AsyncStepTeardownError",
+    "close_async_steps",
+    "execute_row_steps",
+    "ShardDeltaFn",
+]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -71,7 +71,11 @@ from refiner.execution.engine import (
     iter_rows,
     schema_after_segments,
 )
-from refiner.execution.operators.row import ShardDeltaFn, close_async_steps
+from refiner.execution.operators.row import (
+    AsyncWindowRegistry,
+    ShardDeltaFn,
+    close_async_steps,
+)
 from refiner.pipeline.sources.base import SourceUnit
 from refiner.pipeline.sources.readers.utils import (
     DEFAULT_TARGET_SHARD_BYTES,
@@ -495,6 +499,7 @@ class RefinerPipeline:
         *,
         on_shard_delta: ShardDeltaFn | None = None,
     ) -> Iterable[Block]:
+        async_window_registry: AsyncWindowRegistry = {}
         try:
             for rows in windows:
                 yield from execute_segments(
@@ -503,6 +508,7 @@ class RefinerPipeline:
                     max_vectorized_block_bytes=self.max_vectorized_block_bytes,
                     on_shard_delta=on_shard_delta,
                     input_schema=self.source.schema,
+                    async_window_registry=async_window_registry,
                 )
         finally:
             close_async_steps(self.pipeline_steps)

--- a/src/refiner/pipeline/sources/task.py
+++ b/src/refiner/pipeline/sources/task.py
@@ -41,8 +41,11 @@ class TaskSource(BaseSource):
             raise ValueError(f"Invalid task rank {rank} for {self._num_tasks} tasks")
         yield DictRow({"task_rank": rank})
 
-    def describe(self) -> dict[str, int]:
-        return {"num_tasks": self._num_tasks}
+    def describe(self) -> dict[str, Any]:
+        return {
+            "num_tasks": self._num_tasks,
+            "claim_shards_sequentially": self.claim_shards_sequentially,
+        }
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from refiner.execution.engine import block_num_rows
+from refiner.execution.operators.row import AsyncStepTeardownError
 from refiner.pipeline.data.shard import Shard
 from refiner.pipeline.pipeline import RefinerPipeline
 from refiner.pipeline.sinks import NullSink
@@ -328,7 +329,10 @@ class Worker:
                         failed_error,
                     )
                     self.user_metrics_emitter.force_flush_logs()
-                    failed += _fail_inflight_shards(failed_error)
+                    failed_inflight = _fail_inflight_shards(failed_error)
+                    failed += failed_inflight
+                    if isinstance(e, AsyncStepTeardownError) and failed_inflight == 0:
+                        raise
                 else:
                     _heartbeat_once()
                     with inflight_lock:

--- a/tests/pipeline/test_pipeline_task.py
+++ b/tests/pipeline/test_pipeline_task.py
@@ -84,11 +84,16 @@ def test_task_allows_yielding_multiple_rows() -> None:
 
 
 def test_task_compiles_source_and_task_step_plan() -> None:
-    pipeline = task(lambda rank, world_size: {"ok": rank < world_size}, num_tasks=3)
+    pipeline = task(
+        lambda rank, world_size: {"ok": rank < world_size},
+        num_tasks=3,
+        claim_shards_sequentially=False,
+    )
     payload = compile_pipeline_plan(pipeline)
     steps = payload["stages"][0]["steps"]
     assert steps[0]["name"] == "task"
     assert steps[0]["args"]["num_tasks"] == 3
+    assert steps[0]["args"]["claim_shards_sequentially"] is False
     assert steps[1]["name"] == "task_2"
     assert steps[1]["type"] == "flat_map"
     assert "fn" in steps[1]["args"]

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -20,6 +20,7 @@ from refiner.worker.runner import Worker
 from refiner.pipeline.sources.readers.base import BaseReader
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.worker.metrics.api import log_gauge
+from refiner.worker.metrics.emitter import UserMetricsEmitter
 from refiner.worker.lifecycle import FinalizedShardWorker, sort_finalized_workers
 
 
@@ -86,7 +87,7 @@ def test_sort_finalized_workers_uses_legacy_order_when_any_ordinal_is_missing() 
     ]
 
 
-class _NoopTelemetryEmitter:
+class _NoopTelemetryEmitter(UserMetricsEmitter):
     def emit_user_counter(self, **kwargs) -> None:
         del kwargs
 
@@ -518,6 +519,7 @@ def test_task_worker_keeps_async_callable_open_across_claim_windows() -> None:
             self.closed = True
 
     fn = _AsyncCallable()
+    metrics = _MetricRecordingTelemetryEmitter()
     pipeline = task(lambda rank, _world_size: {"rank": rank}, num_tasks=2).map_async(
         fn,
         max_in_flight=1,
@@ -529,6 +531,7 @@ def test_task_worker_keeps_async_callable_open_across_claim_windows() -> None:
         stage_index=0,
         worker_id="local",
         runtime_lifecycle=runtime_lifecycle,
+        user_metrics_emitter=metrics,
     )
 
     stats = worker.run()
@@ -536,6 +539,36 @@ def test_task_worker_keeps_async_callable_open_across_claim_windows() -> None:
     assert stats.completed == 2
     assert fn.ranks == [0, 1]
     assert fn.close_calls == 1
+    assert len(metrics.registered_gauges) == 1
+
+
+def test_worker_propagates_async_teardown_failure_after_completion() -> None:
+    class _AsyncCallable:
+        async def __call__(self, row: Row) -> dict[str, int]:
+            return {"rank": int(row["task_rank"])}
+
+        async def aclose(self) -> None:
+            raise RuntimeError("async teardown failed")
+
+    pipeline = task(
+        lambda rank, _world_size: {"rank": rank},
+        num_tasks=1,
+    ).map_async(_AsyncCallable())
+    shards = pipeline.list_shards()
+    runtime_lifecycle = _FakeRuntimeLifecycle(shards)
+    worker = Worker(
+        pipeline=pipeline,
+        job_id="job",
+        stage_index=0,
+        worker_id="local",
+        runtime_lifecycle=runtime_lifecycle,
+    )
+
+    with pytest.raises(RuntimeError, match="async teardown failed"):
+        worker.run()
+
+    assert runtime_lifecycle.completed_ids == [shards[0].id]
+    assert runtime_lifecycle.failed_ids == []
 
 
 def test_task_worker_stops_claiming_after_heartbeat_failure() -> None:


### PR DESCRIPTION
## Summary

- reuse async execution windows across sequential task-shard drain passes so gauges register once and continue observing the active window
- propagate async callable teardown failures as worker-level failures when every shard has already finalized
- include `claim_shards_sequentially` in serialized task source plans

## Root cause

Sequential task admission executes one fully drained pipeline pass per shard. Each pass previously constructed and registered a fresh async window, while deferred callable teardown could fail after the final shard had already completed. The task source description also omitted the new admission policy.

## Verification

- `uv run pytest tests/execution tests/pipeline tests/worker` — 276 passed
- `uv run pre-commit run --all-files` — Ruff lint, Ruff format, and ty passed