### PR TITLE
fix(debug): keep allocation progress visible

### DIFF
--- a/src/refiner/cli/debug.py
+++ b/src/refiner/cli/debug.py
@@ -33,6 +33,7 @@ from refiner.platform.client import MacrodataApiError, MacrodataClient
 _COMMANDS = frozenset(
     {"create", "status", "run", "profile", "exec", "stop", "sync", "doctor"}
 )
+_STATUS_HEARTBEAT_SECS = 30.0
 
 
 def _print_json(payload: dict[str, Any]) -> None:
@@ -89,7 +90,16 @@ def _add_target(parser: argparse.ArgumentParser, *, required: bool = False) -> N
 
 
 def _debug_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="macrodata debug")
+    parser = argparse.ArgumentParser(
+        prog="macrodata debug",
+        epilog=(
+            "Create a session directly from a pipeline script:\n"
+            "  macrodata debug pipeline.py -- --limit 10\n\n"
+            "The equivalent explicit form is:\n"
+            "  macrodata debug create pipeline.py -- --limit 10"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     subparsers = parser.add_subparsers(dest="debug_command", required=True)
 
     create = subparsers.add_parser(
@@ -305,20 +315,31 @@ def _wait_until_ready(
 ) -> dict[str, Any]:
     if timeout_secs <= 0:
         raise SystemExit("--startup-timeout must be greater than zero")
-    deadline = time.monotonic() + timeout_secs
+    started_at = time.monotonic()
+    deadline = started_at + timeout_secs
+    last_progress_at = started_at
     last_status = ""
     while True:
         payload = client.cloud_debug_status(job_id=job_id)
         status = str(payload.get("status", "unknown"))
+        now = time.monotonic()
         if status != last_status:
             print(f"Debug worker: {status}", flush=True)
             last_status = status
+            last_progress_at = now
+        elif now - last_progress_at >= _STATUS_HEARTBEAT_SECS:
+            elapsed_secs = int(now - started_at)
+            print(
+                f"Debug worker: {status} (still waiting; {elapsed_secs}s elapsed)",
+                flush=True,
+            )
+            last_progress_at = now
         if status == "ready":
             return payload
         if status in {"failed", "stopped", "canceled"}:
             detail = payload.get("error") or payload.get("operation_status") or status
             raise RuntimeError(f"debug worker did not start: {detail}")
-        if time.monotonic() >= deadline:
+        if now >= deadline:
             raise RuntimeError(
                 f"debug worker was not ready within {timeout_secs} seconds; "
                 f"continue with `macrodata debug status --job {job_id}`"

--- a/tests/cli/test_debug_commands.py
+++ b/tests/cli/test_debug_commands.py
@@ -181,6 +181,10 @@ def _command_help(command: str, capsys) -> str:
 
 
 def test_debug_help_documents_passthrough_arguments(capsys) -> None:
+    top_level_help = debug._debug_parser().format_help()
+    assert "macrodata debug pipeline.py -- --limit 10" in top_level_help
+    assert "macrodata debug create pipeline.py -- --limit 10" in top_level_help
+
     create_help = _command_help("create", capsys)
     assert "pipeline [-- PIPELINE_ARG ...]" in create_help
     assert "macrodata debug create pipeline.py -- --limit 10" in create_help
@@ -210,6 +214,37 @@ def test_wait_until_ready_flushes_progress(monkeypatch) -> None:
 
     assert payload == {"status": "ready"}
     assert printed == [(("Debug worker: ready",), {"flush": True})]
+
+
+def test_wait_until_ready_emits_heartbeat_for_unchanged_status(monkeypatch) -> None:
+    client = cast(MacrodataClient, _FakeClient())
+    statuses = iter(("allocating", "allocating", "ready"))
+    timestamps = iter((0.0, 0.0, 31.0, 32.0))
+    printed: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        client,
+        "cloud_debug_status",
+        lambda **_kwargs: {"status": next(statuses)},
+    )
+    monkeypatch.setattr(debug.time, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(debug.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "builtins.print",
+        lambda *args, **kwargs: printed.append((args, kwargs)),
+    )
+
+    payload = debug._wait_until_ready(
+        client=client,
+        job_id="job-1",
+        timeout_secs=1200,
+    )
+
+    assert payload == {"status": "ready"}
+    assert printed == [
+        (("Debug worker: allocating",), {"flush": True}),
+        (("Debug worker: allocating (still waiting; 31s elapsed)",), {"flush": True}),
+        (("Debug worker: ready",), {"flush": True}),
+    ]
 
 
 def test_wait_until_ready_treats_canceled_as_terminal(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- advertise the pipeline shorthand in top-level debug help
- emit a flushed heartbeat every 30 seconds while worker status is unchanged
- preserve status-change and timeout behavior

## Verification
- `.venv/bin/python -m pytest -q tests/cli/test_debug_commands.py` (18 passed)
- Ruff check and format verification passed
- `ty check` passed