### PR TITLE
fix(media): stream indexed MP4 and overlap asset uploads

### DIFF
--- a/docs/writing-data/media-assets-and-reducers.md
+++ b/docs/writing-data/media-assets-and-reducers.md
@@ -121,3 +121,28 @@ workers finish shard-local writes.
 | Zarr | Merge shard-local stores into a single store when configured. |
 
 Reducers are part of the launched pipeline plan and are visible in job progress.
+
+## MP4 Video Output on S3
+
+When a video-writing pipeline targets an `s3://` output, Refiner writes a
+standard indexed MP4 directly to the destination object. The completed file
+contains a normal `moov` index (rather than fragmented `moof` segments), so
+video readers can determine the full duration and frame count and seek across
+the complete video.
+
+No staging directory is required. Refiner holds the first 5 MiB of the output
+and one active 5 MiB upload part in memory while it streams later
+multipart-upload parts. This allows it to write the final MP4 media-data size
+and index when the video closes without buffering the whole video locally.
+Small videos, up to 5 MiB, are uploaded as a single object.
+
+This works with AWS S3 and Cloudflare R2 when R2 is configured through the
+`s3fs` S3-compatible endpoint. Once the first 5 MiB is available, Refiner
+uploads multipart part 1. At close, it uploads the corrected prefix again as
+part 1 before completing the multipart upload. R2 requires all non-final
+parts to have the same size; Refiner uses fixed 5 MiB parts for that reason.
+
+The S3 principal needs permission to put objects and, for videos larger than
+5 MiB, to create, upload, complete, and abort multipart uploads. If the final
+video close fails, Refiner aborts the multipart upload; the destination object
+is not made visible by that upload.

--- a/docs/writing-data/media-assets-and-reducers.md
+++ b/docs/writing-data/media-assets-and-reducers.md
@@ -70,6 +70,13 @@ The configuration fields are:
 | `FileAssetConfig` | `subdir`, `max_in_flight`, `missing_policy` |
 | `BlobAssetConfig` | `subdir`, `target_bytes`, `missing_policy` |
 
