### PR TITLE
fix(sharding): reject plans above 10k

### DIFF
--- a/docs/reading-data/sharding.md
+++ b/docs/reading-data/sharding.md
@@ -48,6 +48,17 @@ pipeline = mdr.read_lerobot(
 )
 ```
 
+Refiner rejects plans above 10,000 shards. This applies both to explicit
+`num_shards` values and to automatic plans derived from input sizes or row
+ranges. If an automatic plan exceeds the limit, increase `target_shard_bytes`
+or set `num_shards` to 10,000 or fewer. If the inputs themselves require more
+than 10,000 shards—for example, more than 10,000 non-empty Zarr stores—combine
+them into fewer inputs before reading them.
+
+`mdr.task(..., num_tasks=...)` has the same 10,000-task limit. For larger
+logical workloads, use 10,000 or fewer tasks and process multiple work units
+inside each task.
+
 Do not overfit shard count before measuring. Too few shards leave workers idle;
 too many shards add scheduling and output overhead.
 
@@ -62,4 +73,3 @@ chunks and then reduces metadata; see [Writing LeRobot](../writing-data/lerobot.
 - [Reader Model](reader-model.md)
 - [Local Launcher](../running-pipelines/local-launcher.md)
 - [Cloud Launcher](../running-pipelines/cloud-launcher.md)
-

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -58,6 +58,7 @@ from refiner.pipeline.sources.readers.hdf5 import MissingPolicy
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.pipeline.sources.readers.mcap import SyncMethod
 from refiner.pipeline.sources.items import ItemsSource
+from refiner.pipeline.sources.shard_limit import validate_shard_count
 from refiner.pipeline.sources.task import TaskSource, TaskStep
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.datatype import DTypeLike, DTypeMapping
@@ -577,7 +578,9 @@ class RefinerPipeline:
         This delegates to the source shard planner and is useful for debugging
         sharding decisions without executing the pipeline transforms.
         """
-        return list(self.source.list_shards())
+        shards = list(self.source.list_shards())
+        validate_shard_count(len(shards), source="Source")
+        return shards
 
     def materialize(self) -> list[Row]:
         """Execute locally and collect every output row into memory.

--- a/src/refiner/pipeline/sources/items.py
+++ b/src/refiner/pipeline/sources/items.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
 from refiner.pipeline.sources.base import BaseSource
+from refiner.pipeline.sources.shard_limit import validate_shard_count
 from refiner.pipeline.data.row import DictRow, Row
 
 _DEFAULT_ITEMS_PER_SHARD = 1_000
@@ -27,6 +28,8 @@ class ItemsSource(BaseSource):
         self._rows = tuple(_normalize_item(item) for item in items)
         self._row_count = len(self._rows)
         self._items_per_shard = items_per_shard
+        shard_count = (self._row_count + items_per_shard - 1) // items_per_shard
+        validate_shard_count(shard_count, source="Items")
 
     def list_shards(self) -> list[Shard]:
         shards: list[Shard] = []

--- a/src/refiner/pipeline/sources/lance.py
+++ b/src/refiner/pipeline/sources/lance.py
@@ -17,6 +17,10 @@ from refiner.pipeline.data.shard import (
 from refiner.pipeline.data.tabular import Tabular, set_or_append_column
 from refiner.pipeline.sinks.lance_utils import validate_lance_uri
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.shard_limit import (
+    validate_num_shards,
+    validate_shard_count,
+)
 from refiner.utils import check_required_dependencies
 
 _LANCE_ROW_ADDRESS_COLUMN = "_rowaddr"
@@ -70,6 +74,7 @@ class LanceSource(BaseSource):
             raise ValueError("batch_size must be > 0")
         if columns is not None and len(set(columns)) != len(columns):
             raise ValueError("Lance columns must be unique")
+        validate_num_shards(num_shards)
 
         self.input = DataFolder.resolve(input)
         if self.input.has_explicit_filesystem_configuration:
@@ -158,6 +163,8 @@ class LanceSource(BaseSource):
         fragment_count = len(self._dataset().get_fragments())
         if fragment_count == 0:
             return []
+        if self.num_shards is None or self.num_shards <= 0:
+            validate_shard_count(fragment_count, source="Lance automatic")
         shard_count = (
             fragment_count
             if self.num_shards is None or self.num_shards <= 0

--- a/src/refiner/pipeline/sources/readers/base.py
+++ b/src/refiner/pipeline/sources/readers/base.py
@@ -15,6 +15,10 @@ from refiner.pipeline.data.datatype import DTypeMapping, schema_with_dtypes
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline.data.tabular import repeat_scalar, set_or_append_column
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.shard_limit import (
+    validate_num_shards,
+    validate_shard_count,
+)
 from refiner.pipeline.sources.readers.utils import (
     BoundedBinaryReader,
     DEFAULT_TARGET_SHARD_BYTES,
@@ -75,6 +79,7 @@ class BaseReader(BaseSource):
             extensions=extensions,
             include_file=include_file,
         )
+        validate_num_shards(num_shards)
         self.target_shard_bytes = max(1, target_shard_bytes)
         self.num_shards = num_shards
         self.file_path_column = file_path_column
@@ -243,6 +248,8 @@ class BaseReader(BaseSource):
             shards.append(
                 Shard.from_file_parts(current_parts, global_ordinal=len(shards))
             )
+            if num_shards is None or num_shards <= 0:
+                validate_shard_count(len(shards), source=self.name)
             current_parts = []
             current_size = 0
             if shard_sizes is not None and len(shards) < len(shard_sizes):

--- a/src/refiner/pipeline/sources/readers/hf_dataset.py
+++ b/src/refiner/pipeline/sources/readers/hf_dataset.py
@@ -20,6 +20,10 @@ from refiner.pipeline.data.shard import (
 from refiner.pipeline.data.tabular import Tabular, filter_table, set_or_append_column
 from refiner.pipeline.expressions import Expr
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.shard_limit import (
+    validate_num_shards,
+    validate_shard_count,
+)
 from refiner.pipeline.sources.readers.parquet import ParquetReader
 from refiner.pipeline.sources.readers.utils import DEFAULT_TARGET_SHARD_BYTES
 from refiner.utils import check_required_dependencies
@@ -61,6 +65,7 @@ class HFDatasetReader(BaseSource):
         self.split = split
         self.timeout = float(timeout)
         self.target_shard_bytes = target_shard_bytes
+        validate_num_shards(num_shards)
         self.num_shards = num_shards
         self.arrow_batch_size = arrow_batch_size
         self.columns_to_read = (
@@ -243,6 +248,7 @@ class HFDatasetReader(BaseSource):
         available = int(getattr(dataset, "num_shards", 1) or 1)
         requested = int(num_shards) if num_shards is not None else None
         wanted = available if requested is None or requested <= 0 else requested
+        validate_shard_count(wanted, source="Hugging Face fallback")
         if wanted > available:
             raise ValueError(
                 f"Hugging Face fallback for {self.repo!r} has only {available} "

--- a/src/refiner/pipeline/sources/readers/lerobot.py
+++ b/src/refiner/pipeline/sources/readers/lerobot.py
@@ -18,6 +18,7 @@ from refiner.pipeline.data.tabular import Tabular, set_or_append_column
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.pipeline.sources.readers.parquet import ParquetReader
 from refiner.pipeline.sources.readers.utils import DEFAULT_TARGET_SHARD_BYTES
+from refiner.pipeline.sources.shard_limit import validate_num_shards
 from refiner.robotics.lerobot_format import (
     LeRobotInfo,
     LeRobotMetadata,
@@ -71,6 +72,7 @@ class LeRobotEpisodeReader(BaseSource):
         )
         if not self._root_fileset.entries:
             raise ValueError("LeRobot reader requires at least one dataset root")
+        validate_num_shards(num_shards)
         self._roots: tuple[DataFolder, ...] | None = None
         self._episode_reader: ParquetReader | None = None
         self.target_shard_bytes = target_shard_bytes

--- a/src/refiner/pipeline/sources/readers/tfds.py
+++ b/src/refiner/pipeline/sources/readers/tfds.py
@@ -13,6 +13,10 @@ from refiner.pipeline.data.row import DictRow
 from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.shard_limit import (
+    validate_num_shards,
+    validate_shard_count,
+)
 from refiner.pipeline.sources.readers.utils import (
     PathSelection,
     path_selection_map,
@@ -81,6 +85,7 @@ class TfdsReader(BaseSource):
             raise ValueError("examples_per_shard must be > 0")
         if num_shards is not None and num_shards <= 0:
             raise ValueError("num_shards must be > 0 when provided")
+        validate_num_shards(num_shards)
         self.inputs = (input,) if isinstance(input, str) else tuple(input)
         if not self.inputs:
             raise ValueError("read_tfds input sequence cannot be empty")
@@ -258,6 +263,12 @@ class TfdsReader(BaseSource):
         total_examples = sum(counts)
         shards: list[Shard] = []
         if self.num_shards is None:
+            planned_count = sum(
+                (count + self.examples_per_shard - 1) // self.examples_per_shard
+                for count in counts
+                if count > 0
+            )
+            validate_shard_count(planned_count, source="TFDS automatic")
             offset = 0
             for count in counts:
                 for start in range(offset, offset + count, self.examples_per_shard):

--- a/src/refiner/pipeline/sources/readers/zarr.py
+++ b/src/refiner/pipeline/sources/readers/zarr.py
@@ -20,6 +20,10 @@ from refiner.pipeline.data.datatype import (
 from refiner.pipeline.data.row import DictRow
 from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.shard_limit import (
+    validate_num_shards,
+    validate_shard_count,
+)
 from refiner.pipeline.sources.readers.utils import (
     DEFAULT_TARGET_SHARD_BYTES,
     PathSelection,
@@ -89,6 +93,7 @@ class ZarrReader(BaseSource):
             raise ValueError("target_shard_bytes must be greater than zero")
         if num_shards is not None and num_shards <= 0:
             raise ValueError("num_shards must be greater than zero")
+        validate_num_shards(num_shards)
         if row_batch_size is not None and row_batch_size <= 0:
             raise ValueError("row_batch_size must be greater than zero")
         self.arrays = (
@@ -187,6 +192,7 @@ class ZarrReader(BaseSource):
                 split_ranges = self._shard_ranges(group, arrays)
             source_key = str(source_index)
             for start, end in split_ranges:
+                validate_shard_count(len(shards) + 1, source="Zarr")
                 shards.append(
                     Shard.from_row_range(
                         start=start,
@@ -431,6 +437,7 @@ class ZarrReader(BaseSource):
                     ),
                 )
                 step = max(chunk_rows, (target_rows // chunk_rows) * chunk_rows)
+                validate_shard_count(ceil(row_count / step), source="Zarr automatic")
             return [
                 (start, min(start + step, row_count))
                 for start in range(0, row_count, step)
@@ -466,11 +473,13 @@ class ZarrReader(BaseSource):
                 and current_bytes + row_bytes > self.target_shard_bytes
             ):
                 ranges.append((shard_start, row_index))
+                validate_shard_count(len(ranges), source="Zarr automatic")
                 shard_start = row_index
                 current_bytes = 0
             current_bytes += row_bytes
             previous_end = end
         ranges.append((shard_start, row_count))
+        validate_shard_count(len(ranges), source="Zarr automatic")
         _check_final_end(arrays, previous_end, label="row_ends", exact=True)
         return ranges
 

--- a/src/refiner/pipeline/sources/shard_limit.py
+++ b/src/refiner/pipeline/sources/shard_limit.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+MAX_SHARDS = 10_000
+
+
+def validate_shard_count(count: int, *, source: str) -> None:
+    if count > MAX_SHARDS:
+        raise ValueError(
+            f"{source} shard plan exceeds the {MAX_SHARDS:,}-shard limit; "
+            f"planned {count:,} shards"
+        )
+
+
+def validate_num_shards(num_shards: int | None) -> None:
+    if num_shards is not None:
+        validate_shard_count(num_shards, source="Explicit")

--- a/src/refiner/pipeline/sources/task.py
+++ b/src/refiner/pipeline/sources/task.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
 from refiner.pipeline.sources.base import BaseSource
+from refiner.pipeline.sources.shard_limit import validate_shard_count
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.pipeline.steps import FlatMapStep, MapResult
 
@@ -23,6 +24,7 @@ class TaskSource(BaseSource):
     ) -> None:
         if num_tasks <= 0:
             raise ValueError("num_tasks must be > 0")
+        validate_shard_count(num_tasks, source="Task")
         self._num_tasks = num_tasks
         self.claim_shards_sequentially = claim_shards_sequentially
 

--- a/tests/pipeline/test_pipeline_from_items.py
+++ b/tests/pipeline/test_pipeline_from_items.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+import pytest
+
 from refiner.pipeline import from_items
 from refiner.pipeline import from_source
 from refiner.pipeline.data.shard import FilePart, Shard
 from refiner.pipeline.data.shard import RowRangeDescriptor
 from refiner.pipeline.data.row import DictRow, Row
 from refiner.pipeline.sources.base import BaseSource
+
+
+def test_from_items_rejects_shard_count_above_limit() -> None:
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        from_items(range(10_001), items_per_shard=1)
 
 
 def test_from_items_yields_rows_across_shards() -> None:
@@ -45,7 +52,24 @@ class _CustomSource(BaseSource):
         yield DictRow({"x": 2})
 
 
+class _OversizedCustomSource(BaseSource):
+    def list_shards(self) -> list[Shard]:
+        shard = Shard.from_file_parts([FilePart(path="custom", start=0, end=1)])
+        return [shard] * 10_001
+
+    def read_shard(self, shard: Shard) -> Iterator[Row]:
+        del shard
+        return iter(())
+
+
 def test_from_source_accepts_custom_source() -> None:
     pipeline = from_source(_CustomSource()).map(lambda row: {"y": int(row["x"]) + 1})
     out = list(pipeline.iter_rows())
     assert [int(row["y"]) for row in out] == [2, 3]
+
+
+def test_from_source_rejects_custom_shard_plan_above_limit() -> None:
+    pipeline = from_source(_OversizedCustomSource())
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        pipeline.list_shards()

--- a/tests/pipeline/test_pipeline_task.py
+++ b/tests/pipeline/test_pipeline_task.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from refiner.pipeline import task
 from refiner.pipeline.planning import compile_pipeline_plan
+
+
+def test_task_rejects_shard_count_above_limit() -> None:
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        task(lambda rank, _world_size: rank, num_tasks=10_001)
 
 
 def test_task_invokes_fn_with_rank_and_world_size() -> None:

--- a/tests/readers/test_csv_reader.py
+++ b/tests/readers/test_csv_reader.py
@@ -1,3 +1,5 @@
+import pytest
+
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.readers import CsvReader
@@ -9,6 +11,22 @@ def _rows_from_shard_units(units):
             yield from unit.to_rows()
         else:
             yield unit
+
+
+def test_csv_rejects_explicit_shard_count_above_limit(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_text("id\n1\n")
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        CsvReader(str(path), num_shards=10_001)
+
+
+def test_csv_rejects_oversized_automatic_plan(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_bytes(b"x" * 10_001)
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        CsvReader(str(path), target_shard_bytes=1).list_shards()
 
 
 def test_csv_bytes_lazy_reads_all_rows_exactly_once(tmp_path):

--- a/tests/readers/test_hf_dataset_reader.py
+++ b/tests/readers/test_hf_dataset_reader.py
@@ -705,3 +705,19 @@ def test_hf_dataset_fallback_treats_non_positive_shards_as_auto(monkeypatch) -> 
     reader = HFDatasetReader("org/repo", num_shards=-1)
 
     assert len(reader.list_shards()) == 3
+
+
+def test_hf_dataset_fallback_rejects_oversized_automatic_plan(monkeypatch) -> None:
+    class FakeStreamingDataset:
+        num_shards = 10_001
+
+    _install_datasets(monkeypatch, dataset=FakeStreamingDataset())
+
+    def fake_get_json(url: str, *, timeout: float) -> object:
+        del timeout
+        return _empty_parquet_resolution(url)
+
+    monkeypatch.setattr(hf_dataset, "_get_json", fake_get_json)
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        HFDatasetReader("org/repo").list_shards()

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -11,6 +11,24 @@ from refiner.pipeline.sources.lance import LanceSource
 from refiner.pipeline.data.tabular import Tabular
 
 
+def test_load_lance_rejects_explicit_shard_count_above_limit() -> None:
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        LanceSource("unused.lance", num_shards=10_001)
+
+
+def test_load_lance_rejects_oversized_automatic_plan() -> None:
+    source = object.__new__(LanceSource)
+    source.num_shards = None
+    source._dataset_cache = type(
+        "Dataset",
+        (),
+        {"get_fragments": lambda self: [None] * 10_001},
+    )()
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        source.list_shards()
+
+
 def test_load_lance_pins_version_and_shards_by_fragment(tmp_path) -> None:
     lance = pytest.importorskip("lance")
     dataset_uri = tmp_path / "input.lance"

--- a/tests/readers/test_lerobot_reader.py
+++ b/tests/readers/test_lerobot_reader.py
@@ -45,6 +45,14 @@ def _episode_rows(reader: LeRobotEpisodeReader) -> list[LeRobotRow]:
     return rows
 
 
+def test_lerobot_rejects_explicit_shard_count_above_limit(tmp_path: Path) -> None:
+    root = tmp_path / "dataset"
+    root.mkdir()
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        LeRobotEpisodeReader(root, num_shards=10_001)
+
+
 def _build_sample_dataset(
     root: Path,
     *,

--- a/tests/readers/test_tfds_reader.py
+++ b/tests/readers/test_tfds_reader.py
@@ -332,3 +332,12 @@ def test_tfds_reader_rejects_non_positive_num_shards(
 
     with pytest.raises(ValueError, match="num_shards"):
         TfdsReader("tiny_dataset", num_shards=0)
+
+
+def test_tfds_reader_rejects_oversized_automatic_plan(monkeypatch) -> None:
+    reader = TfdsReader("tiny_dataset", examples_per_shard=1)
+    reader.num_examples_by_input = [10_001]
+    monkeypatch.setattr(reader, "_ensure_builders", lambda: None)
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        reader.list_shards()

--- a/tests/readers/test_zarr_reader.py
+++ b/tests/readers/test_zarr_reader.py
@@ -444,6 +444,33 @@ def test_read_zarr_plans_row_ends_with_num_shards(tmp_path: Path) -> None:
     np.testing.assert_allclose(rows[0]["action"], [[1.0], [1.1], [1.2]])
 
 
+def test_read_zarr_rejects_explicit_shard_count_above_limit(tmp_path: Path) -> None:
+    path = tmp_path / "policy.zarr"
+    _write_policy_zarr(path)
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        mdr.read_zarr(path, num_shards=10_001)
+
+
+def test_read_zarr_rejects_oversized_automatic_leading_axis_plan(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "large.zarr"
+    root = _open_test_zarr(path, mode="w")
+    _create_array(root, "values", np.arange(10_001, dtype=np.uint16), chunks=(1,))
+
+    reader = mdr.read_zarr(
+        path,
+        arrays={"values": "values"},
+        split_leading_axis=True,
+        target_shard_bytes=1,
+        file_path_column=None,
+    ).source
+
+    with pytest.raises(ValueError, match=r"10,000-shard limit"):
+        reader.list_shards()
+
+
 def test_read_zarr_allows_attrs_only_reads(tmp_path: Path) -> None:
     path = tmp_path / "policy.zarr"
     _write_policy_zarr(path)


### PR DESCRIPTION
## Summary

- reject every explicit shard plan above 10,000
- reject automatic file, TFDS, Hugging Face fallback, Lance, Zarr, item, and task plans above 10,000
- enforce the same cap at the shared pipeline boundary for custom sources and launchers
- fail during planning before oversized descriptor lists are materialized where the source exposes a count
- keep existing shard boundaries and planning behavior unchanged below the limit; do not coarsen plans
- provide guidance to increase `target_shard_bytes` or choose an explicit count when an automatic plan is too large

## Verification

- affected CSV, Hugging Face, Lance, LeRobot, and TFDS tests: 51 passed
- `uv run pytest tests/readers/test_zarr_reader.py`: 90 passed
- focused task, from-items, and custom-source pipeline regressions passed
- repository-wide Ruff lint and formatting passed
- `uv run ty check` passed

## Dependency

Companion Perpetuity PR updates the Refiner submodule pointer. The registration API already enforces the same 10,000-shard ceiling.