### PR TITLE
fix(cloud): preserve runtime positional arguments

### DIFF
--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -58,11 +58,6 @@ Broad selectors are `us`, `eu`, `ca`, and `uk`. Narrow selectors are
 `eu-south`. `eu` excludes the UK. Madrid is classified as `eu-south`; the
 defensive `FRA*` and `AMS` aliases are classified as `eu-west`.
 
-Region selection does not purchase a Modal region lock. Macrodata starts an
-unconstrained worker, checks its actual placement before initializing the
-pipeline or claiming shards, and replaces it when it does not match. A worker
-range is retried up to 20 total placement attempts.
-
 ## What gets submitted
 
 A cloud submission includes:

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -139,11 +139,11 @@ class StageLifecycleResponse(msgspec.Struct, frozen=True):
 @dataclass(frozen=True, slots=True)
 class CloudRuntimeConfig:
     num_workers: int | Literal["auto"]
-    cloud: CloudProvider = "aws"
-    region: tuple[CloudRegion, ...] = ("us", "eu", "ca")
     cpus_per_worker: int | None = None
     mem_mb_per_worker: int | None = None
     gpu: GPU | None = None
+    cloud: CloudProvider = "aws"
+    region: tuple[CloudRegion, ...] = ("us", "eu", "ca")
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -57,6 +57,18 @@ def _request() -> CloudRunCreateRequest:
     )
 
 
+def test_cloud_runtime_config_preserves_positional_resource_order() -> None:
+    gpu = GPU(count=2, type="h100", cuda_version="12.4")
+
+    runtime = CloudRuntimeConfig(2, 4, 8192, gpu)
+
+    assert runtime.cpus_per_worker == 4
+    assert runtime.mem_mb_per_worker == 8192
+    assert runtime.gpu is gpu
+    assert runtime.cloud == "aws"
+    assert runtime.region == ("us", "eu", "ca")
+
+
 def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- preserve the existing positional argument order for `CloudRuntimeConfig`
- keep `cloud` and `region` as appended defaulted fields
- remove internal placement mechanics from the customer guide
- add a regression test for positional construction

## Verification
- `uv run pytest tests/platform/test_cloud_client.py tests/launchers/test_cloud_launcher.py` (70 passed)
- `uv run ruff check --force-exclude src/refiner/platform/client/models.py tests/platform/test_cloud_client.py`
- `uv run ty check`