### PR TITLE
Harden and document packed blob coalescing

### DIFF
--- a/docs/writing-data/media-assets-and-reducers.md
+++ b/docs/writing-data/media-assets-and-reducers.md
@@ -59,6 +59,13 @@ pipeline.write_parquet(
 target, not a hard limit: an individual asset larger than the target is written
 to its own larger block.
 
+When the input rows collectively reference every byte of an existing packed
+blob, Refiner copies that source blob once and translates the output offsets.
+It does not download and upload each referenced range separately. Partial
+selections retain the normal range-copy behavior, and the optimization is
+disabled for missing-asset policies other than `"error"` so their row-level
+semantics remain unchanged.
+
 When the destination uses s3fs, including AWS S3 and Cloudflare R2, Refiner
 uploads large files with bounded multipart concurrency. No additional
 configuration is required. Small files retain s3fs's one-shot PUT behavior.
@@ -145,3 +152,9 @@ size and therefore cannot exceed 10,000 parts; it fails and aborts cleanly
 instead. Peak memory includes the batch buffer and materialized input bytes.
 The patch subclasses s3fs's file class and keeps its normal multipart creation,
 commit, abort, endpoint, credential, and cache behavior.
+
+Complete-blob coalescing groups scalar blob references by source path and only
+uses the fast path when their sorted union covers the source from byte zero
+through its exact size without gaps. Overlapping references are supported;
+malformed or partial reference sets fall back to the established per-range
+writer.

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -724,7 +724,12 @@ class BlobAssetManager:
         """Whether the union of byte references is exactly one source blob."""
         position = 0
         for offset, size in sorted(references):
-            if size < 0 or offset < 0 or offset > source_size or size > source_size - offset:
+            if (
+                size < 0
+                or offset < 0
+                or offset > source_size
+                or size > source_size - offset
+            ):
                 return False
             if offset > position:
                 return False

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -716,6 +716,82 @@ class BlobAssetManager:
             valid = valid and copied
         return rewritten, valid
 
+    @staticmethod
+    def _covers_entire_blob(
+        references: Sequence[tuple[int, int]],
+        source_size: int,
+    ) -> bool:
+        """Whether the union of byte references is exactly one source blob."""
+        position = 0
+        for offset, size in sorted(references):
+            if size < 0 or offset < 0 or offset > source_size or size > source_size - offset:
+                return False
+            if offset > position:
+                return False
+            position = max(position, offset + size)
+        return position == source_size
+
+    def _coalesce_complete_blob_references(
+        self,
+        values: Sequence[object],
+        *,
+        shard_id: str,
+        column_name: str,
+    ) -> dict[int, object]:
+        """Copy complete classic blob sources once and translate their offsets.
+
+        This is deliberately an internal optimization of the existing blob
+        reference writer.  A partial selection still uses the established
+        per-range copier below, preserving its missing-asset policies.
+        """
+        if self.missing_asset_policy != "error":
+            return {}
+        grouped: dict[str, list[tuple[int, int, int]]] = {}
+        for index, value in enumerate(values):
+            if value is None or not isinstance(value, Mapping):
+                continue
+            path = value.get("path")
+            offset = value.get("offset")
+            size = value.get("size")
+            if (
+                isinstance(path, str)
+                and path
+                and isinstance(offset, int)
+                and not isinstance(offset, bool)
+                and isinstance(size, int)
+                and not isinstance(size, bool)
+            ):
+                grouped.setdefault(path, []).append((index, offset, size))
+
+        rewritten: dict[int, object] = {}
+        for path, references in grouped.items():
+            source = DataFile.resolve(path)
+            source_size = int(source.fs.size(source.path))
+            if not self._covers_entire_blob(
+                [(offset, size) for _, offset, size in references], source_size
+            ):
+                continue
+            block = self._block(shard_id, column_name, source_size)
+            output_offset = block.size
+            remaining = source_size
+            with source.open("rb") as stream:
+                while remaining:
+                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
+                    if not chunk:
+                        raise EOFError("asset ended before its declared size")
+                    block.stream.write(chunk)
+                    remaining -= len(chunk)
+            block.size += source_size
+            for index, offset, size in references:
+                rewritten[index] = {
+                    "path": block.path,
+                    "offset": output_offset + offset,
+                    "size": size,
+                }
+            log_throughput("source_blobs_coalesced", 1, shard_id, unit="blobs")
+            log_throughput("assets_uploaded", len(references), shard_id, unit="assets")
+        return rewritten
+
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
         columns = dict(self._asset_columns)
         columns.update(_asset_columns_from_schema(table.schema))
@@ -727,15 +803,26 @@ class BlobAssetManager:
             index = out.schema.get_field_index(column_name)
             if index < 0:
                 continue
-            values: list[object] = []
-            for row_offset, value in enumerate(out.column(index).to_pylist()):
-                rewritten, valid = self._rewrite_value(
-                    value,
-                    shard_id=shard_id,
-                    column_name=column_name,
-                    kind=kind,
-                    storage=storage,
+            original_values = out.column(index).to_pylist()
+            coalesced = (
+                self._coalesce_complete_blob_references(
+                    original_values, shard_id=shard_id, column_name=column_name
                 )
+                if kind == "scalar" and storage == "blob_reference"
+                else {}
+            )
+            values: list[object] = []
+            for row_offset, value in enumerate(original_values):
+                if row_offset in coalesced:
+                    rewritten, valid = coalesced[row_offset], True
+                else:
+                    rewritten, valid = self._rewrite_value(
+                        value,
+                        shard_id=shard_id,
+                        column_name=column_name,
+                        kind=kind,
+                        storage=storage,
+                    )
                 values.append(rewritten)
                 if not valid and self.missing_asset_policy == "drop_row":
                     keep[row_offset] = False

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -98,17 +98,21 @@ def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
 
 
 def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
-    """Normalize every worker's materialized output to the planned schema."""
-    actual_names = set(table.schema.names)
-    expected_names = set(schema.names)
-    if actual_names != expected_names:
-        raise ValueError(
-            "Lance output columns differ from planned schema: "
-            + _schema_difference(schema, table.schema)
+    """Normalize fields known to the planner without forbidding row-map drops.
+
+    Python row maps may use ``row.drop(...)``; their dynamic removal is not
+    visible to the static pipeline schema.  Every surviving field that *is*
+    known to the planner is nevertheless cast to its declared field, which
+    makes dtypes and metadata deterministic across workers.
+    """
+    fields: list[pa.Field] = []
+    for actual_field in table.schema:
+        planned_index = schema.get_field_index(actual_field.name)
+        fields.append(
+            actual_field if planned_index < 0 else schema.field(planned_index)
         )
-    # Selecting establishes the planner's deterministic column order; cast uses
-    # the target fields/metadata rather than preserving worker-local inference.
-    return table.select(schema.names).cast(schema, safe=True)
+    target = pa.schema(fields, metadata=schema.metadata)
+    return table.cast(target, safe=True)
 
 
 def _validate_write_mode(mode: str) -> None:

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -73,6 +73,44 @@ def _import_lance() -> Any:
     return lance
 
 
+def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
+    """Return a compact, actionable schema difference for distributed commits."""
+    details: list[str] = []
+    expected_names = set(expected.names)
+    actual_names = set(actual.names)
+    if missing := sorted(expected_names - actual_names):
+        details.append("missing=" + ", ".join(missing))
+    if extra := sorted(actual_names - expected_names):
+        details.append("unexpected=" + ", ".join(extra))
+    for name in expected.names:
+        actual_index = actual.get_field_index(name)
+        if actual_index < 0:
+            continue
+        expected_field = expected.field(name)
+        actual_field = actual.field(actual_index)
+        if not expected_field.equals(actual_field, check_metadata=True):
+            details.append(
+                f"{name}: expected={expected_field!s}, actual={actual_field!s}"
+            )
+    if expected.metadata != actual.metadata:
+        details.append("schema metadata differs")
+    return "; ".join(details) or "unknown schema difference"
+
+
+def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Normalize every worker's materialized output to the planned schema."""
+    actual_names = set(table.schema.names)
+    expected_names = set(schema.names)
+    if actual_names != expected_names:
+        raise ValueError(
+            "Lance output columns differ from planned schema: "
+            + _schema_difference(schema, table.schema)
+        )
+    # Selecting establishes the planner's deterministic column order; cast uses
+    # the target fields/metadata rather than preserving worker-local inference.
+    return table.select(schema.names).cast(schema, safe=True)
+
+
 def _validate_write_mode(mode: str) -> None:
     valid_modes = get_args(LanceWriteMode)
     if mode not in valid_modes:
@@ -684,6 +722,7 @@ class LanceDatasetSink(BaseSink):
             str, dict[int, _StreamingAddColumnsWriter]
         ] = {}
         self._add_columns_schema: pa.Schema | None = None
+        self._planned_output_schema: pa.Schema | None = None
         self._existing_schema: pa.Schema | None = None
         self._existing_version: int | None = None
         self._source_dataset_cache: Any | None = None
@@ -750,6 +789,10 @@ class LanceDatasetSink(BaseSink):
         if self._assets is not None:
             self._assets.set_input_schema(schema)
             schema = self._assets.output_schema(schema)
+        # The planner has a complete schema for Lance-backed sources and for
+        # maps with dtypes.  Keep it so independent cloud workers cannot leak
+        # local Arrow inference or metadata into their output fragments.
+        self._planned_output_schema = schema
         if self.mode != "add_columns":
             return
         assert self.columns is not None
@@ -853,6 +896,8 @@ class LanceDatasetSink(BaseSink):
             return
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
+        if self._planned_output_schema is not None:
+            table = _cast_to_planned_schema(table, self._planned_output_schema)
         if self.mode == "append":
             existing_schema = self._load_existing_schema()
             _validate_append_asset_layout(table.schema, existing_schema)
@@ -1398,7 +1443,8 @@ class LanceDatasetCommitReducerSink(BaseSink):
                     schema = next_schema
                 elif not schema.equals(next_schema, check_metadata=True):
                     raise ValueError(
-                        "Cannot commit Lance fragments with inconsistent schemas."
+                        "Cannot commit Lance fragments with inconsistent schemas: "
+                        + _schema_difference(schema, next_schema)
                     )
             fragment_json.extend(next_fragments)
             if next_source_version is not None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1563,6 +1563,100 @@ def test_parquet_sink_packs_embedded_assets_into_blob_files(tmp_path) -> None:
     assert datatype.asset_storage(out.schema.field("image")) == "blob_reference"
 
 
+def test_blob_writer_coalesces_complete_source_blob_references(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "source.blob"
+    source.write_bytes(b"abcdef")
+    output = DataFolder.resolve(tmp_path / "coalesced-assets")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(source), "offset": 0, "size": 3},
+                    {"path": str(source), "offset": 3, "size": 3},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=1024),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+
+    def unexpected_range_copy(*_args, **_kwargs):
+        raise AssertionError("complete source blob should not use per-range copies")
+
+    monkeypatch.setattr(manager, "_append", unexpected_range_copy)
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        rewritten = manager.rewrite_table("0123456789ab", table)
+        manager.close()
+
+    references = rewritten.column("video").to_pylist()
+    assert [read_blob(reference) for reference in references] == [b"abc", b"def"]
+    assert references[0]["path"] == references[1]["path"]
+    assert references[0]["offset"] == 0
+    assert references[1]["offset"] == 3
+
+
+def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "source.blob"
+    source.write_bytes(b"abcdef")
+    output = DataFolder.resolve(tmp_path / "partial-assets")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(source), "offset": 0, "size": 3},
+                    {"path": str(source), "offset": 3, "size": 2},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=1024),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+    calls = 0
+    original_append = manager._append
+
+    def count_range_copy(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_append(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "_append", count_range_copy)
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        rewritten = manager.rewrite_table("0123456789ab", table)
+        manager.close()
+
+    assert calls == 2
+    assert [read_blob(reference) for reference in rewritten.column("video").to_pylist()] == [
+        b"abc",
+        b"de",
+    ]
+
+
 def test_file_asset_copy_removes_partial_output_when_source_disappears(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -29,6 +29,7 @@ from refiner.pipeline.sinks.lance import (
     LanceDatasetCommitReducerSink,
     LanceDatasetSink,
     _StreamingAddColumnsWriter,
+    _cast_to_planned_schema,
     _job_token,
     _schema_to_base64,
 )
@@ -80,6 +81,23 @@ def test_iter_rows_ignores_sink(tmp_path) -> None:
     out = list(pipeline.iter_rows())
     assert [int(row["x"]) for row in out] == [1, 2]
     assert list(tmp_path.iterdir()) == []
+
+
+def test_lance_writer_normalizes_worker_schema_metadata() -> None:
+    planned = pa.schema(
+        [pa.field("x", pa.int64(), metadata={b"unit": b"planned"})],
+        metadata={b"schema": b"planned"},
+    )
+    worker_local = pa.schema(
+        [pa.field("x", pa.int64(), metadata={b"unit": b"worker"})],
+        metadata={b"schema": b"worker"},
+    )
+    table = pa.Table.from_arrays([pa.array([1, 2])], schema=worker_local)
+
+    normalized = _cast_to_planned_schema(table, planned)
+
+    assert normalized.schema.equals(planned, check_metadata=True)
+    assert normalized.to_pydict() == {"x": [1, 2]}
 
 
 def test_launch_local_writes_jsonl_per_shard(tmp_path) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1591,7 +1591,9 @@ def test_parquet_sink_packs_embedded_assets_into_blob_files(tmp_path) -> None:
     assert datatype.asset_storage(out.schema.field("image")) == "blob_reference"
 
 
-def test_blob_writer_coalesces_complete_source_blob_references(tmp_path, monkeypatch) -> None:
+def test_blob_writer_coalesces_complete_source_blob_references(
+    tmp_path, monkeypatch
+) -> None:
     source = tmp_path / "source.blob"
     source.write_bytes(b"abcdef")
     output = DataFolder.resolve(tmp_path / "coalesced-assets")
@@ -1636,7 +1638,9 @@ def test_blob_writer_coalesces_complete_source_blob_references(tmp_path, monkeyp
     assert references[1]["offset"] == 3
 
 
-def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(tmp_path, monkeypatch) -> None:
+def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(
+    tmp_path, monkeypatch
+) -> None:
     source = tmp_path / "source.blob"
     source.write_bytes(b"abcdef")
     output = DataFolder.resolve(tmp_path / "partial-assets")
@@ -1679,7 +1683,9 @@ def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(tmp_path, monk
         manager.close()
 
     assert calls == 2
-    assert [read_blob(reference) for reference in rewritten.column("video").to_pylist()] == [
+    assert [
+        read_blob(reference) for reference in rewritten.column("video").to_pylist()
+    ] == [
         b"abc",
         b"de",
     ]

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -100,6 +100,16 @@ def test_lance_writer_normalizes_worker_schema_metadata() -> None:
     assert normalized.to_pydict() == {"x": [1, 2]}
 
 
+def test_lance_writer_allows_row_map_dropped_planned_fields() -> None:
+    planned = pa.schema([pa.field("x", pa.int64()), pa.field("dropped", pa.string())])
+    table = pa.table({"x": [1, 2]})
+
+    normalized = _cast_to_planned_schema(table, planned)
+
+    assert normalized.schema.names == ["x"]
+    assert normalized.schema.field("x").type == pa.int64()
+
+
 def test_launch_local_writes_jsonl_per_shard(tmp_path) -> None:
     output_dir = tmp_path / "jsonl-output"
     pipeline = (


### PR DESCRIPTION
## Status

The core coalescing implementation is already on main because it landed transitively through PR #259. This branch is now merged with current main and contains only the remaining hardening and documentation delta; it no longer replays the old implementation or schema-normalization work.

## Changes

- fall back to the established per-range copier when a readable filesystem cannot report source size
- retain current main's protection against dynamic untyped map schema changes
- document complete-blob coalescing and its fallback behavior
- preserve partial-reference and non-error missing-asset semantics

## Benefit evidence

A local benchmark copied one 64 MiB packed blob represented by 1,024 contiguous 64 KiB references through BlobAssetManager. Both paths copied the same bytes; the baseline forced the existing per-range path and the optimized run used complete-blob coalescing.

| Path | Source opens | Elapsed |
| --- | ---: | ---: |
| Per-range copy | 1,024 | 0.660 s |
| Complete-blob coalescing | 1 | 0.111 s |

That is a 5.9× local speedup and eliminates 1,023 source opens. For object storage, the request-count reduction is the primary expected win: one full-source read replaces one ranged GET per reference, plus the source-size metadata lookup needed to prove complete coverage.

## Verification

- focused blob/schema regression selection — 8 passed
- full suite — 1,307 passed, 22 skipped; one unrelated cloud-launcher test hit the host's exhausted unauthenticated GitHub API quota while checking the branch commit
- the isolated failing launcher test reproduces the same HTTP 403 with core rate-limit remaining=0
- uv run pre-commit run --all-files — passed
- git diff --check — passed

GitHub CI runs from a separate environment and is the authoritative full-suite result for the network-dependent launcher check.
