### PR TITLE
feat(cloud): expand GPU worker types

### DIFF
--- a/docs/examples/cloud/cloud-gpu-job.md
+++ b/docs/examples/cloud/cloud-gpu-job.md
@@ -37,6 +37,6 @@ pipeline.launch_cloud(
 This example requests one H100 GPU for a single cloud worker and logs the raw output of `nvidia-smi` to the worker logs.
 Because the callback is side-effect-only, it does not need to return anything.
 
-For real GPU workloads, use `gpu=mdr.GPU(...)` to specify the required GPU type and count based on your model's needs. Increase the number of tasks if you need to improve parallelization.
+For real GPU workloads, use `gpu=mdr.GPU(...)` to specify the required GPU type and count based on your model's needs. Supported types are `h100`, `l40s`, `a100`, `a10`, `l4`, and `t4`. Increase the number of tasks if you need to improve parallelization.
 
 Related: [Resources, GPUs, and Services](../../running-pipelines/resources-gpus-and-services.md).

--- a/docs/running-pipelines/resources-gpus-and-services.md
+++ b/docs/running-pipelines/resources-gpus-and-services.md
@@ -42,6 +42,15 @@ GPU requests apply per worker. If your transform uses a model directly inside
 the worker, make sure the worker count and GPU count match the model loading
 pattern you want.
 
+Macrodata Cloud supports these GPU types:
+
+- `h100`
+- `l40s`
+- `a100`
+- `a10`
+- `l4`
+- `t4`
+
 ## Runtime services
 
 Some inference workloads are better served by a runtime service, such as vLLM,

--- a/src/refiner/pipeline/resources.py
+++ b/src/refiner/pipeline/resources.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, get_args
 
-GPUType = Literal["h100"]
+GPUType = Literal["h100", "l40s", "a100", "a10", "l4", "t4"]
 CUDAVersion = Literal["12.4", "12.6", "12.8"]
 
 SUPPORTED_GPU_TYPES: tuple[str, ...] = get_args(GPUType)

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import refiner as mdr
 from refiner.pipeline import read_jsonl
-from refiner.pipeline.resources import GPU
+from refiner.pipeline.resources import GPU, GPUType, SUPPORTED_GPU_TYPES
 from refiner.pipeline.planning import PlannedStage, StageComputeRequirements
 from refiner.launchers.cloud import CloudLauncher
 from refiner.platform.auth import MacrodataCredentialsError
@@ -587,7 +587,10 @@ def test_pipeline_launch_cloud_embeds_runtime_services(monkeypatch) -> None:
     assert request.stage_payloads[0].runtime_services[0].to_dict() == expected_service
 
 
-def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:
+@pytest.mark.parametrize("gpu_type", SUPPORTED_GPU_TYPES)
+def test_pipeline_launch_cloud_accepts_structured_gpu(
+    monkeypatch, gpu_type: GPUType
+) -> None:
     captured = _stub_cloud_submit(monkeypatch)
     monkeypatch.setattr(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
@@ -596,24 +599,24 @@ def test_pipeline_launch_cloud_accepts_structured_gpu(monkeypatch) -> None:
 
     read_jsonl("input.jsonl").launch_cloud(
         name="demo cloud",
-        gpu=GPU(count=1, type="h100", cuda_version="12.4"),
+        gpu=GPU(count=1, type=gpu_type, cuda_version="12.4"),
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.plan["stages"][0]["gpu"] == {
         "count": 1,
-        "type": "h100",
+        "type": gpu_type,
         "cuda_version": "12.4",
     }
     runtime = request.stage_payloads[0].runtime
-    assert runtime.gpu == GPU(count=1, type="h100", cuda_version="12.4")
+    assert runtime.gpu == GPU(count=1, type=gpu_type, cuda_version="12.4")
 
 
 def test_gpu_rejects_unsupported_values() -> None:
     with pytest.raises(ValueError, match="gpu.count must be > 0"):
         GPU(count=0, type="h100")
-    with pytest.raises(ValueError, match="gpu.type must be one of: h100"):
-        GPU(count=1, type="a100")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="gpu.type must be one of"):
+        GPU(count=1, type="v100")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="gpu.cuda_version must be one of"):
         GPU(count=1, type="h100", cuda_version="13.0")  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Purpose

Allow Refiner clients to request every GPU worker type supported by the Macrodata Cloud API. This is the client companion to macrodata-labs/perpetuity#891.

## Changes

- widen GPUType to h100, l40s, a100, a10, l4, and t4
- verify every supported value is serialized into both the launch plan and stage runtime payload
- keep unsupported GPU types rejected
- document the supported cloud GPU values

Backend-only compatibility aliases l40 and a10g remain intentionally absent from the typed client; new callers should use l40s and a10.

## Verification

- uv run pytest tests/launchers/test_cloud_launcher.py -k "structured_gpu or gpu_rejects_unsupported_values" (7 passed)
- uv run ruff check --force-exclude src/refiner/pipeline/resources.py tests/launchers/test_cloud_launcher.py
- uv run ruff format --force-exclude --check src/refiner/pipeline/resources.py tests/launchers/test_cloud_launcher.py
- uv run ty check

## Rollout

Merge and deploy macrodata-labs/perpetuity#891 before publishing a Refiner release containing this change.