### PR TITLE
Add cloud debug source sync and doctor

### DIFF
--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -5,95 +5,109 @@ description: "Iterate on a pipeline inside one retained cloud worker"
 
 # Cloud debug sessions
 
-Use a cloud debug session when a pipeline needs the cloud runtime, dependencies,
-data access, CPU, or GPU, but you want to validate one worker before scaling out.
+Use a cloud debug session to validate a pipeline in its real cloud environment
+before launching it at scale. Keep the pipeline script unchanged:
 
 ```python
 import refiner as mdr
 
 pipeline = mdr.read_jsonl("s3://datasets/input.jsonl")
-pipeline.launch_cloud(name="debug-reader", debug=True)
+pipeline.launch_cloud(name="debug-reader", num_workers=16)
 ```
 
-The submission still creates a normal cloud job, registers its real shards, and
-uses the normal worker entrypoint. It allocates one non-preemptible worker and
-keeps that worker ready instead of immediately consuming shards.
-
-The launch output prints the job ID and follow-up commands. Wait for the worker,
-then run the pipeline against a private copy of its shard ledger:
+Create a retained session by passing that script to the CLI:
 
 ```bash
-macrodata debug status JOB_ID
-macrodata debug run JOB_ID --max-shards 1
+macrodata debug pipeline.py
 ```
 
-Every `debug run` rebuilds the private ledger from the job's registered shards.
-Completing or failing a debug shard therefore does not mutate the job's real
-shard ledger, and the same inputs are available on the next run. Omit
-`--max-shards` to exercise all registered shards assigned to the retained
-worker.
+The command executes the script locally, requires exactly one
+`launch_cloud(...)` call, and creates a normal cloud job from that launch. The
+job registers its real stage-0 shards and allocates one non-preemptible worker.
+The CLI remembers the session for the pipeline path, waits for the worker, and
+synchronizes the current project before returning.
 
-Synchronize the current project before another attempt:
+Run a small attempt:
 
 ```bash
-macrodata debug sync JOB_ID .
-macrodata debug run JOB_ID --max-shards 1
+macrodata debug run pipeline.py --max-shards 1
 ```
 
-Sync excludes version-control data, virtual environments, caches,
-`node_modules`, and dotenv files. The worker verifies the archive digest and
-atomically replaces the prior source tree, so a failed upload cannot leave a
-partial tree. Both the project root and its `src/` directory take precedence on
-`PYTHONPATH` for subsequent attempts.
+Attempts use the normal worker entrypoint, runtime token, environment,
+resources, and telemetry. Every attempt starts with fresh shard state, so the
+same inputs can be rerun without changing the job's normal execution records.
 
-Source sync updates imported Python modules. When you change the pipeline
-graph, reader, writer, or a callable captured into the serialized pipeline,
-also replace the session's pipeline payload before running again:
-
-```python
-pipeline.sync_cloud_debug("JOB_ID")
-```
-
-This serializes the selected stage locally and atomically replaces the payload
-used by the next attempt. Pass `stage_index=` when selecting a nonzero planned
-stage.
-
-Inspect the exact retained environment when imports or dependencies behave
-differently from the submitting machine:
+After editing source or the pipeline graph, perform a complete sync and rerun:
 
 ```bash
-macrodata debug doctor JOB_ID
+macrodata debug sync pipeline.py
+macrodata debug run pipeline.py --max-shards 1
 ```
 
-Doctor reports the worker Python executable/version, installed Refiner,
-Cloudpickle, py-spy and Torch versions, GPU visibility, source digest, and the
-pipeline payload path. It does not return mounted secret values.
+Sync executes the script again, captures its current cloud launch, uploads the
+project source and serialized stage-0 pipeline together, derives fresh shards
+inside the retained environment, and activates all three as one generation.
+An interrupted or invalid sync leaves the previous generation runnable. Version
+control data, virtual environments, caches, `node_modules`, and dotenv files are
+excluded.
 
-Run an arbitrary non-interactive command with argv preserved exactly:
+Dependencies, Python and Refiner versions, CPU, memory, GPU, cloud placement,
+runtime services, secrets, and plain environment variables are fixed when the
+worker is allocated. If any of these settings change, sync asks you to stop and
+create a new session:
 
 ```bash
-macrodata debug exec JOB_ID -- python -V
-macrodata debug exec JOB_ID -- bash -lc 'nvidia-smi && pip freeze | head'
+macrodata debug stop pipeline.py
+macrodata debug pipeline.py
 ```
 
-Close the session when you are done:
+Inspect the retained environment or execute a non-interactive command:
 
 ```bash
-macrodata debug stop JOB_ID
+macrodata debug status pipeline.py
+macrodata debug doctor pipeline.py
+macrodata debug exec pipeline.py -- python -V
+macrodata debug exec pipeline.py -- bash -lc 'nvidia-smi && pip freeze | head'
 ```
 
-Closing uses normal cloud job cancellation. The retained worker and its
-ephemeral files are then removed.
+Exec commands time out after 20 minutes by default. Use `--timeout SECONDS` for
+a different limit.
 
-## Current scope
+Profile an attempt with py-spy:
 
-Debug sessions are intentionally single-worker and start at the first pipeline
-stage. They are for validating correctness, dependencies, resource behavior,
-and performance before a separate normal launch scales out. Concurrent debug
-attempts in one session are rejected.
+```bash
+macrodata debug run pipeline.py --max-shards 1 --profile
+```
+
+The flamegraph is written to `refiner-debug-profile.svg`. Choose another path
+with `--profile-output PATH`, or download the latest profile again:
+
+```bash
+macrodata debug profile pipeline.py --output profile.svg
+```
+
+The pipeline path is the normal session handle. When local session state is not
+available, pass a job ID explicitly:
+
+```bash
+macrodata debug status --job JOB_ID
+macrodata debug sync pipeline.py --job JOB_ID
+```
+
+Close the session when finished:
+
+```bash
+macrodata debug stop pipeline.py
+```
+
+If the retained worker crashes or Modal replaces it, the job and debug session
+fail rather than silently continuing in a new container. Start a new session to
+continue. Synchronized files, profiles, and changes made through exec are
+ephemeral.
 
 ## Internal Notes
 
-The retained Modal function input is non-preemptible. A read-only snapshot of
-registered shards seeds an atomic SQLite ledger in the container for each
-attempt; the canonical cloud worker command receives that ledger explicitly.
+Shard claims and completions are written to an atomic, private SQLite ledger in
+the retained worker rather than the job's canonical shard ledger. Each attempt
+resets that private ledger and passes it explicitly to the normal cloud worker
+entrypoint.

--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -33,6 +33,42 @@ shard ledger, and the same inputs are available on the next run. Omit
 `--max-shards` to exercise all registered shards assigned to the retained
 worker.
 
