### PR TITLE
docs(debug): explain sync argument replacement

### DIFF
--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -51,6 +51,15 @@ An interrupted or invalid sync leaves the previous generation runnable. Version
 control data, virtual environments, caches, `node_modules`, and dotenv files are
 excluded.
 
+Sync reuses the script arguments remembered when the session was created. Pass
+new arguments after `--` to replace them, or end the command with `--` to clear
+them and run the script with its default arguments:
+
+```bash
+macrodata debug sync pipeline.py -- --rows 20
+macrodata debug sync pipeline.py --
+```
+
 Dependencies, Python and Refiner versions, CPU, memory, GPU, cloud placement,
 runtime services, secrets, and plain environment variables are fixed when the
 worker is allocated. If any of these settings change, sync asks you to stop and

--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -51,13 +51,22 @@ An interrupted or invalid sync leaves the previous generation runnable. Version
 control data, virtual environments, caches, `node_modules`, and dotenv files are
 excluded.
 
-Sync reuses the script arguments remembered when the session was created. Pass
-new arguments after `--` to replace them, or end the command with `--` to clear
-them and run the script with its default arguments:
+When local session state is available, sync reuses the script arguments
+remembered when the session was created. Pass new arguments after `--` to
+replace them, or end the command with `--` to clear them and run the script with
+its default arguments:
 
 ```bash
 macrodata debug sync pipeline.py -- --rows 20
 macrodata debug sync pipeline.py --
+```
+
+If local session state is unavailable and you select the session with `--job`,
+repeat any required script arguments after `--`. Without them, the script runs
+with its default arguments:
+
+```bash
+macrodata debug sync pipeline.py --job JOB_ID -- --rows 20
 ```
 
 Dependencies, Python and Refiner versions, CPU, memory, GPU, cloud placement,

--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -54,7 +54,8 @@ excluded.
 When local session state is available, sync reuses the script arguments
 remembered when the session was created. Pass new arguments after `--` to
 replace them, or end the command with `--` to clear them and run the script with
-its default arguments:
+its default arguments for that sync. These overrides do not change the
+remembered creation arguments, so a later bare sync reuses the original values:
 
 ```bash
 macrodata debug sync pipeline.py -- --rows 20


### PR DESCRIPTION
## Summary
- document how debug sync reuses remembered script arguments
- show how to replace arguments after `--`
- show how a trailing `--` clears arguments and restores script defaults

## Verification
- `git diff --check`