### PR TITLE
Add bounded Lance reads

### DIFF
--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -22,12 +22,16 @@ pipeline = mdr.load_lance(
     columns=["image", "frame_id"],
     batch_size=128,
     num_shards=32,
+    row_limit=2_000,
 )
 ```
 
 When `version` is omitted, Refiner resolves the latest version once and pins it
 for the pipeline. Column projection is pushed into Lance, and `batch_size`
 controls the streamed Arrow batch size.
+Set `row_limit` to a positive integer to read only that many leading rows from
+the pinned dataset version. Refiner stops scanning inside the final fragment;
+datasets with fewer rows simply yield all available rows.
 
 Classic Lance blob columns are returned as lazy Refiner blob references:
 

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -691,6 +691,8 @@ class RefinerPipeline:
                 raise ValueError(
                     "add_columns requires a pipeline created by load_lance"
                 )
+            if self.source.row_limit is not None:
+                raise ValueError("add_columns does not support a limited Lance source")
             source_uri = self.source.dataset_uri
             source_version = self.source.version
         return self.with_sink(
@@ -1366,11 +1368,13 @@ def load_lance(
     columns: Sequence[str] | None = None,
     batch_size: int = 65_536,
     num_shards: int | None = None,
+    row_limit: int | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline over one immutable version of a Lance dataset.
 
     ``num_shards`` groups whole, adjacent Lance fragments into the requested
     number of scheduling shards without splitting individual fragments.
+    ``row_limit`` reads at most that many leading rows from the pinned version.
     """
     return RefinerPipeline(
         source=LanceSource(
@@ -1379,6 +1383,7 @@ def load_lance(
             columns=columns,
             batch_size=batch_size,
             num_shards=num_shards,
+            row_limit=row_limit,
         )
     )
 

--- a/src/refiner/pipeline/sources/lance.py
+++ b/src/refiner/pipeline/sources/lance.py
@@ -69,12 +69,15 @@ class LanceSource(BaseSource):
         columns: Sequence[str] | None = None,
         batch_size: int = 65_536,
         num_shards: int | None = None,
+        row_limit: int | None = None,
     ) -> None:
         if batch_size <= 0:
             raise ValueError("batch_size must be > 0")
         if columns is not None and len(set(columns)) != len(columns):
             raise ValueError("Lance columns must be unique")
         validate_explicit_num_shards(num_shards)
+        if row_limit is not None and row_limit <= 0:
+            raise ValueError("row_limit must be > 0")
 
         self.input = DataFolder.resolve(input)
         if self.input.has_explicit_filesystem_configuration:
@@ -87,7 +90,9 @@ class LanceSource(BaseSource):
         self.columns = tuple(columns) if columns is not None else None
         self.batch_size = int(batch_size)
         self.num_shards = num_shards
+        self.row_limit = int(row_limit) if row_limit is not None else None
         self._dataset_cache: Any | None = None
+        self._fragment_row_limits: tuple[int, ...] | None = None
 
         dataset = _import_lance().dataset(self.dataset_uri, version=version)
         self.version = int(dataset.version)
@@ -159,8 +164,31 @@ class LanceSource(BaseSource):
         state["_dataset_cache"] = None
         return state
 
+    def _planned_fragment_row_limits(self) -> tuple[int, ...]:
+        if self._fragment_row_limits is not None:
+            return self._fragment_row_limits
+        fragments = self._dataset().get_fragments()
+        if self.row_limit is None:
+            limits = tuple(-1 for _ in fragments)
+        else:
+            remaining = self.row_limit
+            planned: list[int] = []
+            for fragment in fragments:
+                if remaining <= 0:
+                    break
+                rows = int(fragment.count_rows())
+                if rows <= 0:
+                    planned.append(0)
+                    continue
+                take_rows = min(rows, remaining)
+                planned.append(take_rows)
+                remaining -= take_rows
+            limits = tuple(planned)
+        self._fragment_row_limits = limits
+        return limits
+
     def list_shards(self) -> list[Shard]:
-        fragment_count = len(self._dataset().get_fragments())
+        fragment_count = len(self._planned_fragment_row_limits())
         if fragment_count == 0:
             return []
         shard_count = (
@@ -254,9 +282,16 @@ class LanceSource(BaseSource):
             or descriptor.end > len(fragments)
         ):
             raise ValueError("Lance shard fragment range is invalid")
-        for fragment in fragments[descriptor.start : descriptor.end]:
+        fragment_row_limits = self._planned_fragment_row_limits()
+        for fragment_index in range(descriptor.start, descriptor.end):
+            fragment = fragments[fragment_index]
+            planned_rows = fragment_row_limits[fragment_index]
+            expected_rows = (
+                int(fragment.count_rows()) if planned_rows < 0 else planned_rows
+            )
+            if expected_rows == 0:
+                continue
             blob_paths = self._fragment_blob_paths(fragment)
-            expected_rows = int(fragment.count_rows())
             rows_read = 0
             for batch in fragment.to_batches(
                 columns=list(self.columns) if self.columns is not None else None,
@@ -264,6 +299,8 @@ class LanceSource(BaseSource):
                 with_row_address=True,
                 blob_handling="blobs_descriptions",
             ):
+                if rows_read + batch.num_rows > expected_rows:
+                    batch = batch.slice(0, expected_rows - rows_read)
                 table = self._normalize_blob_columns(
                     pa.Table.from_batches([batch]),
                     blob_paths,
@@ -277,6 +314,8 @@ class LanceSource(BaseSource):
                         row_addresses,
                     )
                 )
+                if rows_read >= expected_rows:
+                    break
             if rows_read != expected_rows:
                 raise ValueError(
                     f"Lance fragment {fragment.fragment_id} yielded {rows_read} rows; "
@@ -290,6 +329,7 @@ class LanceSource(BaseSource):
             "columns": list(self.columns) if self.columns is not None else None,
             "batch_size": self.batch_size,
             "num_shards": self.num_shards,
+            "row_limit": self.row_limit,
         }
 
 

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -19,6 +19,8 @@ def test_load_lance_rejects_explicit_shard_count_above_limit() -> None:
 def test_load_lance_caps_automatic_shards_without_dropping_fragments() -> None:
     source = object.__new__(LanceSource)
     source.num_shards = None
+    source.row_limit = None
+    source._fragment_row_limits = None
     source._dataset_cache = type(
         "Dataset",
         (),
@@ -143,6 +145,56 @@ def test_load_lance_groups_fragments_into_requested_shards(tmp_path) -> None:
     ]
     assert [int(row["x"]) for row in pipeline.iter_rows()] == list(range(5))
     assert len(load_lance(dataset_uri, num_shards=100).list_shards()) == fragment_count
+
+
+def test_load_lance_limits_leading_rows_across_fragments(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "limited.lance"
+    lance.write_dataset(
+        pa.table({"x": list(range(10))}),
+        str(dataset_uri),
+        max_rows_per_file=3,
+    )
+
+    pipeline = load_lance(
+        dataset_uri,
+        batch_size=2,
+        num_shards=2,
+        row_limit=5,
+    )
+
+    assert [int(row["x"]) for row in pipeline.iter_rows()] == list(range(5))
+    assert len(pipeline.list_shards()) == 2
+    assert pipeline.source.describe()["row_limit"] == 5
+
+
+def test_load_lance_row_limit_allows_short_dataset(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "short.lance"
+    lance.write_dataset(pa.table({"x": [1, 2]}), str(dataset_uri))
+
+    assert [
+        int(row["x"]) for row in load_lance(dataset_uri, row_limit=10).iter_rows()
+    ] == [1, 2]
+
+
+@pytest.mark.parametrize("row_limit", [0, -1])
+def test_load_lance_rejects_nonpositive_row_limit(row_limit: int) -> None:
+    with pytest.raises(ValueError, match="row_limit must be > 0"):
+        LanceSource("unused.lance", row_limit=row_limit)
+
+
+def test_limited_lance_source_rejects_add_columns(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "limited-add-columns.lance"
+    lance.write_dataset(pa.table({"x": [1, 2]}), str(dataset_uri))
+
+    with pytest.raises(ValueError, match="limited Lance source"):
+        load_lance(dataset_uri, row_limit=1).write_lance_dataset(
+            dataset_uri,
+            mode="add_columns",
+            columns=["y"],
+        )
 
 
 def test_load_lance_uses_physical_row_addresses_as_source_row_ids(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add `row_limit` to `load_lance`
- stop scanning within the final fragment while retaining physical row identity
- reject partial Lance sources for `add_columns`
- document and test cross-fragment and short-dataset behavior

## Validation
- `uv run pytest -q tests/readers/test_lance_source.py tests/pipeline/test_sinks.py -k lance` (78 passed)
- Ruff, format, ty pre-commit hooks