+`FileAssetConfig.max_in_flight` bounds concurrent asset uploads per writer. The
+upload window stays active across input blocks, so even one-row blocks can
+overlap when `max_in_flight` is greater than one. Refiner applies backpressure
+when the window is full and waits for all remaining uploads when the shard is
+finalized. Output rows are kept in order and are not written until every asset
+referenced by that row's input block has finished uploading.
+
 To migrate the previous individual-file API:
 
 ```python

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -27,6 +27,30 @@ MissingAssetPolicy = Literal["error", "drop_row", "set_null"]
 AssetCopyResult = bool | list[bool]
 
 
+@dataclass(frozen=True, slots=True)
+class ReadyAssetBlock:
+    shard_id: str
+    block: pa.Table | list[Row]
+
+
+@dataclass(slots=True)
+class _PendingTable:
+    shard_id: str
+    table: pa.Table
+    result_columns: list[tuple[str, pa.Field]]
+    result_count: int
+
+
+@dataclass(slots=True)
+class _PendingRows:
+    shard_id: str
+    rows: list[tuple[Row, dict[str, object], list[str]]]
+    result_count: int
+
+
+_PendingAssetBlock: TypeAlias = _PendingTable | _PendingRows
+
+
 def _validate_config(
     *,
     subdir: str,
@@ -138,6 +162,8 @@ class AssetUploadManager:
         self._asset_column_segments: dict[str, str] = {}
         self._input_schema_set = False
         self.missing_asset_policy = missing_asset_policy
+        self._pending: deque[_PendingAssetBlock] = deque()
+        self._results: deque[AssetCopyResult] = deque()
 
     def set_input_schema(self, schema: pa.Schema | None) -> None:
         self._set_asset_columns(_asset_columns_from_schema(schema))
@@ -172,11 +198,32 @@ class AssetUploadManager:
 
     def close(self) -> None:
         self._window.cancel_pending()
+        self._pending.clear()
+        self._results.clear()
 
-    def on_shard_complete(self, shard_id: str) -> None:
-        pass
+    def on_shard_complete(self, shard_id: str) -> list[ReadyAssetBlock]:
+        del shard_id
+        self._results.extend(self._window.drain())
+        return self._take_ready()
+
+    def submit_table(
+        self,
+        shard_id: str,
+        table: pa.Table,
+    ) -> list[ReadyAssetBlock]:
+        pending = self._prepare_table(shard_id, table)
+        self._pending.append(pending)
+        self._results.extend(self._window.take_completed())
+        return self._take_ready()
 
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
+        ready = self.submit_table(shard_id, table)
+        ready.extend(self.on_shard_complete(shard_id))
+        if len(ready) != 1 or not isinstance(ready[0].block, pa.Table):
+            raise RuntimeError("rewrite_table cannot be mixed with deferred asset blocks")
+        return ready[0].block
+
+    def _prepare_table(self, shard_id: str, table: pa.Table) -> _PendingTable:
         start = self._next_row_index.get(shard_id, 0)
         out = table
         result_columns: list[tuple[str, pa.Field]] = []
@@ -197,6 +244,7 @@ class AssetUploadManager:
             rewritten = []
             for row_offset, value in enumerate(values):
                 if self.missing_asset_policy == "error" and value is None:
+                    self._window.submit_result(True)
                     rewritten.append(None)
                     continue
                 rewritten.append(
@@ -213,10 +261,22 @@ class AssetUploadManager:
             rewritten_array = pa.array(rewritten, type=output_field.type)
             out = out.set_column(idx, output_field, rewritten_array)
             result_columns.append((column_name, output_field))
-        # Do not expose output rows that point at assets until those copies have
-        # completed; otherwise a later copy failure leaves dangling references.
-        results = self._window.drain()
         self._next_row_index[shard_id] = start + table.num_rows
+        return _PendingTable(
+            shard_id=shard_id,
+            table=out,
+            result_columns=result_columns,
+            result_count=len(result_columns) * table.num_rows,
+        )
+
+    def _finish_table(
+        self,
+        pending: _PendingTable,
+        results: list[AssetCopyResult],
+    ) -> pa.Table:
+        out = pending.table
+        table = pending.table
+        result_columns = pending.result_columns
         if self.missing_asset_policy == "set_null":
             # Each result lines up with one rewritten table cell. Scalar cells
             # return bool; list cells return one bool per non-null path element.
@@ -259,56 +319,45 @@ class AssetUploadManager:
                     log_throughput(
                         "asset_rows_dropped",
                         dropped,
-                        shard_id,
+                        pending.shard_id,
                         unit="rows",
                     )
         return out
+
+    def submit_rows(
+        self,
+        shard_id: str,
+        rows: Iterable[Row],
+    ) -> list[ReadyAssetBlock]:
+        pending = self._prepare_rows(shard_id, rows)
+        self._pending.append(pending)
+        self._results.extend(self._window.take_completed())
+        return self._take_ready()
 
     def rewrite_rows(
         self,
         shard_id: str,
         rows: Iterable[Row],
     ) -> Iterable[Row]:
+        ready = self.submit_rows(shard_id, rows)
+        ready.extend(self.on_shard_complete(shard_id))
+        if len(ready) != 1 or not isinstance(ready[0].block, list):
+            raise RuntimeError("rewrite_rows cannot be mixed with deferred asset blocks")
+        yield from ready[0].block
+
+    def _prepare_rows(
+        self,
+        shard_id: str,
+        rows: Iterable[Row],
+    ) -> _PendingRows:
         self.require_input_schema()
         if not self._asset_columns:
-            yield from rows
-            return
+            materialized = list(rows)
+            return _PendingRows(shard_id, [(row, {}, []) for row in materialized], 0)
 
         start = self._next_row_index.get(shard_id, 0)
-        # Results are ordered by the same nested loop used to build patches:
-        # row, then asset column. Keep only rows whose copy results are still
-        # pending instead of materializing the full input block.
-        pending_rows: deque[tuple[Row, dict[str, object], list[str]]] = deque()
-        results: deque[AssetCopyResult] = deque()
-        dropped = 0
+        pending_rows: list[tuple[Row, dict[str, object], list[str]]] = []
         row_count = 0
-
-        def emit_ready() -> Iterable[Row]:
-            nonlocal dropped
-            while pending_rows:
-                row, patch, result_columns = pending_rows[0]
-                result_count = len(result_columns)
-                if len(results) < result_count:
-                    break
-                pending_rows.popleft()
-                row_results = [results.popleft() for _ in range(result_count)]
-                if self.missing_asset_policy == "drop_row" and not all(
-                    all(result) if isinstance(result, list) else result
-                    for result in row_results
-                ):
-                    dropped += 1
-                    continue
-                if self.missing_asset_policy == "set_null":
-                    for column_name, copied in zip(
-                        result_columns,
-                        row_results,
-                        strict=True,
-                    ):
-                        patch[column_name] = _set_null_value(
-                            patch[column_name],
-                            copied,
-                        )
-                yield row.update(patch) if patch else row
 
         for row_index, row in enumerate(rows, start=start):
             row_count += 1
@@ -335,20 +384,58 @@ class AssetUploadManager:
                 result_columns.append(column_name)
 
             pending_rows.append((row, patch, result_columns))
-            # Error policy must remain block-atomic for row sinks: JSONL writes
-            # rows as they are yielded, so do not expose any rewritten asset paths
-            # until every copy in the block has succeeded.
-            if self.missing_asset_policy != "error":
-                # Non-error policies can stream bounded rows as soon as their
-                # copy results are available.
-                results.extend(self._window.take_completed())
-                yield from emit_ready()
-
-        results.extend(self._window.drain())
-        yield from emit_ready()
         self._next_row_index[shard_id] = start + row_count
+        return _PendingRows(
+            shard_id,
+            pending_rows,
+            sum(len(result_columns) for _, _, result_columns in pending_rows),
+        )
+
+    def _finish_rows(
+        self,
+        pending: _PendingRows,
+        results: list[AssetCopyResult],
+    ) -> list[Row]:
+        output: list[Row] = []
+        result_offset = 0
+        dropped = 0
+        for row, patch, result_columns in pending.rows:
+            row_results = results[result_offset : result_offset + len(result_columns)]
+            result_offset += len(result_columns)
+            if self.missing_asset_policy == "drop_row" and not all(
+                all(result) if isinstance(result, list) else result
+                for result in row_results
+            ):
+                dropped += 1
+                continue
+            if self.missing_asset_policy == "set_null":
+                for column_name, copied in zip(
+                    result_columns,
+                    row_results,
+                    strict=True,
+                ):
+                    patch[column_name] = _set_null_value(patch[column_name], copied)
+            output.append(row.update(patch) if patch else row)
         if dropped:
-            log_throughput("asset_rows_dropped", dropped, shard_id, unit="rows")
+            log_throughput(
+                "asset_rows_dropped", dropped, pending.shard_id, unit="rows"
+            )
+        return output
+
+    def _take_ready(self) -> list[ReadyAssetBlock]:
+        ready: list[ReadyAssetBlock] = []
+        while self._pending:
+            pending = self._pending[0]
+            if len(self._results) < pending.result_count:
+                break
+            self._pending.popleft()
+            results = [self._results.popleft() for _ in range(pending.result_count)]
+            if isinstance(pending, _PendingTable):
+                block: pa.Table | list[Row] = self._finish_table(pending, results)
+            else:
+                block = self._finish_rows(pending, results)
+            ready.append(ReadyAssetBlock(pending.shard_id, block))
+        return ready
 
     def _asset_relpath(
         self,
@@ -955,6 +1042,7 @@ __all__ = [
     "BlobAssetManager",
     "FileAssetConfig",
     "MissingAssetPolicy",
+    "ReadyAssetBlock",
     "asset_config_to_plan",
     "cleanup_rejected_asset_attempts",
 ]

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -220,7 +220,9 @@ class AssetUploadManager:
         ready = self.submit_table(shard_id, table)
         ready.extend(self.on_shard_complete(shard_id))
         if len(ready) != 1 or not isinstance(ready[0].block, pa.Table):
-            raise RuntimeError("rewrite_table cannot be mixed with deferred asset blocks")
+            raise RuntimeError(
+                "rewrite_table cannot be mixed with deferred asset blocks"
+            )
         return ready[0].block
 
     def _prepare_table(self, shard_id: str, table: pa.Table) -> _PendingTable:
@@ -342,7 +344,9 @@ class AssetUploadManager:
         ready = self.submit_rows(shard_id, rows)
         ready.extend(self.on_shard_complete(shard_id))
         if len(ready) != 1 or not isinstance(ready[0].block, list):
-            raise RuntimeError("rewrite_rows cannot be mixed with deferred asset blocks")
+            raise RuntimeError(
+                "rewrite_rows cannot be mixed with deferred asset blocks"
+            )
         yield from ready[0].block
 
     def _prepare_rows(
@@ -417,9 +421,7 @@ class AssetUploadManager:
                     patch[column_name] = _set_null_value(patch[column_name], copied)
             output.append(row.update(patch) if patch else row)
         if dropped:
-            log_throughput(
-                "asset_rows_dropped", dropped, pending.shard_id, unit="rows"
-            )
+            log_throughput("asset_rows_dropped", dropped, pending.shard_id, unit="rows")
         return output
 
     def _take_ready(self) -> list[ReadyAssetBlock]:

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -95,13 +95,15 @@ class BaseSink(ABC):
         """Whether blocks written into this sink should count toward output_rows."""
         return True
 
-    def on_shard_complete(self, shard_id: str) -> None:
+    def on_shard_complete(self, shard_id: str) -> int | None:
         """Flush or finalize state for one shard after upstream completion.
 
         Override this only when the sink keeps shard-local buffered state that
-        should be finalized before `close()`.
+        should be finalized before `close()`. Return the number of output rows
+        written during finalization, if any.
         """
         del shard_id
+        return None
 
     def on_shard_finalized(self, shard_id: str) -> None:
         """Run cleanup after the shard has been marked complete."""

--- a/src/refiner/pipeline/sinks/jsonl.py
+++ b/src/refiner/pipeline/sinks/jsonl.py
@@ -17,6 +17,7 @@ from refiner.pipeline.sinks.assets import (
     BlobAssetConfig,
     BlobAssetManager,
     FileAssetConfig,
+    ReadyAssetBlock,
     asset_config_to_plan,
 )
 from refiner.pipeline.sinks.base import BaseSink
@@ -45,6 +46,7 @@ class JsonlSink(BaseSink):
         self.filename_template = filename_template
         self.assets = assets
         self._files: dict[str, IO[str]] = {}
+        self._asset_rows_written: dict[str, int] = {}
         self._encoder = json.JSONEncoder(
             ensure_ascii=True,
             separators=(",", ":"),
@@ -97,7 +99,9 @@ class JsonlSink(BaseSink):
         return count
 
     def _write_table_rows(self, shard_id: str, table: pa.Table) -> int:
-        if self._assets is not None:
+        if self._assets is not None and not isinstance(
+            self._assets, AssetUploadManager
+        ):
             return self._write_rows(
                 shard_id, self._assets.rewrite_table(shard_id, table).to_pylist()
             )
@@ -107,6 +111,15 @@ class JsonlSink(BaseSink):
         return count
 
     def write_shard_block(self, shard_id: str, block: Block) -> int:
+        if isinstance(self._assets, AssetUploadManager):
+            if isinstance(block, Tabular):
+                ready = self._assets.submit_table(
+                    shard_id, strip_internal_columns(block.table)
+                )
+            else:
+                ready = self._assets.submit_rows(shard_id, block)
+            self._write_ready_asset_blocks(ready)
+            return self._asset_rows_written.pop(shard_id, 0)
         if isinstance(block, Tabular):
             return self._write_table_rows(
                 shard_id,
@@ -117,13 +130,30 @@ class JsonlSink(BaseSink):
             rows = self._assets.rewrite_rows(shard_id, rows)
         return self._write_rows(shard_id, rows)
 
-    def on_shard_complete(self, shard_id: str) -> None:
-        if self._assets is not None:
+    def _write_ready_asset_blocks(self, blocks: list[ReadyAssetBlock]) -> None:
+        for ready in blocks:
+            rows = (
+                ready.block.to_pylist()
+                if isinstance(ready.block, pa.Table)
+                else ready.block
+            )
+            count = self._write_rows(ready.shard_id, rows)
+            self._asset_rows_written[ready.shard_id] = (
+                self._asset_rows_written.get(ready.shard_id, 0) + count
+            )
+
+    def on_shard_complete(self, shard_id: str) -> int | None:
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.on_shard_complete(shard_id))
+        elif self._assets is not None:
             self._assets.on_shard_complete(shard_id)
         file = self._files.pop(shard_id, None)
         if file is not None:
             file.close()
             log_throughput("files_written", 1, shard_id=shard_id, unit="files")
+        if isinstance(self._assets, AssetUploadManager):
+            return self._asset_rows_written.pop(shard_id, 0)
+        return None
 
     def close(self) -> None:
         try:

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -27,6 +27,7 @@ from refiner.pipeline.sinks.assets import (
     BlobAssetConfig,
     BlobAssetManager,
     FileAssetConfig,
+    ReadyAssetBlock,
     asset_config_to_plan,
     cleanup_rejected_asset_attempts,
 )
@@ -680,6 +681,8 @@ class LanceDatasetSink(BaseSink):
             self._assets = None
         self._writers_by_shard: dict[str, _StreamingShardWriter] = {}
         self._schema_by_shard: dict[str, pa.Schema] = {}
+        self._asset_rows_written: dict[str, int] = {}
+        self._pending_add_columns_addresses: dict[str, list[pa.Array]] = {}
         self._add_columns_writers_by_shard: dict[
             str, dict[int, _StreamingAddColumnsWriter]
         ] = {}
@@ -794,8 +797,24 @@ class LanceDatasetSink(BaseSink):
                 "add_columns output is missing columns: " + ", ".join(missing)
             )
         table = table.select(self.columns)
+        if isinstance(self._assets, AssetUploadManager):
+            self._pending_add_columns_addresses.setdefault(shard_id, []).append(
+                row_addresses
+            )
+            self._write_ready_asset_blocks(self._assets.submit_table(shard_id, table))
+            return
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
+
+        self._write_add_columns_table(shard_id, table, row_addresses)
+
+    def _write_add_columns_table(
+        self,
+        shard_id: str,
+        table: pa.Table,
+        row_addresses: pa.Array,
+    ) -> None:
+        assert self.columns is not None
 
         output_schema = pa.schema(
             [table.schema.field(column) for column in self.columns]
@@ -844,15 +863,30 @@ class LanceDatasetSink(BaseSink):
                 table.filter(mask).select(self.columns),
             )
 
-    def write_shard_block(self, shard_id: str, block: Block) -> None:
+    def write_shard_block(self, shard_id: str, block: Block) -> int | None:
         if self.mode == "add_columns":
             self._write_add_columns_block(shard_id, block)
-            return
+            if isinstance(self._assets, AssetUploadManager):
+                return self._asset_rows_written.pop(shard_id, 0)
+            return None
         table = block_to_table(block)
         if table.num_rows == 0:
             return
+        if isinstance(self._assets, AssetUploadManager):
+            output_schema = self._assets.output_schema(table.schema)
+            assert output_schema is not None
+            if self.mode == "append":
+                existing_schema = self._load_existing_schema()
+                _validate_append_asset_layout(output_schema, existing_schema)
+            elif self.mode == "overwrite":
+                self._load_overwrite_version()
+            self._write_ready_asset_blocks(self._assets.submit_table(shard_id, table))
+            return self._asset_rows_written.pop(shard_id, 0)
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
+        self._write_table(shard_id, table)
+
+    def _write_table(self, shard_id: str, table: pa.Table) -> None:
         if self.mode == "append":
             existing_schema = self._load_existing_schema()
             _validate_append_asset_layout(table.schema, existing_schema)
@@ -872,6 +906,21 @@ class LanceDatasetSink(BaseSink):
             )
             self._writers_by_shard[shard_id] = writer
         writer.put_batches(table.to_batches())
+
+    def _write_ready_asset_blocks(self, blocks: list[ReadyAssetBlock]) -> None:
+        for ready in blocks:
+            assert isinstance(ready.block, pa.Table)
+            if self.mode == "add_columns":
+                addresses = self._pending_add_columns_addresses[ready.shard_id].pop(0)
+                self._write_add_columns_table(
+                    ready.shard_id, ready.block, addresses
+                )
+            else:
+                self._write_table(ready.shard_id, ready.block)
+            self._asset_rows_written[ready.shard_id] = (
+                self._asset_rows_written.get(ready.shard_id, 0)
+                + ready.block.num_rows
+            )
 
     def _write_sidecar(
         self,
@@ -911,21 +960,25 @@ class LanceDatasetSink(BaseSink):
             payload["source_version"] = self.source_version
         self._write_sidecar(shard_id, payload)
 
-    def on_shard_complete(self, shard_id: str) -> None:
-        if self._assets is not None:
+    def on_shard_complete(self, shard_id: str) -> int | None:
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.on_shard_complete(shard_id))
+        elif self._assets is not None:
             self._assets.on_shard_complete(shard_id)
+        asset_rows = self._asset_rows_written.pop(shard_id, 0)
+        self._pending_add_columns_addresses.pop(shard_id, None)
         if self.mode == "add_columns":
             self._complete_add_columns_shard(shard_id)
-            return
+            return asset_rows if isinstance(self._assets, AssetUploadManager) else None
         writer = self._writers_by_shard.pop(shard_id, None)
         schema = self._schema_by_shard.pop(shard_id, None)
         if writer is None or schema is None:
             self._write_empty_sidecar(shard_id)
-            return
+            return asset_rows if isinstance(self._assets, AssetUploadManager) else None
         fragments = writer.finish()
         if not fragments:
             self._write_empty_sidecar(shard_id)
-            return
+            return asset_rows if isinstance(self._assets, AssetUploadManager) else None
         created_files = [
             path for fragment in fragments for path in _fragment_data_paths(fragment)
         ]
@@ -941,6 +994,7 @@ class LanceDatasetSink(BaseSink):
             payload,
             created_files=created_files,
         )
+        return asset_rows if isinstance(self._assets, AssetUploadManager) else None
 
     def _complete_add_columns_shard(self, shard_id: str) -> None:
         writers = self._add_columns_writers_by_shard.pop(shard_id, None)

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -912,14 +912,11 @@ class LanceDatasetSink(BaseSink):
             assert isinstance(ready.block, pa.Table)
             if self.mode == "add_columns":
                 addresses = self._pending_add_columns_addresses[ready.shard_id].pop(0)
-                self._write_add_columns_table(
-                    ready.shard_id, ready.block, addresses
-                )
+                self._write_add_columns_table(ready.shard_id, ready.block, addresses)
             else:
                 self._write_table(ready.shard_id, ready.block)
             self._asset_rows_written[ready.shard_id] = (
-                self._asset_rows_written.get(ready.shard_id, 0)
-                + ready.block.num_rows
+                self._asset_rows_written.get(ready.shard_id, 0) + ready.block.num_rows
             )
 
     def _write_sidecar(

--- a/src/refiner/pipeline/sinks/lance_file.py
+++ b/src/refiner/pipeline/sinks/lance_file.py
@@ -15,6 +15,7 @@ from refiner.pipeline.sinks.assets import (
     BlobAssetConfig,
     BlobAssetManager,
     FileAssetConfig,
+    ReadyAssetBlock,
     asset_config_to_plan,
 )
 from refiner.pipeline.sinks.lance_utils import block_to_table, validate_lance_uri
@@ -77,6 +78,7 @@ class LanceSink(BaseSink):
         else:
             self._assets = None
         self._writers: dict[str, Any] = {}
+        self._asset_rows_written: dict[str, int] = {}
 
     def set_input_schema(self, schema: pa.Schema | None) -> None:
         if self._assets is not None:
@@ -102,21 +104,37 @@ class LanceSink(BaseSink):
         self._writers[shard_id] = writer
         return writer
 
-    def write_shard_block(self, shard_id: str, block: Block) -> None:
+    def write_shard_block(self, shard_id: str, block: Block) -> int | None:
         table = block_to_table(block)
         if table.num_rows == 0:
             return
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.submit_table(shard_id, table))
+            return self._asset_rows_written.pop(shard_id, 0)
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
         self._writer(shard_id, table.schema).write_batch(table)
 
-    def on_shard_complete(self, shard_id: str) -> None:
-        if self._assets is not None:
+    def _write_ready_asset_blocks(self, blocks: list[ReadyAssetBlock]) -> None:
+        for ready in blocks:
+            assert isinstance(ready.block, pa.Table)
+            self._writer(ready.shard_id, ready.block.schema).write_batch(ready.block)
+            self._asset_rows_written[ready.shard_id] = (
+                self._asset_rows_written.get(ready.shard_id, 0) + ready.block.num_rows
+            )
+
+    def on_shard_complete(self, shard_id: str) -> int | None:
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.on_shard_complete(shard_id))
+        elif self._assets is not None:
             self._assets.on_shard_complete(shard_id)
         writer = self._writers.pop(shard_id, None)
         if writer is not None:
             writer.close()
             log_throughput("files_written", 1, shard_id=shard_id, unit="files")
+        if isinstance(self._assets, AssetUploadManager):
+            return self._asset_rows_written.pop(shard_id, 0)
+        return None
 
     def close(self) -> None:
         first_error: Exception | None = None

--- a/src/refiner/pipeline/sinks/parquet.py
+++ b/src/refiner/pipeline/sinks/parquet.py
@@ -19,6 +19,7 @@ from refiner.pipeline.sinks.assets import (
     BlobAssetConfig,
     BlobAssetManager,
     FileAssetConfig,
+    ReadyAssetBlock,
     asset_config_to_plan,
 )
 from refiner.pipeline.sinks.base import BaseSink
@@ -43,6 +44,7 @@ class ParquetSink(BaseSink):
         self.assets = assets
         self.dtypes = dtypes
         self._writers: dict[str, pq.ParquetWriter] = {}
+        self._asset_rows_written: dict[str, int] = {}
         self._schema: pa.Schema | None = None
         if isinstance(assets, FileAssetConfig):
             self._assets = AssetUploadManager(
@@ -100,19 +102,35 @@ class ParquetSink(BaseSink):
         if self._assets is None:
             self._writer(shard_id, table.schema).write_table(table)
             return table.num_rows
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.submit_table(shard_id, table))
+            return self._asset_rows_written.pop(shard_id, 0)
         self._writer(
             shard_id,
             (table := self._assets.rewrite_table(shard_id, table)).schema,
         ).write_table(table)
         return table.num_rows
 
-    def on_shard_complete(self, shard_id: str) -> None:
-        if self._assets is not None:
+    def _write_ready_asset_blocks(self, blocks: list[ReadyAssetBlock]) -> None:
+        for ready in blocks:
+            assert isinstance(ready.block, pa.Table)
+            self._writer(ready.shard_id, ready.block.schema).write_table(ready.block)
+            self._asset_rows_written[ready.shard_id] = (
+                self._asset_rows_written.get(ready.shard_id, 0) + ready.block.num_rows
+            )
+
+    def on_shard_complete(self, shard_id: str) -> int | None:
+        if isinstance(self._assets, AssetUploadManager):
+            self._write_ready_asset_blocks(self._assets.on_shard_complete(shard_id))
+        elif self._assets is not None:
             self._assets.on_shard_complete(shard_id)
         writer = self._writers.pop(shard_id, None)
         if writer is not None:
             writer.close()
             log_throughput("files_written", 1, shard_id=shard_id, unit="files")
+        if isinstance(self._assets, AssetUploadManager):
+            return self._asset_rows_written.pop(shard_id, 0)
+        return None
 
     def close(self) -> None:
         try:

--- a/src/refiner/video/remux.py
+++ b/src/refiner/video/remux.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import partial
-from typing import IO, Any
+from typing import IO, Any, cast
 from typing import TYPE_CHECKING
 
 from refiner.io import DataFolder
@@ -16,6 +16,7 @@ from refiner.pipeline.utils.cache.decoder_cache import (
 )
 from refiner.pipeline.utils.cache.lease_cache import CacheLease
 from refiner.utils import check_required_dependencies
+from refiner.video.s3_mp4 import S3MultipartSeekableWriter, supports_s3_multipart
 
 if TYPE_CHECKING:
     from refiner.video.types import VideoBytes, VideoFile
@@ -80,10 +81,19 @@ class RemuxWriter:
         probe: VideoSourceProbe,
     ) -> "RemuxWriter":
         check_required_dependencies("video remuxing", ["av"], dist="video")
-        output_file = folder.open(output_rel, mode="wb")
+        output_abs = folder._join(output_rel)
+        if supports_s3_multipart(folder.fs):
+            output_file = cast(
+                IO[bytes], S3MultipartSeekableWriter(folder.fs, output_abs)
+            )
+            movflags = None
+        else:
+            output_file = folder.open(output_rel, mode="wb")
+            movflags = _SEGMENTED_MP4_MOVFLAGS
         return cls.open_file(
             output_file=output_file,
             probe=probe,
+            movflags=movflags,
         )
 
     @classmethod
@@ -106,7 +116,11 @@ class RemuxWriter:
                 options=options,
             )
         except Exception:
-            output_file.close()
+            abort = getattr(output_file, "abort", None)
+            if callable(abort):
+                abort()
+            else:
+                output_file.close()
             raise
         return cls(probe=probe, output_file=output_file, container=container)
 
@@ -115,7 +129,13 @@ class RemuxWriter:
         return int(self.output_file.tell())
 
     def close(self) -> None:
-        self.container.close()
+        try:
+            self.container.close()
+        except Exception:
+            abort = getattr(self.output_file, "abort", None)
+            if callable(abort):
+                abort()
+            raise
         self.output_file.close()
 
     def append_prepared_video(

--- a/src/refiner/video/s3_mp4.py
+++ b/src/refiner/video/s3_mp4.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import errno
+import io
+from typing import Any
+
+_S3_MULTIPART_MIN_PART_SIZE = 5 * 1024 * 1024
+
+
+def supports_s3_multipart(fs: Any) -> bool:
+    """Return whether *fs* exposes s3fs' multipart-upload primitives."""
+    protocol = getattr(fs, "protocol", ())
+    protocols = {protocol} if isinstance(protocol, str) else set(protocol)
+    return (
+        "s3" in protocols
+        and callable(getattr(fs, "call_s3", None))
+        and callable(getattr(fs, "split_path", None))
+    )
+
+
+class S3MultipartSeekableWriter(io.RawIOBase):
+    """Bounded-memory, forward-streaming S3 writer with a mutable first part.
+
+    FFmpeg's normal MP4 muxer writes the ``mdat`` length into the initial bytes
+    only after it has written media data. S3 multipart uploads permit parts to
+    arrive out of order, so this writer withholds part 1, uploads later full
+    parts immediately, and uploads the patched first part during finalization.
+    """
+
+    def __init__(self, fs: Any, path: str) -> None:
+        super().__init__()
+        self._fs = fs
+        self._path = path
+        self._bucket, self._key, _ = fs.split_path(path)
+        self._prefix = bytearray()
+        self._tail = bytearray()
+        self._position = 0
+        self._size = 0
+        self._upload_id: str | None = None
+        self._parts: dict[int, dict[str, Any]] = {}
+        self._next_media_part = 2
+        self._closed = False
+
+    def writable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return False
+
+    def tell(self) -> int:
+        self._check_open()
+        return self._position
+
+    def write(self, data: Any) -> int:
+        self._check_open()
+        payload = bytes(data)
+        end = self._position + len(payload)
+        if self._position > self._size:
+            raise OSError(errno.EINVAL, "cannot create holes in an MP4 output")
+        if self._position < self._size and end > self._size:
+            raise OSError(errno.ESPIPE, "cannot overwrite uploaded MP4 media")
+        if self._position < _S3_MULTIPART_MIN_PART_SIZE:
+            prefix_end = min(end, _S3_MULTIPART_MIN_PART_SIZE)
+            self._write_prefix(self._position, payload[: prefix_end - self._position])
+            if prefix_end < end:
+                self._append_tail(payload[prefix_end - self._position :])
+        elif self._position == self._size:
+            self._append_tail(payload)
+        else:
+            raise OSError(errno.ESPIPE, "cannot overwrite uploaded MP4 media")
+        self._position = end
+        self._size = max(self._size, end)
+        return len(payload)
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        self._check_open()
+        if whence == io.SEEK_SET:
+            position = offset
+        elif whence == io.SEEK_CUR:
+            position = self._position + offset
+        elif whence == io.SEEK_END:
+            position = self._size + offset
+        else:
+            raise ValueError(f"unsupported seek whence: {whence}")
+        if position < 0:
+            raise ValueError("negative seek position")
+        if position > self._size:
+            raise OSError(errno.EINVAL, "cannot seek beyond the MP4 output")
+        if position > _S3_MULTIPART_MIN_PART_SIZE and position != self._size:
+            raise OSError(errno.ESPIPE, "cannot seek into uploaded MP4 media")
+        self._position = position
+        return position
+
+    def flush(self) -> None:
+        # AVIO may flush while it is closing the Python file object.
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._complete()
+        except Exception:
+            self.abort()
+            raise
+        finally:
+            self._closed = True
+            super().close()
+
+    def abort(self) -> None:
+        if self._upload_id is not None:
+            try:
+                self._call_s3(
+                    "abort_multipart_upload",
+                    Bucket=self._bucket,
+                    Key=self._key,
+                    UploadId=self._upload_id,
+                )
+            finally:
+                self._upload_id = None
+                self._parts.clear()
+        self._closed = True
+        super().close()
+
+    def _write_prefix(self, position: int, data: bytes) -> None:
+        was_complete = len(self._prefix) == _S3_MULTIPART_MIN_PART_SIZE
+        end = position + len(data)
+        if end > len(self._prefix):
+            if position != len(self._prefix):
+                raise OSError(errno.EINVAL, "cannot create holes in MP4 prefix")
+            self._prefix.extend(data)
+        else:
+            self._prefix[position:end] = data
+        if not was_complete and len(self._prefix) == _S3_MULTIPART_MIN_PART_SIZE:
+            self._ensure_upload()
+            self._upload_part(part_number=1, data=bytes(self._prefix))
+
+    def _append_tail(self, data: bytes) -> None:
+        self._tail.extend(data)
+        while len(self._tail) >= _S3_MULTIPART_MIN_PART_SIZE:
+            self._ensure_upload()
+            self._upload_part(
+                part_number=self._next_media_part,
+                data=bytes(self._tail[:_S3_MULTIPART_MIN_PART_SIZE]),
+            )
+            self._next_media_part += 1
+            del self._tail[:_S3_MULTIPART_MIN_PART_SIZE]
+
+    def _complete(self) -> None:
+        if self._upload_id is None:
+            self._call_s3(
+                "put_object",
+                Bucket=self._bucket,
+                Key=self._key,
+                Body=bytes(self._prefix),
+            )
+            return
+        # Re-uploading part 1 atomically replaces its placeholder version in
+        # both S3 and R2 before the multipart upload is completed.
+        self._upload_part(part_number=1, data=bytes(self._prefix))
+        if self._tail:
+            self._upload_part(part_number=self._next_media_part, data=bytes(self._tail))
+        self._call_s3(
+            "complete_multipart_upload",
+            Bucket=self._bucket,
+            Key=self._key,
+            UploadId=self._upload_id,
+            MultipartUpload={
+                "Parts": [self._parts[number] for number in sorted(self._parts)]
+            },
+        )
+        self._upload_id = None
+        self._parts.clear()
+
+    def _ensure_upload(self) -> None:
+        if self._upload_id is not None:
+            return
+        response = self._call_s3(
+            "create_multipart_upload", Bucket=self._bucket, Key=self._key
+        )
+        self._upload_id = str(response["UploadId"])
+
+    def _upload_part(self, *, part_number: int, data: bytes) -> None:
+        if self._upload_id is None:
+            raise RuntimeError("multipart upload was not initialized")
+        response = self._call_s3(
+            "upload_part",
+            Bucket=self._bucket,
+            Key=self._key,
+            UploadId=self._upload_id,
+            PartNumber=part_number,
+            Body=data,
+        )
+        part: dict[str, Any] = {"PartNumber": part_number, "ETag": response["ETag"]}
+        if "ChecksumSHA256" in response:
+            part["ChecksumSHA256"] = response["ChecksumSHA256"]
+        self._parts[part_number] = part
+
+    def _call_s3(self, method: str, **kwargs: Any) -> Any:
+        """Match s3fs' per-file calls, including configured S3 request options."""
+        return self._fs.call_s3(
+            method, getattr(self._fs, "s3_additional_kwargs", {}), **kwargs
+        )
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise ValueError("I/O operation on closed S3 multipart writer")
+
+
+__all__ = ["S3MultipartSeekableWriter", "supports_s3_multipart"]

--- a/src/refiner/video/transcode.py
+++ b/src/refiner/video/transcode.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from fractions import Fraction
 import os
-from typing import IO, Any
+from typing import IO, Any, cast
 import numpy as np
 
 from refiner.io import DataFolder
@@ -15,6 +15,7 @@ from refiner.video.remux import (
     video_from_timestamp_s,
     video_to_timestamp_s,
 )
+from refiner.video.s3_mp4 import S3MultipartSeekableWriter, supports_s3_multipart
 
 _SEGMENTED_MP4_MOVFLAGS = "frag_keyframe+default_base_moof"
 
@@ -74,11 +75,20 @@ class TranscodeWriter:
         fps: float,
     ) -> "TranscodeWriter":
         check_required_dependencies("video transcoding", ["av"], dist="video")
-        output_file = folder.open(output_rel, mode="wb")
+        output_abs = folder._join(output_rel)
+        if supports_s3_multipart(folder.fs):
+            output_file = cast(
+                IO[bytes], S3MultipartSeekableWriter(folder.fs, output_abs)
+            )
+            movflags = None
+        else:
+            output_file = folder.open(output_rel, mode="wb")
+            movflags = _SEGMENTED_MP4_MOVFLAGS
         return cls.open_file(
             output_file=output_file,
             config=config,
             fps=fps,
+            movflags=movflags,
         )
 
     @classmethod
@@ -103,7 +113,11 @@ class TranscodeWriter:
                 options=options,
             )
         except Exception:
-            output_file.close()
+            abort = getattr(output_file, "abort", None)
+            if callable(abort):
+                abort()
+            else:
+                output_file.close()
             raise
         return writer
 
@@ -212,8 +226,13 @@ class TranscodeWriter:
             if self.stream is not None:
                 for packet in self.stream.encode(None):
                     container.mux(packet)
-        finally:
             container.close()
+        except Exception:
+            abort = getattr(self.output_file, "abort", None)
+            if callable(abort):
+                abort()
+            raise
+        finally:
             self.container = None
             self.stream = None
         if self.output_file is not None:

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -17,6 +17,7 @@ from refiner.worker.metrics.emitter import (
     NOOP_USER_METRICS_EMITTER,
     UserMetricsEmitter,
 )
+from refiner.worker.metrics.api import log_throughput
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,13 +124,21 @@ class Worker:
                     return
 
         def _complete_shard(shard_id: str) -> None:
-            nonlocal completed
+            nonlocal completed, output_rows
             with inflight_lock:
                 shard = inflight_by_id.get(shard_id)
                 if shard is None:
                     return
             with set_active_step_index(sink_step_index):
-                sink.on_shard_complete(shard_id)
+                finalized_rows = sink.on_shard_complete(shard_id)
+            if finalized_rows is not None and sink.counts_output_rows:
+                output_rows += finalized_rows
+                log_throughput(
+                    "rows_written",
+                    finalized_rows,
+                    shard_id=shard_id,
+                    unit="rows",
+                )
             self.user_metrics_emitter.force_flush_user_metrics()
             self.runtime_lifecycle.complete(shard)
             try:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1585,6 +1585,59 @@ def test_file_asset_copy_removes_partial_output_when_source_disappears(
     assert not (tmp_path / "file-assets" / relpath).exists()
 
 
+def test_file_asset_upload_window_overlaps_one_row_blocks(
+    tmp_path, monkeypatch
+) -> None:
+    output_dir = tmp_path / "overlapping-file-assets"
+    shard_id = "0123456789ab"
+    sink = JsonlSink(output_dir, assets=FileAssetConfig(max_in_flight=2))
+    sink.set_input_schema(pa.schema([datatype.image_path().with_name("image")]))
+    assert isinstance(sink._assets, AssetUploadManager)
+    both_started = threading.Event()
+    release = threading.Event()
+    started = 0
+    lock = threading.Lock()
+
+    def blocked_copy(
+        _value: object,
+        _storage: str,
+        _relpath: str,
+        *,
+        shard_id: str,
+    ) -> bool:
+        nonlocal started
+        del shard_id
+        with lock:
+            started += 1
+            if started == 2:
+                both_started.set()
+        assert release.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(sink._assets, "_copy_asset", blocked_copy)
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        assert sink.write_shard_block(
+            shard_id, [DictRow({"image": "first.png", "value": 1})]
+        ) == 0
+        assert sink.write_shard_block(
+            shard_id, [DictRow({"image": "second.png", "value": 2})]
+        ) == 0
+        assert both_started.wait(timeout=5)
+        assert not list(output_dir.glob("*.jsonl"))
+        release.set()
+        assert sink.on_shard_complete(shard_id) == 2
+
+    output_file = next(output_dir.glob("*.jsonl"))
+    rows = [json.loads(line) for line in output_file.read_text().splitlines()]
+    assert [row["value"] for row in rows] == [1, 2]
+
+
 def test_blob_asset_copy_stages_source_before_mutating_output(
     tmp_path, monkeypatch
 ) -> None:
@@ -1793,14 +1846,15 @@ def test_jsonl_sink_error_policy_raises_on_later_failed_asset(tmp_path) -> None:
         worker_name=None,
         runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
     ):
+        sink.write_shard_block(
+            shard_id,
+            [
+                DictRow({"image": str(source), "label": "valid"}),
+                DictRow({"image": str(missing), "label": "missing"}),
+            ],
+        )
         with pytest.raises(FileNotFoundError):
-            sink.write_shard_block(
-                shard_id,
-                [
-                    DictRow({"image": str(source), "label": "valid"}),
-                    DictRow({"image": str(missing), "label": "missing"}),
-                ],
-            )
+            sink.on_shard_complete(shard_id)
 
 
 def test_asset_upload_rejects_unsafe_assets_subdir(tmp_path) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1622,12 +1622,18 @@ def test_file_asset_upload_window_overlaps_one_row_blocks(
         worker_name=None,
         runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
     ):
-        assert sink.write_shard_block(
-            shard_id, [DictRow({"image": "first.png", "value": 1})]
-        ) == 0
-        assert sink.write_shard_block(
-            shard_id, [DictRow({"image": "second.png", "value": 2})]
-        ) == 0
+        assert (
+            sink.write_shard_block(
+                shard_id, [DictRow({"image": "first.png", "value": 1})]
+            )
+            == 0
+        )
+        assert (
+            sink.write_shard_block(
+                shard_id, [DictRow({"image": "second.png", "value": 2})]
+            )
+            == 0
+        )
         assert both_started.wait(timeout=5)
         assert not list(output_dir.glob("*.jsonl"))
         release.set()

--- a/tests/video/test_s3_mp4.py
+++ b/tests/video/test_s3_mp4.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+from refiner.video.s3_mp4 import S3MultipartSeekableWriter, supports_s3_multipart
+from refiner.video.transcode import TranscodeWriter, VideoTranscodeConfig
+
+_PART_SIZE = 5 * 1024 * 1024
+
+
+class _FakeS3FileSystem:
+    protocol = "s3"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.parts: dict[int, bytes] = {}
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    @staticmethod
+    def split_path(path: str) -> tuple[str, str, None]:
+        bucket, key = path.split("/", 1)
+        return bucket, key, None
+
+    def call_s3(self, method: str, *args, **kwargs):
+        assert args == ({},)
+        self.calls.append((method, kwargs))
+        if method == "create_multipart_upload":
+            return {"UploadId": "upload-1"}
+        if method == "upload_part":
+            self.parts[kwargs["PartNumber"]] = bytes(kwargs["Body"])
+            return {"ETag": f"etag-{kwargs['PartNumber']}"}
+        if method == "complete_multipart_upload":
+            parts = kwargs["MultipartUpload"]["Parts"]
+            self.objects[(kwargs["Bucket"], kwargs["Key"])] = b"".join(
+                self.parts[part["PartNumber"]] for part in parts
+            )
+            return {}
+        if method == "abort_multipart_upload":
+            self.parts.clear()
+            return {}
+        if method == "put_object":
+            self.objects[(kwargs["Bucket"], kwargs["Key"])] = bytes(kwargs["Body"])
+            return {}
+        raise AssertionError(method)
+
+
+def test_s3_multipart_writer_rewrites_only_prefix_and_streams_later_parts() -> None:
+    fs = _FakeS3FileSystem()
+    writer = S3MultipartSeekableWriter(fs, "bucket/video.mp4")
+    payload = bytearray(b"\0" * (_PART_SIZE * 2 + 23))
+    writer.write(payload)
+    writer.seek(36)
+    writer.write(b"mdat")
+    writer.seek(0, io.SEEK_END)
+    writer.close()
+
+    assert fs.objects[("bucket", "video.mp4")][36:40] == b"mdat"
+    assert len(fs.objects[("bucket", "video.mp4")]) == len(payload)
+    assert [method for method, _ in fs.calls] == [
+        "create_multipart_upload",
+        "upload_part",
+        "upload_part",
+        "upload_part",
+        "upload_part",
+        "complete_multipart_upload",
+    ]
+    assert [call[1]["PartNumber"] for call in fs.calls if call[0] == "upload_part"] == [
+        1,
+        2,
+        1,
+        3,
+    ]
+    uploaded_parts = [call[1] for call in fs.calls if call[0] == "upload_part"]
+    assert uploaded_parts[0]["Body"][36:40] == b"\0\0\0\0"
+    assert uploaded_parts[2]["Body"][36:40] == b"mdat"
+    assert [
+        part["PartNumber"] for part in fs.calls[-1][1]["MultipartUpload"]["Parts"]
+    ] == [
+        1,
+        2,
+        3,
+    ]
+
+
+def test_s3_multipart_writer_aborts_after_upload_failure() -> None:
+    class FailingS3(_FakeS3FileSystem):
+        def call_s3(self, method: str, *args, **kwargs):
+            if method == "complete_multipart_upload":
+                raise RuntimeError("completion failed")
+            return super().call_s3(method, *args, **kwargs)
+
+    fs = FailingS3()
+    writer = S3MultipartSeekableWriter(fs, "bucket/video.mp4")
+    writer.write(b"\0" * (_PART_SIZE + 1))
+
+    with pytest.raises(RuntimeError, match="completion failed"):
+        writer.close()
+
+    assert fs.calls[-1][0] == "abort_multipart_upload"
+
+
+def test_conventional_mp4_uses_moov_not_moof() -> None:
+    fs = _FakeS3FileSystem()
+    output = S3MultipartSeekableWriter(fs, "bucket/video.mp4")
+    writer = TranscodeWriter.open_file(
+        output_file=output,
+        config=VideoTranscodeConfig(codec="h264"),
+        fps=5,
+        movflags=None,
+    )
+    writer.append_frame_arrays(
+        [np.full((16, 16, 3), value, dtype=np.uint8) for value in range(10)]
+    )
+    writer.close()
+
+    data = fs.objects[("bucket", "video.mp4")]
+    assert b"moov" in data
+    assert b"moof" not in data
+
+    import av
+
+    with av.open(io.BytesIO(data), mode="r") as container:
+        stream = container.streams.video[0]
+        assert stream.frames == 10
+        assert float(stream.duration * stream.time_base) == pytest.approx(2.0)
+
+
+def test_s3_capability_requires_s3fs_multipart_surface() -> None:
+    assert supports_s3_multipart(_FakeS3FileSystem())
+    assert not supports_s3_multipart(object())

--- a/tests/video/test_s3_mp4.py
+++ b/tests/video/test_s3_mp4.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from typing import IO, cast
 
 import numpy as np
 import pytest
@@ -106,7 +107,7 @@ def test_conventional_mp4_uses_moov_not_moof() -> None:
     fs = _FakeS3FileSystem()
     output = S3MultipartSeekableWriter(fs, "bucket/video.mp4")
     writer = TranscodeWriter.open_file(
-        output_file=output,
+        output_file=cast(IO[bytes], output),
         config=VideoTranscodeConfig(codec="h264"),
         fps=5,
         movflags=None,
@@ -125,6 +126,8 @@ def test_conventional_mp4_uses_moov_not_moof() -> None:
     with av.open(io.BytesIO(data), mode="r") as container:
         stream = container.streams.video[0]
         assert stream.frames == 10
+        assert stream.duration is not None
+        assert stream.time_base is not None
         assert float(stream.duration * stream.time_base) == pytest.approx(2.0)
 
 


### PR DESCRIPTION
## Summary

- write conventional indexed MP4 files directly to S3-compatible object storage without buffering the complete video locally
- support AWS S3 and Cloudflare R2 through the s3fs multipart API, replacing the retained first part after FFmpeg patches the mdat header
- keep FileAssetConfig upload windows alive across input blocks, applying bounded backpressure only at max_in_flight and draining at shard finalization
- preserve ordered output, missing-asset policies, exact output-row accounting, and cleanup behavior across Parquet, JSONL, standalone Lance, and Lance datasets

## Why

Standard fsspec object-store write handles are non-seekable, which forced video outputs to use fragmented MP4. FFmpeg normal MP4 finalization only needs bounded backward access to the retained prefix, so multipart part replacement enables a conventional moov index without a full temporary video.

File asset sinks separately drained their asynchronous upload window after every input block. With block size 1, this reduced max_in_flight to effectively one asset upload per block and prevented cross-block I/O overlap. Pending rows and upload results now survive block boundaries and are finalized in submission order.

## User impact

S3 and R2 video outputs are conventional indexed MP4 files with complete duration and frame metadata. FileAssetConfig can overlap uploads even for one-row blocks, while rows remain hidden until their referenced uploads complete. Failures may surface during bounded backpressure or shard finalization.

## Validation

- 102 pipeline sink tests passed
- 22 worker runner tests passed
- 4 S3 multipart MP4 tests passed
- Ruff passed for changed source and tests
- Ty passed for source and relevant tests; repository check also passes when excluding the unrelated untracked examples/debug directory