+Synchronize the current project before another attempt:
+
+```bash
+macrodata debug sync JOB_ID .
+macrodata debug run JOB_ID --max-shards 1
+```
+
+Sync excludes version-control data, virtual environments, caches,
+`node_modules`, and dotenv files. The worker verifies the archive digest and
+atomically replaces the prior source tree, so a failed upload cannot leave a
+partial tree. Both the project root and its `src/` directory take precedence on
+`PYTHONPATH` for subsequent attempts.
+
+Source sync updates imported Python modules. When you change the pipeline
+graph, reader, writer, or a callable captured into the serialized pipeline,
+also replace the session's pipeline payload before running again:
+
+```python
+pipeline.sync_cloud_debug("JOB_ID")
+```
+
+This serializes the selected stage locally and atomically replaces the payload
+used by the next attempt. Pass `stage_index=` when selecting a nonzero planned
+stage.
+
+Inspect the exact retained environment when imports or dependencies behave
+differently from the submitting machine:
+
+```bash
+macrodata debug doctor JOB_ID
+```
+
+Doctor reports the worker Python executable/version, installed Refiner,
+Cloudpickle, py-spy and Torch versions, GPU visibility, source digest, and the
+pipeline payload path. It does not return mounted secret values.
+
 Run an arbitrary non-interactive command with argv preserved exactly:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ all = [
 [project.scripts]
 macrodata = "refiner.cli.main:main"
 mdr = "refiner.cli.main:main"
-refiner = "refiner.cli.main:main"
 
 [build-system]
 requires = ["setuptools>=77", "wheel"]

--- a/src/refiner/cli/commands/debug.py
+++ b/src/refiner/cli/commands/debug.py
@@ -33,3 +33,16 @@ def register_debug_command(
     stop.add_argument("job_id")
     stop.add_argument("--json", action="store_true")
     stop.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_stop")
+
+    sync = debug_subparsers.add_parser("sync", help="Synchronize local source")
+    sync.add_argument("job_id")
+    sync.add_argument("path", nargs="?", default=".")
+    sync.add_argument("--json", action="store_true")
+    sync.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_sync")
+
+    doctor = debug_subparsers.add_parser(
+        "doctor", help="Inspect the exact worker environment"
+    )
+    doctor.add_argument("job_id")
+    doctor.add_argument("--json", action="store_true")
+    doctor.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_doctor")

--- a/src/refiner/cli/commands/debug.py
+++ b/src/refiner/cli/commands/debug.py
@@ -6,43 +6,11 @@ import argparse
 def register_debug_command(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
-    debug = subparsers.add_parser("debug", help="Control a retained cloud debug worker")
-    debug_subparsers = debug.add_subparsers(dest="debug_command", required=True)
-
-    status = debug_subparsers.add_parser("status", help="Show debug worker status")
-    status.add_argument("job_id")
-    status.add_argument("--json", action="store_true")
-    status.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_status")
-
-    run = debug_subparsers.add_parser("run", help="Run the current pipeline once")
-    run.add_argument("job_id")
-    run.add_argument("--max-shards", type=int)
-    run.add_argument("--timeout", type=int, default=3600)
-    run.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_run")
-
-    execute = debug_subparsers.add_parser(
-        "exec", help="Execute argv in the debug worker"
+    debug = subparsers.add_parser(
+        "debug",
+        help="Create and control a retained cloud debug worker",
+        add_help=False,
     )
-    execute.add_argument("job_id")
-    execute.add_argument("--workdir")
-    execute.add_argument("--timeout", type=int, default=300)
-    execute.add_argument("exec_command", nargs=argparse.REMAINDER)
-    execute.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_exec")
-
-    stop = debug_subparsers.add_parser("stop", help="Close the debug session")
-    stop.add_argument("job_id")
-    stop.add_argument("--json", action="store_true")
-    stop.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_stop")
-
-    sync = debug_subparsers.add_parser("sync", help="Synchronize local source")
-    sync.add_argument("job_id")
-    sync.add_argument("path", nargs="?", default=".")
-    sync.add_argument("--json", action="store_true")
-    sync.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_sync")
-
-    doctor = debug_subparsers.add_parser(
-        "doctor", help="Inspect the exact worker environment"
-    )
-    doctor.add_argument("job_id")
-    doctor.add_argument("--json", action="store_true")
-    doctor.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug_doctor")
+    debug.add_argument("-h", "--help", dest="debug_help", action="store_true")
+    debug.add_argument("debug_args", nargs=argparse.REMAINDER)
+    debug.set_defaults(handler_module="refiner.cli.debug", handler="cmd_debug")

--- a/src/refiner/cli/debug.py
+++ b/src/refiner/cli/debug.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any
 
 from refiner.platform.client import MacrodataClient
+from refiner.cli.debug_sync import build_source_archive
 
 
 def _print_json(payload: dict[str, Any]) -> None:
@@ -68,4 +69,27 @@ def cmd_debug_stop(args: argparse.Namespace) -> int:
         _print_json(payload)
     else:
         print(f"Debug session closed: {args.job_id}")
+    return 0
+
+
+def cmd_debug_sync(args: argparse.Namespace) -> int:
+    archive = build_source_archive(args.path)
+    payload = MacrodataClient().cloud_debug_sync(
+        job_id=args.job_id,
+        archive=archive.payload,
+        sha256=archive.sha256,
+    )
+    if args.json:
+        _print_json(payload)
+    else:
+        print(
+            f"Synced {payload.get('files', archive.file_count)} files "
+            f"({archive.sha256[:12]}) to {args.job_id}"
+        )
+    return 0
+
+
+def cmd_debug_doctor(args: argparse.Namespace) -> int:
+    payload = MacrodataClient().cloud_debug_doctor(job_id=args.job_id)
+    _print_json(payload)
     return 0

--- a/src/refiner/cli/debug.py
+++ b/src/refiner/cli/debug.py
@@ -1,12 +1,38 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import nullcontext, redirect_stdout
 import json
+from pathlib import Path
 import sys
+import tempfile
+import time
 from typing import Any
 
-from refiner.platform.client import MacrodataClient
-from refiner.cli.debug_sync import build_source_archive
+from refiner.cli.debug_sessions import (
+    DebugSessionRecord,
+    find_session,
+    new_session_record,
+    remove_session,
+    save_session,
+    session_creation_lock,
+)
+from refiner.cli.debug_sync import (
+    DebugSyncBundle,
+    build_debug_sync_bundle,
+    find_project_root,
+    pickle_project_modules_by_value,
+)
+from refiner.cli.run.command import cmd_run
+from refiner.launchers.cloud import CloudLauncher, PreparedDebugSync
+from refiner.launchers.cloud_debug_capture import capture_cloud_launches
+from refiner.platform.auth import MacrodataCredentialsError
+from refiner.platform.client import MacrodataApiError, MacrodataClient
+
+
+_COMMANDS = frozenset(
+    {"create", "status", "run", "profile", "exec", "stop", "sync", "doctor"}
+)
 
 
 def _print_json(payload: dict[str, Any]) -> None:
@@ -19,77 +45,405 @@ def _emit_exec_result(payload: dict[str, Any]) -> int:
     if isinstance(stdout, str) and stdout:
         print(stdout, end="" if stdout.endswith("\n") else "\n")
     if isinstance(stderr, str) and stderr:
-        print(
-            stderr,
-            end="" if stderr.endswith("\n") else "\n",
-            file=sys.stderr,
-        )
+        print(stderr, end="" if stderr.endswith("\n") else "\n", file=sys.stderr)
     return_code = payload.get("exit_code")
     return return_code if isinstance(return_code, int) else 1
 
 
-def cmd_debug_status(args: argparse.Namespace) -> int:
-    payload = MacrodataClient().cloud_debug_status(job_id=args.job_id)
-    if args.json:
-        _print_json(payload)
+def _save_profile(payload: dict[str, Any], output: str) -> Path:
+    profile = payload.get("profile")
+    if not isinstance(profile, str) or not profile.strip():
+        raise RuntimeError("cloud debug profile response did not contain an SVG")
+    output_path = Path(output).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(profile)
+            temporary_path = Path(temporary_file.name)
+        temporary_path.replace(output_path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return output_path
+
+
+def _add_target(parser: argparse.ArgumentParser, *, required: bool = False) -> None:
+    parser.add_argument("pipeline", nargs=None if required else "?")
+    parser.add_argument("--job", dest="job_id")
+
+
+def _debug_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="macrodata debug")
+    subparsers = parser.add_subparsers(dest="debug_command", required=True)
+
+    create = subparsers.add_parser("create", help="Create a retained debug session")
+    create.add_argument("pipeline")
+    create.add_argument("--startup-timeout", type=int, default=1200)
+
+    status = subparsers.add_parser("status", help="Show debug worker status")
+    _add_target(status)
+    status.add_argument("--json", action="store_true")
+
+    run = subparsers.add_parser("run", help="Run the synchronized pipeline once")
+    _add_target(run)
+    run.add_argument("--max-shards", type=int)
+    run.add_argument("--timeout", type=int, default=3600)
+    run.add_argument("--profile", action="store_true")
+    run.add_argument("--profile-output", default="refiner-debug-profile.svg")
+
+    profile = subparsers.add_parser(
+        "profile", help="Download the latest recorded flamegraph"
+    )
+    _add_target(profile)
+    profile.add_argument("--output", default="refiner-debug-profile.svg")
+
+    execute = subparsers.add_parser("exec", help="Execute argv in the debug worker")
+    _add_target(execute)
+    execute.add_argument("--workdir")
+    execute.add_argument("--timeout", type=int, default=1200)
+    execute.set_defaults(exec_command=[])
+
+    stop = subparsers.add_parser("stop", help="Close the debug session")
+    _add_target(stop)
+    stop.add_argument("--json", action="store_true")
+
+    sync = subparsers.add_parser(
+        "sync", help="Synchronize source, pipeline, and private shards"
+    )
+    _add_target(sync, required=True)
+    sync.add_argument("--json", action="store_true")
+
+    doctor = subparsers.add_parser(
+        "doctor", help="Inspect the exact worker environment"
+    )
+    _add_target(doctor)
+    doctor.add_argument("--json", action="store_true")
+    return parser
+
+
+def _parse_debug_args(raw_args: list[str]) -> argparse.Namespace:
+    if not raw_args:
+        _debug_parser().print_help()
+        raise SystemExit(0)
+    if raw_args in (["--help"], ["-h"]):
+        return _debug_parser().parse_args(raw_args)
+    normalized = raw_args if raw_args[0] in _COMMANDS else ["create", *raw_args]
+    script_args: list[str] = []
+    exec_command: list[str] | None = None
+    if normalized[0] in {"create", "sync"} and "--" in normalized:
+        separator = normalized.index("--")
+        script_args = normalized[separator + 1 :]
+        normalized = normalized[:separator]
+    elif normalized[0] == "exec" and "--" in normalized:
+        separator = normalized.index("--")
+        exec_command = normalized[separator + 1 :]
+        normalized = normalized[:separator]
+    parsed = _debug_parser().parse_args(normalized)
+    if parsed.debug_command in {"create", "sync"}:
+        parsed.script_args = script_args
+    elif parsed.debug_command == "exec" and exec_command is not None:
+        parsed.exec_command = exec_command
+    return parsed
+
+
+def _normalized_script_args(values: list[str]) -> list[str]:
+    return values[1:] if values[:1] == ["--"] else values
+
+
+def _capture_launcher(script: str, script_args: list[str]) -> CloudLauncher:
+    with capture_cloud_launches() as capture:
+        return_code = cmd_run(
+            argparse.Namespace(
+                script=script,
+                script_args=script_args,
+                attach=False,
+                detach=False,
+                logs=None,
+            )
+        )
+    if return_code != 0:
+        raise SystemExit(return_code)
+    return capture.single()
+
+
+def _record_for_target(
+    args: argparse.Namespace, client: MacrodataClient
+) -> DebugSessionRecord | None:
+    pipeline = getattr(args, "pipeline", None)
+    return find_session(script=pipeline, client=client) if pipeline else None
+
+
+def _job_for_target(
+    args: argparse.Namespace, client: MacrodataClient
+) -> tuple[str, DebugSessionRecord | None]:
+    explicit_job = getattr(args, "job_id", None)
+    if explicit_job:
+        return explicit_job, None
+    record = _record_for_target(args, client)
+    if record is None:
+        if getattr(args, "pipeline", None):
+            raise SystemExit(
+                "No debug session is remembered for this pipeline. "
+                "Run `macrodata debug PIPELINE.py` first or pass --job JOB_ID."
+            )
+        raise SystemExit("Provide a pipeline path or --job JOB_ID.")
+    return record.job_id, record
+
+
+def _build_sync_bundle(
+    *,
+    launcher: CloudLauncher,
+    project_root: str | Path,
+    client: MacrodataClient,
+) -> tuple[PreparedDebugSync, DebugSyncBundle]:
+    with pickle_project_modules_by_value(project_root):
+        prepared = launcher.prepare_debug_sync(client=client)
+    bundle = build_debug_sync_bundle(
+        source_root=project_root,
+        pipeline_payload=prepared.pipeline_payload,
+        pipeline_sha256=prepared.pipeline_sha256,
+        allocation_fingerprint=prepared.allocation_fingerprint,
+    )
+    return prepared, bundle
+
+
+def _sync_launcher(
+    *,
+    launcher: CloudLauncher,
+    pipeline: str,
+    job_id: str,
+    project_root: str | Path,
+    client: MacrodataClient,
+) -> dict[str, Any]:
+    prepared, bundle = _build_sync_bundle(
+        launcher=launcher,
+        project_root=project_root,
+        client=client,
+    )
+    payload = client.cloud_debug_sync(
+        job_id=job_id,
+        bundle=bundle.payload,
+        sha256=bundle.sha256,
+        allocation_fingerprint=prepared.allocation_fingerprint,
+    )
+    payload.setdefault("files", bundle.file_count)
+    payload.setdefault("source_sha256", bundle.source_sha256)
+    payload.setdefault("pipeline_sha256", bundle.pipeline_sha256)
+    payload.setdefault("project_root", str(Path(project_root).resolve()))
+    payload.setdefault("pipeline", str(Path(pipeline).resolve()))
+    return payload
+
+
+def _wait_until_ready(
+    *, client: MacrodataClient, job_id: str, timeout_secs: int
+) -> dict[str, Any]:
+    if timeout_secs <= 0:
+        raise SystemExit("--startup-timeout must be greater than zero")
+    deadline = time.monotonic() + timeout_secs
+    last_status = ""
+    while True:
+        payload = client.cloud_debug_status(job_id=job_id)
+        status = str(payload.get("status", "unknown"))
+        if status != last_status:
+            print(f"Debug worker: {status}")
+            last_status = status
+        if status == "ready":
+            return payload
+        if status in {"failed", "stopped"}:
+            detail = payload.get("error") or payload.get("operation_status") or status
+            raise RuntimeError(f"debug worker did not start: {detail}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"debug worker was not ready within {timeout_secs} seconds; "
+                f"continue with `macrodata debug status --job {job_id}`"
+            )
+        time.sleep(2)
+
+
+def _clear_existing_session(*, script: Path, client: MacrodataClient) -> None:
+    existing = find_session(script=script, client=client)
+    if existing is None:
+        return
+    try:
+        status = client.cloud_debug_status(job_id=existing.job_id).get("status")
+    except MacrodataApiError as error:
+        if error.status != 404:
+            raise
     else:
-        print(f"{payload.get('status', 'unknown')}\t{args.job_id}")
+        if status not in {"failed", "stopped"}:
+            raise SystemExit(
+                f"A debug session already exists for {script}: {existing.job_id}. "
+                f"Use `macrodata debug sync {script}` or stop it first."
+            )
+    remove_session(script=script, client=client)
+
+
+def _cmd_create(args: argparse.Namespace) -> int:
+    if args.startup_timeout <= 0:
+        raise SystemExit("--startup-timeout must be greater than zero")
+    client = MacrodataClient()
+    script = Path(args.pipeline).expanduser().resolve()
+    with session_creation_lock(script=script, client=client):
+        _clear_existing_session(script=script, client=client)
+        script_args = _normalized_script_args(list(args.script_args))
+        launcher = _capture_launcher(str(script), script_args)
+        project_root = find_project_root(script)
+        # Validate local serialization and source-size limits before creating a
+        # retained worker. Sync rebuilds the bundle after allocation so its
+        # fingerprint reflects the exact allocation settings submitted.
+        _build_sync_bundle(
+            launcher=launcher,
+            project_root=project_root,
+            client=client,
+        )
+        with pickle_project_modules_by_value(project_root):
+            result = launcher.launch_debug()
+        record = new_session_record(
+            script=script,
+            project_root=project_root,
+            script_args=script_args,
+            job_id=result.job_id,
+            client=client,
+        )
+        save_session(record)
+    print(f"Debug session {result.job_id} remembered for {script}")
+    _wait_until_ready(
+        client=client,
+        job_id=result.job_id,
+        timeout_secs=args.startup_timeout,
+    )
+    payload = _sync_launcher(
+        launcher=launcher,
+        pipeline=str(script),
+        job_id=result.job_id,
+        project_root=project_root,
+        client=client,
+    )
+    print(
+        f"Ready: synchronized {payload.get('files', 0)} files and "
+        f"{payload.get('shards', 0)} private shards"
+    )
     return 0
 
 
-def cmd_debug_run(args: argparse.Namespace) -> int:
-    if args.max_shards is not None and args.max_shards <= 0:
-        raise SystemExit("--max-shards must be greater than zero")
-    payload = MacrodataClient().cloud_debug_run(
-        job_id=args.job_id,
-        max_shards=args.max_shards,
-        timeout_secs=args.timeout,
-    )
-    return _emit_exec_result(payload)
-
-
-def cmd_debug_exec(args: argparse.Namespace) -> int:
-    command = list(args.exec_command)
-    if command[:1] == ["--"]:
-        command = command[1:]
-    if not command:
-        raise SystemExit("debug exec requires a command after --")
-    payload = MacrodataClient().cloud_debug_exec(
-        job_id=args.job_id,
-        command=command,
-        workdir=args.workdir,
-        timeout_secs=args.timeout,
-    )
-    return _emit_exec_result(payload)
-
-
-def cmd_debug_stop(args: argparse.Namespace) -> int:
-    payload = MacrodataClient().cloud_debug_stop(job_id=args.job_id)
-    if args.json:
-        _print_json(payload)
-    else:
-        print(f"Debug session closed: {args.job_id}")
-    return 0
-
-
-def cmd_debug_sync(args: argparse.Namespace) -> int:
-    archive = build_source_archive(args.path)
-    payload = MacrodataClient().cloud_debug_sync(
-        job_id=args.job_id,
-        archive=archive.payload,
-        sha256=archive.sha256,
-    )
+def _cmd_sync(args: argparse.Namespace) -> int:
+    client = MacrodataClient()
+    job_id, record = _job_for_target(args, client)
+    script_args = _normalized_script_args(list(args.script_args))
+    if not script_args and record is not None:
+        script_args = record.script_args
+    output_context = redirect_stdout(sys.stderr) if args.json else nullcontext()
+    with output_context:
+        launcher = _capture_launcher(args.pipeline, script_args)
+        project_root = (
+            record.project_root
+            if record is not None
+            else find_project_root(args.pipeline)
+        )
+        payload = _sync_launcher(
+            launcher=launcher,
+            pipeline=args.pipeline,
+            job_id=job_id,
+            project_root=project_root,
+            client=client,
+        )
     if args.json:
         _print_json(payload)
     else:
         print(
-            f"Synced {payload.get('files', archive.file_count)} files "
-            f"({archive.sha256[:12]}) to {args.job_id}"
+            f"Synced {payload.get('files', 0)} files, pipeline "
+            f"{str(payload.get('pipeline_sha256', ''))[:12]}, and "
+            f"{payload.get('shards', 0)} private shards to {job_id}"
         )
     return 0
 
 
-def cmd_debug_doctor(args: argparse.Namespace) -> int:
-    payload = MacrodataClient().cloud_debug_doctor(job_id=args.job_id)
-    _print_json(payload)
-    return 0
+def _dispatch(args: argparse.Namespace) -> int:
+    if args.debug_command == "create":
+        return _cmd_create(args)
+    if args.debug_command == "sync":
+        return _cmd_sync(args)
+
+    client = MacrodataClient()
+    job_id, record = _job_for_target(args, client)
+    if args.debug_command == "status":
+        payload = client.cloud_debug_status(job_id=job_id)
+        if args.json:
+            _print_json(payload)
+        else:
+            print(f"{payload.get('status', 'unknown')}\t{job_id}")
+        return 0
+    if args.debug_command == "doctor":
+        _print_json(client.cloud_debug_doctor(job_id=job_id))
+        return 0
+    if args.debug_command == "run":
+        if args.max_shards is not None and args.max_shards <= 0:
+            raise SystemExit("--max-shards must be greater than zero")
+        payload = client.cloud_debug_run(
+            job_id=job_id,
+            max_shards=args.max_shards,
+            timeout_secs=args.timeout,
+            profile=args.profile,
+        )
+        return_code = _emit_exec_result(payload)
+        if args.profile:
+            profile = client.cloud_debug_profile(job_id=job_id)
+            output_path = _save_profile(profile, args.profile_output)
+            print(f"Profile saved to {output_path}")
+        return return_code
+    if args.debug_command == "profile":
+        payload = client.cloud_debug_profile(job_id=job_id)
+        output_path = _save_profile(payload, args.output)
+        print(f"Profile saved to {output_path}")
+        return 0
+    if args.debug_command == "exec":
+        command = list(args.exec_command)
+        if command[:1] == ["--"]:
+            command = command[1:]
+        if not command:
+            raise SystemExit("debug exec requires a command after --")
+        return _emit_exec_result(
+            client.cloud_debug_exec(
+                job_id=job_id,
+                command=command,
+                workdir=args.workdir,
+                timeout_secs=args.timeout,
+            )
+        )
+    if args.debug_command == "stop":
+        payload = client.cloud_debug_stop(job_id=job_id)
+        if record is not None:
+            remove_session(script=record.script_path, client=client)
+        if args.json:
+            _print_json(payload)
+        else:
+            print(f"Debug session closed: {job_id}")
+        return 0
+    raise AssertionError("unreachable")
+
+
+def cmd_debug(args: argparse.Namespace) -> int:
+    try:
+        if getattr(args, "debug_help", False):
+            _debug_parser().print_help()
+            return 0
+        return _dispatch(_parse_debug_args(list(args.debug_args)))
+    except (
+        MacrodataApiError,
+        MacrodataCredentialsError,
+        RuntimeError,
+        ValueError,
+    ) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+__all__ = ["cmd_debug"]

--- a/src/refiner/cli/debug_sessions.py
+++ b/src/refiner/cli/debug_sessions.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any, Iterator, Protocol, cast
+
+from refiner.platform.client import MacrodataClient
+
+
+class _FcntlBackend(Protocol):
+    LOCK_EX: int
+    LOCK_UN: int
+
+    def flock(self, fd: int, operation: int) -> None: ...
+
+
+class _MsvcrtBackend(Protocol):
+    LK_NBLCK: int
+    LK_UNLCK: int
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None: ...
+
+
+_fcntl: _FcntlBackend | None
+try:
+    import fcntl as _fcntl_module
+except ImportError:  # pragma: no cover - exercised on Windows
+    _fcntl = None
+else:
+    _fcntl = cast(_FcntlBackend, _fcntl_module)
+
+_msvcrt: _MsvcrtBackend | None
+try:
+    import msvcrt as _msvcrt_module
+except ImportError:  # pragma: no cover - exercised on Unix
+    _msvcrt = None
+else:
+    _msvcrt = cast(_MsvcrtBackend, _msvcrt_module)
+
+
+@dataclass(frozen=True, slots=True)
+class DebugSessionRecord:
+    script_path: str
+    project_root: str
+    script_args: list[str]
+    job_id: str
+    base_url: str
+    workspace: str
+
+
+def debug_sessions_path() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "macrodata" / "debug_sessions.json"
+
+
+def _scope(client: MacrodataClient) -> tuple[str, str]:
+    identity = client.verify_api_key()
+    if identity.workspace is not None:
+        workspace = identity.workspace.slug
+    else:
+        workspace = identity.key_id or identity.name
+    return client.base_url.rstrip("/"), workspace
+
+
+@contextmanager
+def _exclusive_file_lock(path: Path) -> Iterator[None]:
+    with path.open("a+b") as lock:
+        os.chmod(path, 0o600)
+        if _fcntl is not None:
+            _fcntl.flock(lock.fileno(), _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lock.fileno(), _fcntl.LOCK_UN)
+            return
+        if _msvcrt is None:
+            raise RuntimeError("file locking is unavailable on this platform")
+        lock.seek(0, os.SEEK_END)
+        if lock.tell() == 0:
+            lock.write(b"\0")
+            lock.flush()
+        while True:
+            lock.seek(0)
+            try:
+                _msvcrt.locking(lock.fileno(), _msvcrt.LK_NBLCK, 1)
+                break
+            except OSError:
+                time.sleep(0.05)
+        try:
+            yield
+        finally:
+            lock.seek(0)
+            _msvcrt.locking(lock.fileno(), _msvcrt.LK_UNLCK, 1)
+
+
+@contextmanager
+def session_creation_lock(
+    *, script: str | Path, client: MacrodataClient
+) -> Iterator[None]:
+    script_path = str(Path(script).expanduser().resolve())
+    base_url, workspace = _scope(client)
+    lock_key = hashlib.sha256(
+        json.dumps([script_path, base_url, workspace], separators=(",", ":")).encode()
+    ).hexdigest()
+    lock_directory = debug_sessions_path().parent / "debug_session_locks"
+    lock_directory.mkdir(parents=True, exist_ok=True)
+    os.chmod(lock_directory, 0o700)
+    lock_path = lock_directory / f"{lock_key}.lock"
+    with _exclusive_file_lock(lock_path):
+        yield
+
+
+@contextmanager
+def _locked_registry() -> Iterator[Path]:
+    path = debug_sessions_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(".lock")
+    with _exclusive_file_lock(lock_path):
+        yield path
+
+
+def _read(path: Path) -> list[DebugSessionRecord]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid debug session registry: {path}") from error
+    rows = payload.get("sessions") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError(f"invalid debug session registry: {path}")
+    try:
+        return [DebugSessionRecord(**row) for row in rows if isinstance(row, dict)]
+    except TypeError as error:
+        raise RuntimeError(f"invalid debug session registry: {path}") from error
+
+
+def _write(path: Path, records: list[DebugSessionRecord]) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "sessions": [asdict(record) for record in records],
+    }
+    fd, temporary_name = tempfile.mkstemp(prefix=".debug_sessions.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+        os.chmod(path, 0o600)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def find_session(
+    *, script: str | Path, client: MacrodataClient
+) -> DebugSessionRecord | None:
+    script_path = str(Path(script).expanduser().resolve())
+    base_url, workspace = _scope(client)
+    with _locked_registry() as path:
+        return next(
+            (
+                record
+                for record in _read(path)
+                if record.script_path == script_path
+                and record.base_url == base_url
+                and record.workspace == workspace
+            ),
+            None,
+        )
+
+
+def save_session(record: DebugSessionRecord) -> None:
+    with _locked_registry() as path:
+        records = [
+            existing
+            for existing in _read(path)
+            if not (
+                existing.script_path == record.script_path
+                and existing.base_url == record.base_url
+                and existing.workspace == record.workspace
+            )
+        ]
+        records.append(record)
+        _write(path, records)
+
+
+def remove_session(*, script: str | Path, client: MacrodataClient) -> None:
+    script_path = str(Path(script).expanduser().resolve())
+    base_url, workspace = _scope(client)
+    with _locked_registry() as path:
+        records = [
+            record
+            for record in _read(path)
+            if not (
+                record.script_path == script_path
+                and record.base_url == base_url
+                and record.workspace == workspace
+            )
+        ]
+        _write(path, records)
+
+
+def new_session_record(
+    *,
+    script: str | Path,
+    project_root: str | Path,
+    script_args: list[str],
+    job_id: str,
+    client: MacrodataClient,
+) -> DebugSessionRecord:
+    base_url, workspace = _scope(client)
+    return DebugSessionRecord(
+        script_path=str(Path(script).expanduser().resolve()),
+        project_root=str(Path(project_root).expanduser().resolve()),
+        script_args=list(script_args),
+        job_id=job_id,
+        base_url=base_url,
+        workspace=workspace,
+    )
+
+
+__all__ = [
+    "DebugSessionRecord",
+    "debug_sessions_path",
+    "find_session",
+    "new_session_record",
+    "remove_session",
+    "save_session",
+    "session_creation_lock",
+]

--- a/src/refiner/cli/debug_sync.py
+++ b/src/refiner/cli/debug_sync.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import io
+from pathlib import Path
+import tarfile
+
+MAX_SOURCE_ARCHIVE_BYTES = 16 * 1024 * 1024
+EXCLUDED_PARTS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
+)
+EXCLUDED_FILES = frozenset({".env"})
+
+
+@dataclass(frozen=True, slots=True)
+class SourceArchive:
+    payload: bytes
+    sha256: str
+    file_count: int
+
+
+def _included_file(root: Path, path: Path) -> bool:
+    relative = path.relative_to(root)
+    return (
+        path.is_file()
+        and not path.is_symlink()
+        and not any(part in EXCLUDED_PARTS for part in relative.parts)
+        and relative.name not in EXCLUDED_FILES
+        and not relative.name.startswith(".env.")
+    )
+
+
+def build_source_archive(path: str | Path) -> SourceArchive:
+    root = Path(path).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"source path is not a directory: {root}")
+    files = sorted(
+        (candidate for candidate in root.rglob("*") if _included_file(root, candidate)),
+        key=lambda candidate: candidate.relative_to(root).as_posix(),
+    )
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz", compresslevel=6) as archive:
+        for file_path in files:
+            archive.add(
+                file_path,
+                arcname=file_path.relative_to(root).as_posix(),
+                recursive=False,
+            )
+    payload = output.getvalue()
+    if not payload:
+        raise ValueError("source archive is empty")
+    if len(payload) > MAX_SOURCE_ARCHIVE_BYTES:
+        raise ValueError("compressed source archive exceeds 16 MiB")
+    return SourceArchive(
+        payload=payload,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        file_count=len(files),
+    )

--- a/src/refiner/cli/debug_sync.py
+++ b/src/refiner/cli/debug_sync.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 import hashlib
 import io
+import json
 from pathlib import Path
+import sys
 import tarfile
+from types import ModuleType
+
+import cloudpickle
 
 MAX_SOURCE_ARCHIVE_BYTES = 16 * 1024 * 1024
+MAX_DEBUG_SYNC_BUNDLE_BYTES = 64 * 1024 * 1024
 EXCLUDED_PARTS = frozenset(
     {
         ".git",
@@ -16,6 +24,7 @@ EXCLUDED_PARTS = frozenset(
         ".ruff_cache",
         ".tox",
         ".venv",
+        "venv",
         "__pycache__",
         "node_modules",
     }
@@ -27,6 +36,15 @@ EXCLUDED_FILES = frozenset({".env"})
 class SourceArchive:
     payload: bytes
     sha256: str
+    file_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class DebugSyncBundle:
+    payload: bytes
+    sha256: str
+    source_sha256: str
+    pipeline_sha256: str
     file_count: int
 
 
@@ -49,6 +67,8 @@ def build_source_archive(path: str | Path) -> SourceArchive:
         (candidate for candidate in root.rglob("*") if _included_file(root, candidate)),
         key=lambda candidate: candidate.relative_to(root).as_posix(),
     )
+    if not files:
+        raise ValueError("source archive is empty")
     output = io.BytesIO()
     with tarfile.open(fileobj=output, mode="w:gz", compresslevel=6) as archive:
         for file_path in files:
@@ -58,12 +78,99 @@ def build_source_archive(path: str | Path) -> SourceArchive:
                 recursive=False,
             )
     payload = output.getvalue()
-    if not payload:
-        raise ValueError("source archive is empty")
     if len(payload) > MAX_SOURCE_ARCHIVE_BYTES:
         raise ValueError("compressed source archive exceeds 16 MiB")
     return SourceArchive(
         payload=payload,
         sha256=hashlib.sha256(payload).hexdigest(),
         file_count=len(files),
+    )
+
+
+def find_project_root(script: str | Path) -> Path:
+    script_path = Path(script).expanduser().resolve()
+    for candidate in (script_path.parent, *script_path.parents):
+        if (candidate / ".git").exists() or (candidate / "pyproject.toml").is_file():
+            return candidate
+    return script_path.parent
+
+
+def _module_is_within(module: ModuleType, root: Path) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if not isinstance(module_file, str):
+        return False
+    try:
+        relative = Path(module_file).resolve().relative_to(root)
+    except (OSError, ValueError):
+        return False
+    return not any(part in EXCLUDED_PARTS for part in relative.parts)
+
+
+@contextmanager
+def pickle_project_modules_by_value(path: str | Path) -> Iterator[None]:
+    """Make a debug payload independent of imports from synchronized source."""
+
+    root = Path(path).expanduser().resolve()
+    already_registered = set(cloudpickle.list_registry_pickle_by_value())
+    registered: list[ModuleType] = []
+    for module in tuple(sys.modules.values()):
+        if (
+            isinstance(module, ModuleType)
+            and module.__name__ not in already_registered
+            and _module_is_within(module, root)
+        ):
+            cloudpickle.register_pickle_by_value(module)
+            registered.append(module)
+    try:
+        yield
+    finally:
+        for module in registered:
+            cloudpickle.unregister_pickle_by_value(module)
+
+
+def build_debug_sync_bundle(
+    *,
+    source_root: str | Path,
+    pipeline_payload: bytes,
+    pipeline_sha256: str,
+    allocation_fingerprint: str,
+) -> DebugSyncBundle:
+    actual_pipeline_sha256 = hashlib.sha256(pipeline_payload).hexdigest()
+    if actual_pipeline_sha256 != pipeline_sha256:
+        raise ValueError("pipeline payload sha256 mismatch")
+    if len(allocation_fingerprint) != 64 or not all(
+        character in "0123456789abcdef" for character in allocation_fingerprint.lower()
+    ):
+        raise ValueError("allocation fingerprint must be 64 hexadecimal characters")
+    source = build_source_archive(source_root)
+    metadata = json.dumps(
+        {
+            "schema_version": 1,
+            "allocation_fingerprint": allocation_fingerprint,
+            "source_sha256": source.sha256,
+            "pipeline_sha256": pipeline_sha256,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w") as archive:
+        for name, content in (
+            ("sync.json", metadata),
+            ("source.tar.gz", source.payload),
+            ("pipeline.cloudpickle", pipeline_payload),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            info.mode = 0o600
+            archive.addfile(info, io.BytesIO(content))
+    payload = output.getvalue()
+    if len(payload) > MAX_DEBUG_SYNC_BUNDLE_BYTES:
+        raise ValueError("debug sync bundle exceeds 64 MiB")
+    return DebugSyncBundle(
+        payload=payload,
+        sha256=hashlib.sha256(payload).hexdigest(),
+        source_sha256=source.sha256,
+        pipeline_sha256=pipeline_sha256,
+        file_count=source.file_count,
     )

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -442,5 +442,22 @@ class CloudLauncher(BaseLauncher):
             warnings=response_warnings,
         )
 
+    def sync_debug_pipeline(
+        self,
+        *,
+        job_id: str,
+        stage_index: int = 0,
+    ) -> dict[str, object]:
+        stages = self._resolved_stages()
+        stage = next((stage for stage in stages if stage.index == stage_index), None)
+        if stage is None:
+            raise ValueError(f"pipeline has no stage {stage_index}")
+        serialized = PreparedPipelinePayload.from_pipeline(stage.pipeline)
+        return MacrodataClient().cloud_debug_sync_pipeline(
+            job_id=job_id,
+            payload=serialized.payload_bytes,
+            sha256=serialized.sha256,
+        )
+
 
 __all__ = ["CloudLauncher", "CloudLaunchResult"]

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import hashlib
+import json
 import os
 import re
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from refiner.cli.run.modes import (
     CloudAttachContext,
@@ -130,6 +132,13 @@ class CloudLaunchResult:
     warnings: list[str]
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedDebugSync:
+    pipeline_payload: bytes
+    pipeline_sha256: str
+    allocation_fingerprint: str
+
+
 class CloudLauncher(BaseLauncher):
     """Cloud launcher that submits a compiled run to the cloud controller.
 
@@ -170,7 +179,6 @@ class CloudLauncher(BaseLauncher):
         env: dict[str, object | None] | None = None,
         continue_from_job: str | None = None,
         unsafe_continue: bool = False,
-        debug: bool = False,
     ):
         super().__init__(
             pipeline=pipeline,
@@ -182,8 +190,6 @@ class CloudLauncher(BaseLauncher):
         normalized_continue_from_job = _parse_continue_from_job(continue_from_job)
         if unsafe_continue and normalized_continue_from_job is None:
             raise ValueError("unsafe_continue requires continue_from_job")
-        if debug and normalized_continue_from_job is not None:
-            raise ValueError("debug cannot be combined with continue_from_job")
         if mem_mb_per_worker is not None and mem_mb_per_worker <= 0:
             raise ValueError("mem_mb_per_worker must be > 0")
         self.cpus_per_worker = cpus_per_worker
@@ -197,7 +203,6 @@ class CloudLauncher(BaseLauncher):
         self.env = env
         self.continue_from_job = normalized_continue_from_job
         self.unsafe_continue = unsafe_continue
-        self.debug = debug
 
     @staticmethod
     def _fallback_to_latest_pypi_enabled() -> bool:
@@ -329,14 +334,15 @@ class CloudLauncher(BaseLauncher):
             for stage, serialized in zip(stages, serialized_payloads, strict=True)
         }
 
-    def launch(self) -> CloudLaunchResult:
-        try:
-            client = MacrodataClient()
-        except MacrodataCredentialsError as err:
-            raise SystemExit(
-                "Launching jobs in the Macrodata cloud requires Macrodata "
-                "authentication. Run `macrodata login` or set MACRODATA_API_KEY."
-            ) from err
+    def _resolve_submission(
+        self,
+    ) -> tuple[
+        list[PlannedStage],
+        dict[str, object],
+        dict[str, object],
+        list[dict[str, Any]] | None,
+        dict[str, str] | None,
+    ]:
         resolved_secret_sources, secret_values = resolve_secret_sources(self.secrets)
         resolved_env = resolve_env_mapping(self.env) if self.env else None
         stages = self._resolved_stages()
@@ -345,6 +351,208 @@ class CloudLauncher(BaseLauncher):
             stages=stages,
         )
         plan = self._compiled_plan(stages, secret_values=secret_values)
+        return stages, manifest, plan, resolved_secret_sources, resolved_env
+
+    def _secret_mount_spec(
+        self,
+        resolved_secret_sources: list[dict[str, Any]] | None,
+        *,
+        workspace_secret_versions: dict[str, list[dict[str, str]]] | None = None,
+    ) -> list[dict[str, object]]:
+        specs: list[dict[str, object]] = []
+        for source in resolved_secret_sources or []:
+            if source.get("__type__") != "__envkeys__":
+                specs.append(
+                    {
+                        "kind": "dict",
+                        "value_digests": {
+                            key: hashlib.sha256(str(value).encode()).hexdigest()
+                            for key, value in sorted(source.items())
+                        },
+                    }
+                )
+            else:
+                env_name = str(source.get("envname") or "default")
+                selected_keys = (
+                    set(source["keys"])
+                    if isinstance(source.get("keys"), list)
+                    else None
+                )
+                specs.append(
+                    {
+                        "kind": "env",
+                        "name": env_name,
+                        "keys": sorted(source["keys"])
+                        if isinstance(source.get("keys"), list)
+                        else None,
+                        "versions": [
+                            secret
+                            for secret in (workspace_secret_versions or {}).get(
+                                env_name, []
+                            )
+                            if selected_keys is None or secret["name"] in selected_keys
+                        ],
+                    }
+                )
+        return specs
+
+    @staticmethod
+    def _workspace_secret_versions(
+        *,
+        client: MacrodataClient | None,
+        resolved_secret_sources: list[dict[str, Any]] | None,
+    ) -> dict[str, list[dict[str, str]]]:
+        env_names = {
+            str(source.get("envname") or "default")
+            for source in resolved_secret_sources or []
+            if source.get("__type__") == "__envkeys__"
+        }
+        versions: dict[str, list[dict[str, str]]] = {}
+        if not env_names:
+            return versions
+        resolved_client = client or MacrodataClient()
+        for env_name in sorted(env_names):
+            payload = resolved_client.cli_list_secrets(env=env_name)
+            secrets = payload.get("secrets")
+            if not isinstance(secrets, list):
+                raise ValueError("invalid workspace secret metadata response")
+            env_versions: list[dict[str, str]] = []
+            for secret in secrets:
+                if not isinstance(secret, dict):
+                    raise ValueError("invalid workspace secret metadata response")
+                secret_id = secret.get("id")
+                name = secret.get("name")
+                version = secret.get("version")
+                if not all(
+                    isinstance(value, str) and value for value in (secret_id, name)
+                ) or not (
+                    isinstance(version, str)
+                    and len(version) == 64
+                    and all(character in "0123456789abcdef" for character in version)
+                ):
+                    raise ValueError("invalid workspace secret metadata response")
+                env_versions.append({"id": secret_id, "name": name, "version": version})
+            versions[env_name] = sorted(
+                env_versions, key=lambda secret: (secret["name"], secret["id"])
+            )
+        return versions
+
+    def _debug_allocation_fingerprint(
+        self,
+        *,
+        stages: list[PlannedStage],
+        manifest: dict[str, object],
+        resolved_secret_sources: list[dict[str, Any]] | None,
+        resolved_env: dict[str, str] | None,
+        workspace_secret_versions: dict[str, list[dict[str, str]]] | None = None,
+    ) -> str:
+        stage_specs: list[dict[str, object]] = []
+        for stage in stages:
+            runtime = CloudRuntimeConfig(
+                num_workers=1,
+                cloud=self.cloud,
+                region=self.region,
+                cpus_per_worker=stage.compute.cpus_per_worker,
+                mem_mb_per_worker=stage.compute.memory_mb_per_worker,
+                gpu=stage.compute.gpu,
+            ).to_dict()
+            runtime.pop("num_workers", None)
+            stage_specs.append(
+                {
+                    "stage_index": stage.index,
+                    "runtime": runtime,
+                    "runtime_services": [
+                        service.to_dict()
+                        for service in collect_pipeline_services(stage.pipeline)
+                    ],
+                }
+            )
+        allocation = {
+            "schema_version": 1,
+            "environment": manifest.get("environment"),
+            "dependencies": manifest.get("dependencies"),
+            "stages": stage_specs,
+            "secret_mounts": self._secret_mount_spec(
+                resolved_secret_sources,
+                workspace_secret_versions=workspace_secret_versions,
+            ),
+            "env": resolved_env,
+        }
+        encoded = json.dumps(
+            allocation,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    def prepare_debug_sync(
+        self, *, client: MacrodataClient | None = None
+    ) -> PreparedDebugSync:
+        if self.continue_from_job is not None:
+            raise ValueError("cloud debug cannot be combined with continue_from_job")
+        stages, manifest, _, resolved_secret_sources, resolved_env = (
+            self._resolve_submission()
+        )
+        stage = next((item for item in stages if item.index == 0), None)
+        if stage is None:
+            raise ValueError("pipeline has no stage 0")
+        serialized = PreparedPipelinePayload.from_pipeline(stage.pipeline)
+        workspace_secret_versions = self._workspace_secret_versions(
+            client=client,
+            resolved_secret_sources=resolved_secret_sources,
+        )
+        return PreparedDebugSync(
+            pipeline_payload=serialized.payload_bytes,
+            pipeline_sha256=serialized.sha256,
+            allocation_fingerprint=self._debug_allocation_fingerprint(
+                stages=stages,
+                manifest=manifest,
+                resolved_secret_sources=resolved_secret_sources,
+                resolved_env=resolved_env,
+                workspace_secret_versions=workspace_secret_versions,
+            ),
+        )
+
+    def launch(self) -> CloudLaunchResult:
+        from refiner.launchers.cloud_debug_capture import active_cloud_launch_capture
+
+        capture = active_cloud_launch_capture()
+        if capture is not None:
+            return capture.capture(self)
+        return self._launch(debug=False)
+
+    def launch_debug(self) -> CloudLaunchResult:
+        return self._launch(debug=True)
+
+    def _launch(self, *, debug: bool) -> CloudLaunchResult:
+        if debug and self.continue_from_job is not None:
+            raise ValueError("cloud debug cannot be combined with continue_from_job")
+        try:
+            client = MacrodataClient()
+        except MacrodataCredentialsError as err:
+            raise SystemExit(
+                "Launching jobs in the Macrodata cloud requires Macrodata "
+                "authentication. Run `macrodata login` or set MACRODATA_API_KEY."
+            ) from err
+        stages, manifest, plan, resolved_secret_sources, resolved_env = (
+            self._resolve_submission()
+        )
+        if debug:
+            workspace_secret_versions = self._workspace_secret_versions(
+                client=client,
+                resolved_secret_sources=resolved_secret_sources,
+            )
+            manifest = dict(manifest)
+            manifest["debug_allocation_fingerprint"] = (
+                self._debug_allocation_fingerprint(
+                    stages=stages,
+                    manifest=manifest,
+                    resolved_secret_sources=resolved_secret_sources,
+                    resolved_env=resolved_env,
+                    workspace_secret_versions=workspace_secret_versions,
+                )
+            )
         try:
             pipeline_payloads = self._upload_stage_payloads(
                 client=client, stages=stages
@@ -373,7 +581,7 @@ class CloudLauncher(BaseLauncher):
                 env=resolved_env,
                 continue_from_job=self.continue_from_job,
                 unsafe_continue=self.unsafe_continue,
-                debug=self.debug,
+                debug=debug,
             )
             resp = client.cloud_submit_job(request=request)
         except MacrodataCredentialsError as err:
@@ -400,14 +608,7 @@ class CloudLauncher(BaseLauncher):
             stage_index=resp.stage_index,
         )
         print(f"Cloud job launched. View job:\n  {tracking_url}")
-        if self.debug:
-            print(
-                "Debug worker is allocating. Continue with:\n"
-                f"  macrodata debug status {resp.job_id}\n"
-                f"  macrodata debug run {resp.job_id}\n"
-                f"  macrodata debug exec {resp.job_id} -- python -V\n"
-                f"  macrodata debug stop {resp.job_id}"
-            )
+        if debug:
             return CloudLaunchResult(
                 job_id=resp.job_id,
                 stage_index=resp.stage_index,
@@ -442,22 +643,5 @@ class CloudLauncher(BaseLauncher):
             warnings=response_warnings,
         )
 
-    def sync_debug_pipeline(
-        self,
-        *,
-        job_id: str,
-        stage_index: int = 0,
-    ) -> dict[str, object]:
-        stages = self._resolved_stages()
-        stage = next((stage for stage in stages if stage.index == stage_index), None)
-        if stage is None:
-            raise ValueError(f"pipeline has no stage {stage_index}")
-        serialized = PreparedPipelinePayload.from_pipeline(stage.pipeline)
-        return MacrodataClient().cloud_debug_sync_pipeline(
-            job_id=job_id,
-            payload=serialized.payload_bytes,
-            sha256=serialized.sha256,
-        )
 
-
-__all__ = ["CloudLauncher", "CloudLaunchResult"]
+__all__ = ["CloudLauncher", "CloudLaunchResult", "PreparedDebugSync"]

--- a/src/refiner/launchers/cloud_debug_capture.py
+++ b/src/refiner/launchers/cloud_debug_capture.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    from refiner.launchers.cloud import CloudLauncher, CloudLaunchResult
+
+
+_ACTIVE_CAPTURE: ContextVar[CloudLaunchCapture | None] = ContextVar(
+    "refiner_cloud_debug_capture",
+    default=None,
+)
+
+
+@dataclass(slots=True)
+class CloudLaunchCapture:
+    launchers: list[CloudLauncher] = field(default_factory=list)
+
+    def capture(self, launcher: CloudLauncher) -> CloudLaunchResult:
+        from refiner.launchers.cloud import CloudLaunchResult
+
+        self.launchers.append(launcher)
+        return CloudLaunchResult(
+            job_id="debug-capture",
+            stage_index=0,
+            status="captured",
+            warnings=[],
+        )
+
+    def single(self) -> CloudLauncher:
+        if not self.launchers:
+            raise ValueError(
+                "pipeline script must call launch_cloud(...) exactly once; found none"
+            )
+        if len(self.launchers) != 1:
+            raise ValueError(
+                "pipeline script must call launch_cloud(...) exactly once; "
+                f"found {len(self.launchers)}"
+            )
+        return self.launchers[0]
+
+
+@contextmanager
+def capture_cloud_launches() -> Iterator[CloudLaunchCapture]:
+    capture = CloudLaunchCapture()
+    token = _ACTIVE_CAPTURE.set(capture)
+    try:
+        yield capture
+    finally:
+        _ACTIVE_CAPTURE.reset(token)
+
+
+def active_cloud_launch_capture() -> CloudLaunchCapture | None:
+    return _ACTIVE_CAPTURE.get()
+
+
+__all__ = [
+    "CloudLaunchCapture",
+    "active_cloud_launch_capture",
+    "capture_cloud_launches",
+]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -805,7 +805,6 @@ class RefinerPipeline:
         env: Mapping[str, object | None] | None = None,
         continue_from_job: str | None = None,
         unsafe_continue: bool = False,
-        debug: bool = False,
     ) -> "CloudLaunchResult":
         """Launch the pipeline on Macrodata Cloud.
 
@@ -840,8 +839,6 @@ class RefinerPipeline:
                 job id, one prior job id plus `:stage_index`, or `"infer"`.
             unsafe_continue: Allow continue when the reused stage boundary is not
                 fully compatible with the current pipeline.
-            debug: Retain one non-preemptible cloud worker for repeated debug
-                runs instead of scaling the job out.
         """
         from refiner.launchers.cloud import CloudLauncher
 
@@ -861,33 +858,8 @@ class RefinerPipeline:
             env=dict(env) if env is not None else None,
             continue_from_job=continue_from_job,
             unsafe_continue=unsafe_continue,
-            debug=debug,
         )
         return launcher.launch()
-
-    def sync_cloud_debug(
-        self,
-        job_id: str,
-        *,
-        stage_index: int = 0,
-    ) -> dict[str, object]:
-        """Replace the pipeline payload used by a retained cloud debug session.
-
-        Source synchronization updates imported modules; call this method as
-        well when the pipeline graph, reader, writer, or captured callable has
-        changed.
-        """
-        from refiner.launchers.cloud import CloudLauncher
-
-        launcher = CloudLauncher(
-            pipeline=self,
-            name="debug-sync",
-            debug=True,
-        )
-        return launcher.sync_debug_pipeline(
-            job_id=job_id,
-            stage_index=stage_index,
-        )
 
     def write_lerobot(
         self,

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -865,6 +865,30 @@ class RefinerPipeline:
         )
         return launcher.launch()
 
+    def sync_cloud_debug(
+        self,
+        job_id: str,
+        *,
+        stage_index: int = 0,
+    ) -> dict[str, object]:
+        """Replace the pipeline payload used by a retained cloud debug session.
+
+        Source synchronization updates imported modules; call this method as
+        well when the pipeline graph, reader, writer, or captured callable has
+        changed.
+        """
+        from refiner.launchers.cloud import CloudLauncher
+
+        launcher = CloudLauncher(
+            pipeline=self,
+            name="debug-sync",
+            debug=True,
+        )
+        return launcher.sync_debug_pipeline(
+            job_id=job_id,
+            stage_index=stage_index,
+        )
+
     def write_lerobot(
         self,
         output: DataFolderLike,

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -459,6 +459,67 @@ class MacrodataClient:
             timeout_s=60.0,
         )
 
+    def cloud_debug_doctor(self, *, job_id: str) -> dict[str, Any]:
+        return self._request_raw(
+            method="GET",
+            path=f"/api/cloud/debug/{quote(job_id, safe='')}/doctor",
+            timeout_s=60.0,
+        )
+
+    def cloud_debug_sync(
+        self,
+        *,
+        job_id: str,
+        archive: bytes,
+        sha256: str,
+    ) -> dict[str, Any]:
+        path = f"/api/cloud/debug/{quote(job_id, safe='')}/sync"
+        url = f"{self.base_url}{path}"
+        try:
+            response = self._http_client.post(
+                url,
+                params={"sha256": sha256},
+                headers={"content-type": "application/gzip"},
+                content=archive,
+                timeout=300.0,
+            )
+        except httpx.RequestError as err:
+            raise MacrodataApiError(status=0, message=str(err), url=url) from err
+        if response.is_error:
+            raise MacrodataApiError(
+                status=response.status_code,
+                message=_http_error_message(response),
+                url=url,
+            )
+        return _decode_json_object(response, context=path, url=url)
+
+    def cloud_debug_sync_pipeline(
+        self,
+        *,
+        job_id: str,
+        payload: bytes,
+        sha256: str,
+    ) -> dict[str, Any]:
+        path = f"/api/cloud/debug/{quote(job_id, safe='')}/pipeline"
+        url = f"{self.base_url}{path}"
+        try:
+            response = self._http_client.post(
+                url,
+                params={"sha256": sha256},
+                headers={"content-type": "application/octet-stream"},
+                content=payload,
+                timeout=300.0,
+            )
+        except httpx.RequestError as err:
+            raise MacrodataApiError(status=0, message=str(err), url=url) from err
+        if response.is_error:
+            raise MacrodataApiError(
+                status=response.status_code,
+                message=_http_error_message(response),
+                url=url,
+            )
+        return _decode_json_object(response, context=path, url=url)
+
     def cli_list_jobs(
         self,
         *,

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -432,6 +432,7 @@ class MacrodataClient:
             path=f"/api/cloud/debug/{quote(job_id, safe='')}/exec",
             json_payload=payload,
             timeout_s=float(timeout_secs + 30),
+            retry_attempts=1,
         )
 
     def cloud_debug_run(
@@ -440,15 +441,26 @@ class MacrodataClient:
         job_id: str,
         max_shards: int | None = None,
         timeout_secs: int = 3600,
+        profile: bool = False,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {"timeout_secs": timeout_secs}
         if max_shards is not None:
             payload["max_shards"] = max_shards
+        if profile:
+            payload["profile"] = True
         return self._request_raw(
             method="POST",
             path=f"/api/cloud/debug/{quote(job_id, safe='')}/run",
             json_payload=payload,
             timeout_s=float(timeout_secs + 30),
+            retry_attempts=1,
+        )
+
+    def cloud_debug_profile(self, *, job_id: str) -> dict[str, Any]:
+        return self._request_raw(
+            method="GET",
+            path=f"/api/cloud/debug/{quote(job_id, safe='')}/profile",
+            timeout_s=60.0,
         )
 
     def cloud_debug_stop(self, *, job_id: str) -> dict[str, Any]:
@@ -470,44 +482,21 @@ class MacrodataClient:
         self,
         *,
         job_id: str,
-        archive: bytes,
+        bundle: bytes,
         sha256: str,
+        allocation_fingerprint: str,
     ) -> dict[str, Any]:
         path = f"/api/cloud/debug/{quote(job_id, safe='')}/sync"
         url = f"{self.base_url}{path}"
         try:
             response = self._http_client.post(
                 url,
-                params={"sha256": sha256},
-                headers={"content-type": "application/gzip"},
-                content=archive,
-                timeout=300.0,
-            )
-        except httpx.RequestError as err:
-            raise MacrodataApiError(status=0, message=str(err), url=url) from err
-        if response.is_error:
-            raise MacrodataApiError(
-                status=response.status_code,
-                message=_http_error_message(response),
-                url=url,
-            )
-        return _decode_json_object(response, context=path, url=url)
-
-    def cloud_debug_sync_pipeline(
-        self,
-        *,
-        job_id: str,
-        payload: bytes,
-        sha256: str,
-    ) -> dict[str, Any]:
-        path = f"/api/cloud/debug/{quote(job_id, safe='')}/pipeline"
-        url = f"{self.base_url}{path}"
-        try:
-            response = self._http_client.post(
-                url,
-                params={"sha256": sha256},
-                headers={"content-type": "application/octet-stream"},
-                content=payload,
+                params={
+                    "sha256": sha256,
+                    "allocation_fingerprint": allocation_fingerprint,
+                },
+                headers={"content-type": "application/x-tar"},
+                content=bundle,
                 timeout=300.0,
             )
         except httpx.RequestError as err:

--- a/tests/cli/test_debug_commands.py
+++ b/tests/cli/test_debug_commands.py
@@ -25,6 +25,14 @@ class _FakeClient:
         self.calls.append(("stop", kwargs))
         return {"status": "canceled"}
 
+    def cloud_debug_sync(self, **kwargs):
+        self.calls.append(("sync", kwargs))
+        return {"files": 1}
+
+    def cloud_debug_doctor(self, **kwargs):
+        self.calls.append(("doctor", kwargs))
+        return {"status": "ready", "python": {"version": "3.10"}}
+
 
 def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
     client = _FakeClient()
@@ -67,3 +75,25 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
     assert "Python 3.10" in captured.out
     assert "Debug session closed: job-1" in captured.out
     assert "failed" in captured.err
+
+
+def test_debug_sync_and_doctor(monkeypatch, tmp_path, capsys) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(debug, "MacrodataClient", lambda: client)
+    (tmp_path / "pipeline.py").write_text("PIPELINE = 1\n")
+
+    assert (
+        debug.cmd_debug_sync(Namespace(job_id="job-1", path=str(tmp_path), json=False))
+        == 0
+    )
+    assert debug.cmd_debug_doctor(Namespace(job_id="job-1", json=False)) == 0
+
+    sync_call = client.calls[0]
+    assert sync_call[0] == "sync"
+    assert sync_call[1]["job_id"] == "job-1"
+    assert isinstance(sync_call[1]["archive"], bytes)
+    sha256 = sync_call[1]["sha256"]
+    assert isinstance(sha256, str)
+    assert len(sha256) == 64
+    assert client.calls[1] == ("doctor", {"job_id": "job-1"})
+    assert "Synced 1 files" in capsys.readouterr().out

--- a/tests/cli/test_debug_commands.py
+++ b/tests/cli/test_debug_commands.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from contextlib import nullcontext
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
 
 from refiner.cli import debug
+from refiner.platform.client import MacrodataApiError, MacrodataClient
 
 
 class _FakeClient:
@@ -21,28 +28,32 @@ class _FakeClient:
         self.calls.append(("run", kwargs))
         return {"exit_code": 2, "stdout": "", "stderr": "failed\n"}
 
+    def cloud_debug_profile(self, **kwargs):
+        self.calls.append(("profile", kwargs))
+        return {"profile": "<svg>profile</svg>"}
+
     def cloud_debug_stop(self, **kwargs):
         self.calls.append(("stop", kwargs))
         return {"status": "canceled"}
-
-    def cloud_debug_sync(self, **kwargs):
-        self.calls.append(("sync", kwargs))
-        return {"files": 1}
 
     def cloud_debug_doctor(self, **kwargs):
         self.calls.append(("doctor", kwargs))
         return {"status": "ready", "python": {"version": "3.10"}}
 
 
+def _args(command: str, **kwargs) -> Namespace:
+    return Namespace(debug_command=command, pipeline=None, job_id="job-1", **kwargs)
+
+
 def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
     client = _FakeClient()
     monkeypatch.setattr(debug, "MacrodataClient", lambda: client)
 
-    assert debug.cmd_debug_status(Namespace(job_id="job-1", json=False)) == 0
+    assert debug._dispatch(_args("status", json=False)) == 0
     assert (
-        debug.cmd_debug_exec(
-            Namespace(
-                job_id="job-1",
+        debug._dispatch(
+            _args(
+                "exec",
                 exec_command=["--", "python", "-V"],
                 workdir=None,
                 timeout=20,
@@ -50,8 +61,19 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
         )
         == 0
     )
-    assert debug.cmd_debug_run(Namespace(job_id="job-1", max_shards=1, timeout=30)) == 2
-    assert debug.cmd_debug_stop(Namespace(job_id="job-1", json=False)) == 0
+    assert (
+        debug._dispatch(
+            _args(
+                "run",
+                max_shards=1,
+                timeout=30,
+                profile=False,
+                profile_output="unused.svg",
+            )
+        )
+        == 2
+    )
+    assert debug._dispatch(_args("stop", json=False)) == 0
 
     assert client.calls == [
         ("status", {"job_id": "job-1"}),
@@ -66,7 +88,12 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
         ),
         (
             "run",
-            {"job_id": "job-1", "max_shards": 1, "timeout_secs": 30},
+            {
+                "job_id": "job-1",
+                "max_shards": 1,
+                "timeout_secs": 30,
+                "profile": False,
+            },
         ),
         ("stop", {"job_id": "job-1"}),
     ]
@@ -77,23 +104,253 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
     assert "failed" in captured.err
 
 
-def test_debug_sync_and_doctor(monkeypatch, tmp_path, capsys) -> None:
+def test_debug_run_profiles_and_downloads_flamegraph(
+    monkeypatch, tmp_path, capsys
+) -> None:
     client = _FakeClient()
     monkeypatch.setattr(debug, "MacrodataClient", lambda: client)
-    (tmp_path / "pipeline.py").write_text("PIPELINE = 1\n")
+    output = tmp_path / "attempt.svg"
 
     assert (
-        debug.cmd_debug_sync(Namespace(job_id="job-1", path=str(tmp_path), json=False))
+        debug._dispatch(
+            _args(
+                "run",
+                max_shards=1,
+                timeout=30,
+                profile=True,
+                profile_output=str(output),
+            )
+        )
+        == 2
+    )
+    assert output.read_text() == "<svg>profile</svg>"
+    assert client.calls[-1] == ("profile", {"job_id": "job-1"})
+    assert f"Profile saved to {output}" in capsys.readouterr().out
+
+
+def test_profile_download_uses_a_unique_temporary_file(monkeypatch, tmp_path) -> None:
+    temporary_paths: list[Path] = []
+    named_temporary_file = debug.tempfile.NamedTemporaryFile
+
+    def record_temporary_file(*args, **kwargs):
+        temporary_file = named_temporary_file(*args, **kwargs)
+        temporary_paths.append(Path(temporary_file.name))
+        return temporary_file
+
+    monkeypatch.setattr(debug.tempfile, "NamedTemporaryFile", record_temporary_file)
+    output = tmp_path / "profile.svg"
+
+    debug._save_profile({"profile": "<svg>first</svg>"}, str(output))
+    debug._save_profile({"profile": "<svg>second</svg>"}, str(output))
+
+    assert output.read_text() == "<svg>second</svg>"
+    assert len(set(temporary_paths)) == 2
+    assert all(not path.exists() for path in temporary_paths)
+
+
+def test_file_driven_parser_supports_create_sync_and_exec() -> None:
+    create = debug._parse_debug_args(["pipeline.py"])
+    assert create.debug_command == "create"
+    assert create.pipeline == "pipeline.py"
+
+    explicit_create = debug._parse_debug_args(["create", "pipeline.py"])
+    assert explicit_create.debug_command == "create"
+    assert explicit_create.pipeline == "pipeline.py"
+
+    sync = debug._parse_debug_args(["sync", "pipeline.py"])
+    assert sync.debug_command == "sync"
+    assert sync.pipeline == "pipeline.py"
+
+    execute = debug._parse_debug_args(
+        ["exec", "pipeline.py", "--timeout", "10", "--", "python", "-V"]
+    )
+    assert execute.exec_command == ["python", "-V"]
+    assert execute.timeout == 10
+
+
+def test_debug_create_rejects_invalid_timeout_before_allocating(monkeypatch) -> None:
+    monkeypatch.setattr(
+        debug,
+        "MacrodataClient",
+        lambda: pytest.fail("client must not be created for an invalid timeout"),
+    )
+
+    with pytest.raises(SystemExit, match="--startup-timeout must be greater than zero"):
+        debug._cmd_create(
+            Namespace(
+                pipeline="pipeline.py",
+                script_args=[],
+                startup_timeout=0,
+            )
+        )
+
+
+def test_debug_create_validates_sync_bundle_before_allocating(
+    monkeypatch, tmp_path
+) -> None:
+    class Launcher:
+        def launch_debug(self):
+            pytest.fail("worker must not launch when sync validation fails")
+
+    monkeypatch.setattr(debug, "MacrodataClient", object)
+    monkeypatch.setattr(debug, "session_creation_lock", lambda **_kwargs: nullcontext())
+    monkeypatch.setattr(debug, "find_session", lambda **_kwargs: None)
+    monkeypatch.setattr(debug, "_capture_launcher", lambda *_args: Launcher())
+    monkeypatch.setattr(debug, "find_project_root", lambda _script: tmp_path)
+    monkeypatch.setattr(
+        debug,
+        "_build_sync_bundle",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("source archive too large")),
+    )
+
+    with pytest.raises(ValueError, match="source archive too large"):
+        debug._cmd_create(
+            Namespace(
+                pipeline=str(tmp_path / "pipeline.py"),
+                script_args=[],
+                startup_timeout=1200,
+            )
+        )
+
+
+def test_debug_create_discards_missing_remembered_session(
+    monkeypatch, tmp_path
+) -> None:
+    client = cast(MacrodataClient, _FakeClient())
+    record = debug.DebugSessionRecord(
+        script_path=str(tmp_path / "pipeline.py"),
+        project_root=str(tmp_path),
+        script_args=[],
+        job_id="missing-job",
+        base_url="https://example.test",
+        workspace="workspace",
+    )
+    removed: list[Path] = []
+    monkeypatch.setattr(debug, "find_session", lambda **_kwargs: record)
+    monkeypatch.setattr(
+        client,
+        "cloud_debug_status",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            MacrodataApiError(status=404, message="missing")
+        ),
+    )
+    monkeypatch.setattr(
+        debug,
+        "remove_session",
+        lambda *, script, client: removed.append(Path(script)),
+    )
+
+    debug._clear_existing_session(script=tmp_path / "pipeline.py", client=client)
+
+    assert removed == [tmp_path / "pipeline.py"]
+
+
+def test_debug_create_preserves_remembered_session_on_status_failure(
+    monkeypatch, tmp_path
+) -> None:
+    client = cast(MacrodataClient, _FakeClient())
+    record = debug.DebugSessionRecord(
+        script_path=str(tmp_path / "pipeline.py"),
+        project_root=str(tmp_path),
+        script_args=[],
+        job_id="unavailable-job",
+        base_url="https://example.test",
+        workspace="workspace",
+    )
+    monkeypatch.setattr(debug, "find_session", lambda **_kwargs: record)
+    monkeypatch.setattr(
+        client,
+        "cloud_debug_status",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            MacrodataApiError(status=503, message="unavailable")
+        ),
+    )
+    monkeypatch.setattr(
+        debug,
+        "remove_session",
+        lambda **_kwargs: pytest.fail("transient errors must preserve the session"),
+    )
+
+    with pytest.raises(MacrodataApiError) as error:
+        debug._clear_existing_session(script=tmp_path / "pipeline.py", client=client)
+
+    assert error.value.status == 503
+
+
+def test_capture_requires_exactly_one_cloud_launch(monkeypatch) -> None:
+    monkeypatch.setattr(debug, "cmd_run", lambda _args: 0)
+
+    try:
+        debug._capture_launcher("pipeline.py", [])
+    except ValueError as error:
+        assert "found none" in str(error)
+    else:
+        raise AssertionError("capture without launch should fail")
+
+
+def test_capture_executes_an_unchanged_pipeline_script(tmp_path) -> None:
+    script = tmp_path / "pipeline.py"
+    script.write_text(
+        "import refiner as mdr\n"
+        "mdr.from_items([1, 2]).launch_cloud(name='captured pipeline')\n"
+    )
+
+    launcher = debug._capture_launcher(str(script), [])
+
+    assert launcher.name == "captured pipeline"
+
+
+def test_debug_sync_json_redirects_pipeline_stdout(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(debug, "MacrodataClient", lambda: object())
+    monkeypatch.setattr(
+        debug,
+        "_job_for_target",
+        lambda _args, _client: ("job-1", None),
+    )
+
+    def capture_launcher(_pipeline, _script_args):
+        print("pipeline diagnostic")
+        return object()
+
+    monkeypatch.setattr(debug, "_capture_launcher", capture_launcher)
+    monkeypatch.setattr(debug, "find_project_root", lambda _pipeline: Path("."))
+    monkeypatch.setattr(
+        debug,
+        "_sync_launcher",
+        lambda **_kwargs: (
+            print("manifest diagnostic"),
+            {"status": "ready", "shards": 2},
+        )[1],
+    )
+
+    assert (
+        debug._cmd_sync(
+            Namespace(
+                pipeline="pipeline.py",
+                job_id="job-1",
+                script_args=[],
+                json=True,
+            )
+        )
         == 0
     )
-    assert debug.cmd_debug_doctor(Namespace(job_id="job-1", json=False)) == 0
 
-    sync_call = client.calls[0]
-    assert sync_call[0] == "sync"
-    assert sync_call[1]["job_id"] == "job-1"
-    assert isinstance(sync_call[1]["archive"], bytes)
-    sha256 = sync_call[1]["sha256"]
-    assert isinstance(sha256, str)
-    assert len(sha256) == 64
-    assert client.calls[1] == ("doctor", {"job_id": "job-1"})
-    assert "Synced 1 files" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {"status": "ready", "shards": 2}
+    assert captured.err == "pipeline diagnostic\nmanifest diagnostic\n"
+
+
+def test_debug_reports_expected_errors_without_traceback(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        debug,
+        "_dispatch",
+        lambda _args: (_ for _ in ()).throw(RuntimeError("not ready")),
+    )
+
+    assert (
+        debug.cmd_debug(
+            Namespace(debug_help=False, debug_args=["status", "pipeline.py"])
+        )
+        == 1
+    )
+    assert capsys.readouterr().err == "not ready\n"

--- a/tests/cli/test_debug_sessions.py
+++ b/tests/cli/test_debug_sessions.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from threading import Event, Thread
+from types import SimpleNamespace
+
+from refiner.cli import debug_sessions
+from refiner.cli.debug_sessions import (
+    find_session,
+    new_session_record,
+    remove_session,
+    save_session,
+    session_creation_lock,
+)
+
+
+class _Client:
+    def __init__(self, workspace: str) -> None:
+        self.base_url = "https://macrodata.test"
+        self.workspace = workspace
+
+    def verify_api_key(self):
+        return SimpleNamespace(
+            workspace=SimpleNamespace(slug=self.workspace),
+            key_id="key-1",
+            name="test",
+        )
+
+
+def test_session_registry_is_scoped_by_pipeline_endpoint_and_workspace(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    script = tmp_path / "project" / "pipeline.py"
+    script.parent.mkdir()
+    script.write_text("pass\n")
+    client = _Client("workspace-a")
+    record = new_session_record(
+        script=script,
+        project_root=script.parent,
+        script_args=["--rows", "10"],
+        job_id="job-1",
+        client=client,  # type: ignore[arg-type]
+    )
+
+    save_session(record)
+
+    assert find_session(script=script, client=client) == record  # type: ignore[arg-type]
+    assert find_session(script=script, client=_Client("workspace-b")) is None  # type: ignore[arg-type]
+    remove_session(script=script, client=client)  # type: ignore[arg-type]
+    assert find_session(script=script, client=client) is None  # type: ignore[arg-type]
+
+
+def test_session_creation_lock_serializes_same_pipeline(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    script = tmp_path / "project" / "pipeline.py"
+    script.parent.mkdir()
+    script.write_text("pass\n")
+    client = _Client("workspace-a")
+    waiting = Event()
+    acquired = Event()
+
+    def acquire_again() -> None:
+        waiting.set()
+        with session_creation_lock(script=script, client=client):  # type: ignore[arg-type]
+            acquired.set()
+
+    with session_creation_lock(script=script, client=client):  # type: ignore[arg-type]
+        contender = Thread(target=acquire_again)
+        contender.start()
+        assert waiting.wait(timeout=1)
+        assert not acquired.wait(timeout=0.05)
+
+    contender.join(timeout=1)
+    assert not contender.is_alive()
+    assert acquired.is_set()
+
+
+def test_exclusive_file_lock_uses_windows_backend(monkeypatch, tmp_path) -> None:
+    calls: list[int] = []
+
+    class _Msvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(_fd: int, mode: int, size: int) -> None:
+            assert size == 1
+            calls.append(mode)
+
+    monkeypatch.setattr(debug_sessions, "_fcntl", None)
+    monkeypatch.setattr(debug_sessions, "_msvcrt", _Msvcrt)
+
+    with debug_sessions._exclusive_file_lock(tmp_path / "session.lock"):
+        assert calls == [_Msvcrt.LK_NBLCK]
+
+    assert calls == [_Msvcrt.LK_NBLCK, _Msvcrt.LK_UNLCK]

--- a/tests/cli/test_debug_sync.py
+++ b/tests/cli/test_debug_sync.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
+import hashlib
+import importlib.util
 import io
+import json
+import sys
 import tarfile
+from types import ModuleType
 
-from refiner.cli.debug_sync import build_source_archive
+import cloudpickle
+import pytest
+
+from refiner.cli.debug_sync import (
+    build_debug_sync_bundle,
+    build_source_archive,
+    find_project_root,
+    pickle_project_modules_by_value,
+)
 
 
 def test_source_archive_excludes_secrets_and_build_artifacts(tmp_path) -> None:
@@ -20,3 +33,91 @@ def test_source_archive_excludes_secrets_and_build_artifacts(tmp_path) -> None:
     assert names == ["src/pipeline.py"]
     assert archive.file_count == 1
     assert len(archive.sha256) == 64
+
+
+def test_source_archive_rejects_projects_with_no_included_files(tmp_path) -> None:
+    (tmp_path / ".env").write_text("SECRET=nope\n")
+
+    with pytest.raises(ValueError, match="source archive is empty"):
+        build_source_archive(tmp_path)
+
+
+def test_source_archive_excludes_conventional_virtualenv(tmp_path) -> None:
+    (tmp_path / "pipeline.py").write_text("PIPELINE = 1\n")
+    (tmp_path / "venv" / "lib").mkdir(parents=True)
+    (tmp_path / "venv" / "lib" / "dependency.py").write_text("SECRET = 1\n")
+
+    archive = build_source_archive(tmp_path)
+
+    with tarfile.open(fileobj=io.BytesIO(archive.payload), mode="r:gz") as tar:
+        assert tar.getnames() == ["pipeline.py"]
+
+
+def test_debug_sync_bundle_contains_one_complete_generation(tmp_path) -> None:
+    (tmp_path / "pipeline.py").write_text("PIPELINE = 1\n")
+
+    pipeline_payload = b"cloudpickle"
+    pipeline_sha256 = hashlib.sha256(pipeline_payload).hexdigest()
+    bundle = build_debug_sync_bundle(
+        source_root=tmp_path,
+        pipeline_payload=pipeline_payload,
+        pipeline_sha256=pipeline_sha256,
+        allocation_fingerprint="a" * 64,
+    )
+
+    with tarfile.open(fileobj=io.BytesIO(bundle.payload), mode="r:") as archive:
+        assert archive.getnames() == [
+            "sync.json",
+            "source.tar.gz",
+            "pipeline.cloudpickle",
+        ]
+        metadata_file = archive.extractfile("sync.json")
+        assert metadata_file is not None
+        metadata = json.loads(metadata_file.read())
+    assert metadata["allocation_fingerprint"] == "a" * 64
+    assert metadata["pipeline_sha256"] == pipeline_sha256
+    assert metadata["source_sha256"] == bundle.source_sha256
+    assert bundle.file_count == 1
+    assert len(bundle.sha256) == 64
+
+
+def test_project_root_prefers_nearest_project_marker(tmp_path) -> None:
+    project = tmp_path / "project"
+    nested = project / "pipelines"
+    nested.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='example'\n")
+    script = nested / "pipeline.py"
+    script.write_text("pass\n")
+
+    assert find_project_root(script) == project
+
+
+def test_project_modules_are_pickled_without_remote_source_imports(tmp_path) -> None:
+    module_path = tmp_path / "debug_helper.py"
+    module_path.write_text("def transform(value):\n    return value + 1\n")
+    spec = importlib.util.spec_from_file_location("debug_helper", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module.__name__] = module
+    try:
+        spec.loader.exec_module(module)
+        with pickle_project_modules_by_value(tmp_path):
+            payload = cloudpickle.dumps(module.transform)
+    finally:
+        sys.modules.pop(module.__name__, None)
+
+    module_path.unlink()
+    restored = cloudpickle.loads(payload)
+    assert restored(2) == 3
+    assert module.__name__ not in cloudpickle.list_registry_pickle_by_value()
+
+
+def test_project_virtualenv_modules_are_not_registered_by_value(tmp_path) -> None:
+    virtualenv_module = ModuleType("__main__")
+    virtualenv_module.__file__ = str(tmp_path / ".venv" / "bin" / "macrodata")
+    sys.modules["debug_virtualenv_main"] = virtualenv_module
+    try:
+        with pickle_project_modules_by_value(tmp_path):
+            pass
+    finally:
+        sys.modules.pop("debug_virtualenv_main", None)

--- a/tests/cli/test_debug_sync.py
+++ b/tests/cli/test_debug_sync.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import io
+import tarfile
+
+from refiner.cli.debug_sync import build_source_archive
+
+
+def test_source_archive_excludes_secrets_and_build_artifacts(tmp_path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "pipeline.py").write_text("PIPELINE = 1\n")
+    (tmp_path / ".env").write_text("SECRET=nope\n")
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "installed.py").write_text("NOPE = 1\n")
+
+    archive = build_source_archive(tmp_path)
+
+    with tarfile.open(fileobj=io.BytesIO(archive.payload), mode="r:gz") as tar:
+        names = tar.getnames()
+    assert names == ["src/pipeline.py"]
+    assert archive.file_count == 1
+    assert len(archive.sha256) == 64

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -17,15 +17,12 @@ def test_parser_has_auth_commands() -> None:
 
 def test_parser_has_debug_commands() -> None:
     parser = build_parser()
-    args = parser.parse_args(["debug", "exec", "job-1", "--", "python", "-V"])
+    args = parser.parse_args(["debug", "exec", "pipeline.py", "--", "python", "-V"])
     assert args.command == "debug"
-    assert args.exec_command == ["python", "-V"]
-    assert args.debug_command == "exec"
-    assert args.job_id == "job-1"
+    assert args.debug_args == ["exec", "pipeline.py", "--", "python", "-V"]
 
-    sync_args = parser.parse_args(["debug", "sync", "job-1", "project"])
-    assert sync_args.debug_command == "sync"
-    assert sync_args.path == "project"
+    create_args = parser.parse_args(["debug", "pipeline.py"])
+    assert create_args.debug_args == ["pipeline.py"]
 
 
 def test_parser_has_run_command() -> None:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -23,6 +23,10 @@ def test_parser_has_debug_commands() -> None:
     assert args.debug_command == "exec"
     assert args.job_id == "job-1"
 
+    sync_args = parser.parse_args(["debug", "sync", "job-1", "project"])
+    assert sync_args.debug_command == "sync"
+    assert sync_args.path == "project"
+
 
 def test_parser_has_run_command() -> None:
     parser = build_parser()

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -41,6 +41,27 @@ def _prepared_payload(payload_bytes: bytes) -> PreparedPipelinePayload:
     )
 
 
+class _SecretMetadataClient:
+    def __init__(self, versions: dict[str, str], *, env: str = "production"):
+        self.versions = versions
+        self.env = env
+
+    def cli_list_secrets(self, *, env: str | None = None) -> dict[str, object]:
+        assert env == self.env
+        return {
+            "secrets": [
+                {
+                    "id": f"secret-{index}",
+                    "name": name,
+                    "version": version,
+                }
+                for index, (name, version) in enumerate(
+                    sorted(self.versions.items()), start=1
+                )
+            ]
+        }
+
+
 def _cloud_file_upload_instruction(
     file: CloudFileUploadRequestItem,
     *,
@@ -78,6 +99,7 @@ def _stub_cloud_submit(
     fail_on_upload_urls: bool = False,
     fail_on_upload: bool = False,
     fail_on_complete: bool = False,
+    workspace_secrets: list[dict[str, str]] | None = None,
 ) -> dict[str, object]:
     captured: dict[str, object] = {
         "events": [],
@@ -159,6 +181,10 @@ def _stub_cloud_submit(
                 warnings: list[str] = []
 
             return _Resp()
+
+        def cli_list_secrets(self, *, env: str | None = None) -> dict[str, object]:
+            cast(list[str], captured["events"]).append(f"list-secrets:{env}")
+            return {"secrets": workspace_secrets or []}
 
     monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
     monkeypatch.setattr(
@@ -260,9 +286,11 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert captured["events"] == ["upload-urls", "upload", "complete", "submit"]
 
 
-def test_pipeline_launch_cloud_debug_submits_and_does_not_attach(
+def test_captured_pipeline_launch_submits_debug_and_does_not_attach(
     monkeypatch, capsys
 ) -> None:
+    from refiner.launchers.cloud_debug_capture import capture_cloud_launches
+
     captured = _stub_cloud_submit(monkeypatch)
     monkeypatch.setattr("refiner.launchers.cloud.stdout_is_interactive", lambda: True)
     monkeypatch.setattr(
@@ -270,53 +298,154 @@ def test_pipeline_launch_cloud_debug_submits_and_does_not_attach(
         lambda **_: pytest.fail("debug launch must not attach to normal job logs"),
     )
 
-    result = read_jsonl("input.jsonl").launch_cloud(
-        name="debug cloud",
-        num_workers=16,
-        debug=True,
-    )
+    with capture_cloud_launches() as capture:
+        placeholder = read_jsonl("input.jsonl").launch_cloud(
+            name="debug cloud",
+            num_workers=16,
+        )
+    assert placeholder.status == "captured"
+    result = capture.single().launch_debug()
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.debug is True
     assert request.stage_payloads[0].runtime.num_workers == 16
     assert result.job_id == "job-123"
-    output = capsys.readouterr().out
-    assert "macrodata debug status job-123" in output
-    assert "macrodata debug run job-123" in output
-    assert "macrodata debug stop job-123" in output
+    assert "Cloud job launched" in capsys.readouterr().out
 
 
-def test_pipeline_launch_cloud_debug_rejects_continue() -> None:
+def test_debug_launch_rejects_continue() -> None:
+    launcher = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug cloud",
+        continue_from_job="00000000-0000-1000-8000-000000000123",
+    )
+
     with pytest.raises(ValueError, match="debug cannot be combined"):
-        CloudLauncher(
-            pipeline=read_jsonl("input.jsonl"),
-            name="debug cloud",
-            debug=True,
-            continue_from_job="00000000-0000-1000-8000-000000000123",
-        )
+        launcher.launch_debug()
 
 
-def test_pipeline_can_replace_retained_debug_payload(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    class FakeMacrodataClient:
-        def cloud_debug_sync_pipeline(self, **kwargs):
-            captured.update(kwargs)
-            return {"sha256": kwargs["sha256"]}
-
-    monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
+def test_launcher_prepares_debug_sync_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
     monkeypatch.setattr(
         "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
         lambda _pipeline: _prepared_payload(b"updated-pipeline"),
     )
-    pipeline = read_jsonl("input.jsonl")
+    launcher = CloudLauncher(pipeline=read_jsonl("input.jsonl"), name="debug")
 
-    result = pipeline.sync_cloud_debug("job-123")
+    prepared = launcher.prepare_debug_sync()
 
-    assert captured["job_id"] == "job-123"
-    assert captured["payload"] == b"updated-pipeline"
-    assert captured["sha256"] == _prepared_payload(b"updated-pipeline").sha256
-    assert result == {"sha256": captured["sha256"]}
+    assert prepared.pipeline_payload == b"updated-pipeline"
+    assert prepared.pipeline_sha256 == _prepared_payload(b"updated-pipeline").sha256
+    assert len(prepared.allocation_fingerprint) == 64
+
+
+def test_debug_allocation_fingerprint_changes_with_resolved_secret(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
+    monkeypatch.setenv("API_KEY", "first-secret")
+    first = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        secrets={"API_KEY": None},
+    ).prepare_debug_sync()
+
+    monkeypatch.setenv("API_KEY", "rotated-secret")
+    second = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        secrets={"API_KEY": None},
+    ).prepare_debug_sync()
+
+    assert first.allocation_fingerprint != second.allocation_fingerprint
+
+
+def test_debug_allocation_fingerprint_changes_with_workspace_secret_rotation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda _pipeline: _prepared_payload(b"pipeline"),
+    )
+
+    client = _SecretMetadataClient({"API_KEY": "a" * 64})
+    launcher = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        secrets=Secrets.env(name="production", keys=["API_KEY"]),
+    )
+    first = launcher.prepare_debug_sync(client=cast(MacrodataClient, client))
+    client.versions["API_KEY"] = "b" * 64
+    second = launcher.prepare_debug_sync(client=cast(MacrodataClient, client))
+
+    assert first.allocation_fingerprint != second.allocation_fingerprint
+
+
+def test_debug_allocation_fingerprint_ignores_unselected_workspace_secret(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda _pipeline: _prepared_payload(b"pipeline"),
+    )
+
+    client = _SecretMetadataClient({"API_KEY": "a" * 64, "UNRELATED": "b" * 64})
+    launcher = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        secrets=Secrets.env(name="production", keys=["API_KEY"]),
+    )
+    first = launcher.prepare_debug_sync(client=cast(MacrodataClient, client))
+    client.versions["UNRELATED"] = "c" * 64
+    second = launcher.prepare_debug_sync(client=cast(MacrodataClient, client))
+
+    assert first.allocation_fingerprint == second.allocation_fingerprint
+
+
+def test_debug_launch_fingerprint_changes_with_workspace_secret_version(
+    monkeypatch,
+) -> None:
+    workspace_secrets = [
+        {
+            "id": "00000000-0000-7000-8000-000000000001",
+            "name": "API_KEY",
+            "version": "a" * 64,
+        }
+    ]
+    captured = _stub_cloud_submit(
+        monkeypatch,
+        workspace_secrets=workspace_secrets,
+    )
+    launcher = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        secrets=Secrets.env(name="production", keys=["API_KEY"]),
+    )
+
+    launcher.launch_debug()
+    first_request = cast(CloudRunCreateRequest, captured["submit_request"])
+    first_fingerprint = cast(dict[str, object], first_request.manifest)[
+        "debug_allocation_fingerprint"
+    ]
+    workspace_secrets[0]["version"] = "b" * 64
+    launcher.launch_debug()
+    second_request = cast(CloudRunCreateRequest, captured["submit_request"])
+    second_fingerprint = cast(dict[str, object], second_request.manifest)[
+        "debug_allocation_fingerprint"
+    ]
+
+    assert first_fingerprint != second_fingerprint
+    assert cast(list[str], captured["events"]).count("list-secrets:production") == 2
 
 
 def test_pipeline_launch_cloud_preserves_auto_workers_without_listing_shards(

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -296,6 +296,29 @@ def test_pipeline_launch_cloud_debug_rejects_continue() -> None:
         )
 
 
+def test_pipeline_can_replace_retained_debug_payload(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeMacrodataClient:
+        def cloud_debug_sync_pipeline(self, **kwargs):
+            captured.update(kwargs)
+            return {"sha256": kwargs["sha256"]}
+
+    monkeypatch.setattr("refiner.launchers.cloud.MacrodataClient", FakeMacrodataClient)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.PreparedPipelinePayload.from_pipeline",
+        lambda _pipeline: _prepared_payload(b"updated-pipeline"),
+    )
+    pipeline = read_jsonl("input.jsonl")
+
+    result = pipeline.sync_cloud_debug("job-123")
+
+    assert captured["job_id"] == "job-123"
+    assert captured["payload"] == b"updated-pipeline"
+    assert captured["sha256"] == _prepared_payload(b"updated-pipeline").sha256
+    assert result == {"sha256": captured["sha256"]}
+
+
 def test_pipeline_launch_cloud_preserves_auto_workers_without_listing_shards(
     monkeypatch,
 ) -> None:

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -163,7 +163,8 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         workdir="/tmp/refiner-debug",
         timeout_secs=12,
     )
-    client.cloud_debug_run(job_id="job/1", max_shards=1, timeout_secs=30)
+    client.cloud_debug_run(job_id="job/1", max_shards=1, timeout_secs=30, profile=True)
+    client.cloud_debug_profile(job_id="job/1")
     client.cloud_debug_stop(job_id="job/1")
     client.cloud_debug_doctor(job_id="job/1")
 
@@ -171,6 +172,7 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         "/api/cloud/debug/job%2F1/status",
         "/api/cloud/debug/job%2F1/exec",
         "/api/cloud/debug/job%2F1/run",
+        "/api/cloud/debug/job%2F1/profile",
         "/api/cloud/debug/job%2F1/stop",
         "/api/cloud/debug/job%2F1/doctor",
     ]
@@ -179,10 +181,16 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         "timeout_secs": 12,
         "workdir": "/tmp/refiner-debug",
     }
-    assert calls[2]["json_payload"] == {"timeout_secs": 30, "max_shards": 1}
+    assert calls[2]["json_payload"] == {
+        "timeout_secs": 30,
+        "max_shards": 1,
+        "profile": True,
+    }
+    assert calls[1]["retry_attempts"] == 1
+    assert calls[2]["retry_attempts"] == 1
 
 
-def test_cloud_debug_sync_streams_archive_bytes() -> None:
+def test_cloud_debug_sync_streams_bundle_bytes() -> None:
     captured: list[tuple[httpx.Request, bytes]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -198,26 +206,18 @@ def test_cloud_debug_sync_streams_archive_bytes() -> None:
 
     result = client.cloud_debug_sync(
         job_id="job-1",
-        archive=b"archive-bytes",
+        bundle=b"bundle-bytes",
         sha256="a" * 64,
-    )
-    pipeline_result = client.cloud_debug_sync_pipeline(
-        job_id="job-1",
-        payload=b"cloudpickle",
-        sha256="b" * 64,
+        allocation_fingerprint="b" * 64,
     )
 
     request, content = captured[0]
     assert request.url.path == "/api/cloud/debug/job-1/sync"
     assert request.url.params["sha256"] == "a" * 64
-    assert request.headers["content-type"] == "application/gzip"
-    assert content == b"archive-bytes"
+    assert request.url.params["allocation_fingerprint"] == "b" * 64
+    assert request.headers["content-type"] == "application/x-tar"
+    assert content == b"bundle-bytes"
     assert result == {"files": 2}
-    pipeline_request, pipeline_content = captured[1]
-    assert pipeline_request.url.path == "/api/cloud/debug/job-1/pipeline"
-    assert pipeline_request.url.params["sha256"] == "b" * 64
-    assert pipeline_content == b"cloudpickle"
-    assert pipeline_result == {"files": 2}
 
 
 def test_cloud_client_cloud_submit_job_requires_job_and_stage_ids(monkeypatch) -> None:

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -165,12 +165,14 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
     )
     client.cloud_debug_run(job_id="job/1", max_shards=1, timeout_secs=30)
     client.cloud_debug_stop(job_id="job/1")
+    client.cloud_debug_doctor(job_id="job/1")
 
     assert [call["path"] for call in calls] == [
         "/api/cloud/debug/job%2F1/status",
         "/api/cloud/debug/job%2F1/exec",
         "/api/cloud/debug/job%2F1/run",
         "/api/cloud/debug/job%2F1/stop",
+        "/api/cloud/debug/job%2F1/doctor",
     ]
     assert calls[1]["json_payload"] == {
         "command": ["python", "-V"],
@@ -178,6 +180,44 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         "workdir": "/tmp/refiner-debug",
     }
     assert calls[2]["json_payload"] == {"timeout_secs": 30, "max_shards": 1}
+
+
+def test_cloud_debug_sync_streams_archive_bytes() -> None:
+    captured: list[tuple[httpx.Request, bytes]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append((request, request.content))
+        return httpx.Response(200, json={"files": 2})
+
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    client._http_client.close()
+    client._http_client = httpx.Client(
+        headers={"Authorization": "Bearer md_test"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.cloud_debug_sync(
+        job_id="job-1",
+        archive=b"archive-bytes",
+        sha256="a" * 64,
+    )
+    pipeline_result = client.cloud_debug_sync_pipeline(
+        job_id="job-1",
+        payload=b"cloudpickle",
+        sha256="b" * 64,
+    )
+
+    request, content = captured[0]
+    assert request.url.path == "/api/cloud/debug/job-1/sync"
+    assert request.url.params["sha256"] == "a" * 64
+    assert request.headers["content-type"] == "application/gzip"
+    assert content == b"archive-bytes"
+    assert result == {"files": 2}
+    pipeline_request, pipeline_content = captured[1]
+    assert pipeline_request.url.path == "/api/cloud/debug/job-1/pipeline"
+    assert pipeline_request.url.params["sha256"] == "b" * 64
+    assert pipeline_content == b"cloudpickle"
+    assert pipeline_result == {"files": 2}
 
 
 def test_cloud_client_cloud_submit_job_requires_job_and_stage_ids(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- synchronize filtered local source archives into the retained worker
- replace serialized pipeline payloads independently
- add exact-environment doctor output
- document safe iterative workflows

This is PR 2/3 of the Refiner cloud-debug client stack and depends on #245.

## Tests
- archive safety tests
- client, CLI, launcher, Ruff, and type checks