### PR TITLE
Add production Lance inference and async transform primitives

### DIFF
--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -29,9 +29,23 @@ pipeline = mdr.load_lance(
 When `version` is omitted, Refiner resolves the latest version once and pins it
 for the pipeline. Column projection is pushed into Lance, and `batch_size`
 controls the streamed Arrow batch size.
+
+## Limit the number of rows
+
 Set `max_rows` to a non-negative integer to read only that many leading rows from
 the pinned dataset version. Refiner stops scanning inside the final fragment;
 datasets with fewer rows simply yield all available rows.
+
+The limit is applied before pipeline transforms. Omit `max_rows` to read the
+entire pinned version, or use `max_rows=0` to produce no source rows. For
+example, this processes only the first 10,000 stored rows:
+
+```python
+pipeline = mdr.load_lance(
+    "s3://my-bucket/hands.lance",
+    max_rows=10_000,
+)
+```
 
 Classic Lance blob columns are returned as lazy Refiner blob references:
 

--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -22,14 +22,14 @@ pipeline = mdr.load_lance(
     columns=["image", "frame_id"],
     batch_size=128,
     num_shards=32,
-    row_limit=2_000,
+    max_rows=2_000,
 )
 ```
 
 When `version` is omitted, Refiner resolves the latest version once and pins it
 for the pipeline. Column projection is pushed into Lance, and `batch_size`
 controls the streamed Arrow batch size.
-Set `row_limit` to a positive integer to read only that many leading rows from
+Set `max_rows` to a non-negative integer to read only that many leading rows from
 the pinned dataset version. Refiner stops scanning inside the final fragment;
 datasets with fewer rows simply yield all available rows.
 

--- a/docs/transforms/async-and-batch-transforms.md
+++ b/docs/transforms/async-and-batch-transforms.md
@@ -1,6 +1,6 @@
 ---
 title: "Async and batch transforms"
-description: "Use map_async and batch_map for concurrent I/O and batched model work"
+description: "Use map_async, batch_map, and batch_map_async for concurrent I/O and batched model work"
 ---
 
 # Async and batch transforms
@@ -127,6 +127,32 @@ pipeline = pipeline.batch_map(
 ```
 
 Exactly one of the positional callback or `factory` must be provided.
+
+## `batch_map_async`
+
+`batch_map_async` keeps a bounded number of whole batches in flight. It is
+useful when CPU or remote-I/O preparation for a later batch can overlap GPU or
+service work for an earlier batch:
+
+```python
+pipeline = pipeline.batch_map_async(
+    factory=create_async_batch_model,
+    batch_size=64,
+    max_in_flight=2,
+    preserve_order=True,
+)
+```
+
+The factory is initialized once per worker, just like `map_async` and
+`batch_map`. Its returned callable receives `list[Row]` and may return either an
+iterable of rows or an awaitable resolving to one. Refiner retains at most
+`max_in_flight` unresolved batches and blocks source consumption when the window
+is full, so memory stays bounded. If the returned callable defines `aclose()`,
+Refiner calls it after all batches drain.
+
+Refiner may invoke the returned callable concurrently. Stateful GPU processors
+should serialize access to a shared model while allowing preparation to run in
+parallel—for example, by using a CPU executor plus a one-worker GPU executor.
 
 ## Order and backpressure
 

--- a/docs/transforms/async-and-batch-transforms.md
+++ b/docs/transforms/async-and-batch-transforms.md
@@ -28,6 +28,38 @@ pipeline = pipeline.map_async(
 Use `max_in_flight` to match provider rate limits, memory limits, or open file
 limits.
 
+For expensive worker-local state, pass a zero-argument `factory` instead of a
+callback. Refiner calls the factory once in each worker and reuses the returned
+callable across every row handled by that worker:
+
+```python
+class Classifier:
+    def __init__(self):
+        self.client = create_client()
+
+    async def __call__(self, row):
+        label = await self.client.classify(row["text"])
+        return {"label": label}
+
+    async def aclose(self):
+        await self.client.aclose()
+
+
+def create_classifier():
+    return Classifier()
+
+
+pipeline = pipeline.map_async(
+    factory=create_classifier,
+    max_in_flight=32,
+)
+```
+
+The factory is not called while building, inspecting, or serializing the
+pipeline. The returned async callable may receive up to `max_in_flight`
+concurrent calls. If it defines `aclose()`, Refiner calls it when that worker's
+execution ends.
+
 When callbacks return large values such as image or video bytes, set a small
 execution block row limit:
 
@@ -74,6 +106,27 @@ pipeline = pipeline.batch_map(add_batch_rank, batch_size=32)
 ```
 
 Use this for perception pipelines or model APIs that naturally process batches.
+
+Use `factory` when constructing the batch callback loads a model or another
+expensive resource:
+
+```python
+def create_batch_model():
+    model = load_model("model.pt")
+
+    def infer(rows):
+        return model.predict(rows)
+
+    return infer
+
+
+pipeline = pipeline.batch_map(
+    factory=create_batch_model,
+    batch_size=32,
+)
+```
+
+Exactly one of the positional callback or `factory` must be provided.
 
 ## Order and backpressure
 

--- a/docs/transforms/async-and-batch-transforms.md
+++ b/docs/transforms/async-and-batch-transforms.md
@@ -29,8 +29,7 @@ Use `max_in_flight` to match provider rate limits, memory limits, or open file
 limits.
 
 For expensive worker-local state, pass a zero-argument `factory` instead of a
-callback. Refiner calls the factory once in each worker and reuses the returned
-callable across every row handled by that worker:
+callback:
 
 ```python
 class Classifier:
@@ -40,9 +39,6 @@ class Classifier:
     async def __call__(self, row):
         label = await self.client.classify(row["text"])
         return {"label": label}
-
-    async def aclose(self):
-        await self.client.aclose()
 
 
 def create_classifier():
@@ -54,11 +50,6 @@ pipeline = pipeline.map_async(
     max_in_flight=32,
 )
 ```
-
-The factory is not called while building, inspecting, or serializing the
-pipeline. The returned async callable may receive up to `max_in_flight`
-concurrent calls. If it defines `aclose()`, Refiner calls it when that worker's
-execution ends.
 
 When callbacks return large values such as image or video bytes, set a small
 execution block row limit:
@@ -126,13 +117,11 @@ pipeline = pipeline.batch_map(
 )
 ```
 
-Exactly one of the positional callback or `factory` must be provided.
-
 ## `batch_map_async`
 
-`batch_map_async` keeps a bounded number of whole batches in flight. It is
-useful when CPU or remote-I/O preparation for a later batch can overlap GPU or
-service work for an earlier batch:
+`batch_map_async` processes multiple batches concurrently. Use
+`max_in_flight` to bound concurrency and `preserve_order` when output order
+must match input order:
 
 ```python
 pipeline = pipeline.batch_map_async(
@@ -143,16 +132,8 @@ pipeline = pipeline.batch_map_async(
 )
 ```
 
-The factory is initialized once per worker, just like `map_async` and
-`batch_map`. Its returned callable receives `list[Row]` and may return either an
-iterable of rows or an awaitable resolving to one. Refiner retains at most
-`max_in_flight` unresolved batches and blocks source consumption when the window
-is full, so memory stays bounded. If the returned callable defines `aclose()`,
-Refiner calls it after all batches drain.
-
-Refiner may invoke the returned callable concurrently. Stateful GPU processors
-should serialize access to a shared model while allowing preparation to run in
-parallel—for example, by using a CPU executor plus a one-worker GPU executor.
+The callback receives `list[Row]` and returns rows, either directly or through
+an awaitable.
 
 ## Order and backpressure
 

--- a/docs/transforms/vectorized-transforms.md
+++ b/docs/transforms/vectorized-transforms.md
@@ -61,9 +61,7 @@ def normalize(table: pa.Table) -> pa.Table:
 pipeline = pipeline.map_table(normalize)
 ```
 
-For expensive state such as a GPU model, provide a zero-argument factory.
-Refiner calls it once in each worker and reuses the returned callable for every
-table handled by that worker:
+For expensive state such as a GPU model, provide a zero-argument factory:
 
 ```python
 class Embedder:
@@ -82,10 +80,8 @@ def create_embedder():
 pipeline = pipeline.map_table(factory=create_embedder)
 ```
 
-The factory is not called while building, inspecting, or serializing the
-pipeline. Use `with_max_block_rows(...)` and
+Use `with_max_block_rows(...)` and
 `with_max_vectorized_block_bytes(...)` to bound the tables passed to the model.
-Exactly one of the positional callback or `factory` must be provided.
 
 ## When not to use vectorized transforms
 

--- a/docs/transforms/vectorized-transforms.md
+++ b/docs/transforms/vectorized-transforms.md
@@ -46,6 +46,47 @@ pipeline = pipeline.cast(
 
 Use casts when the storage format cannot fully represent asset/media semantics.
 
+## Custom Arrow table transforms
+
+Use `map_table` when a library already accepts and returns Arrow tables:
+
+```python
+import pyarrow as pa
+
+
+def normalize(table: pa.Table) -> pa.Table:
+    return table
+
+
+pipeline = pipeline.map_table(normalize)
+```
+
+For expensive state such as a GPU model, provide a zero-argument factory.
+Refiner calls it once in each worker and reuses the returned callable for every
+table handled by that worker:
+
+```python
+class Embedder:
+    def __init__(self):
+        self.model = load_model("clip").cuda()
+
+    def __call__(self, table: pa.Table) -> pa.Table:
+        embeddings = self.model.encode(table.column("image"))
+        return table.append_column("embedding", embeddings)
+
+
+def create_embedder():
+    return Embedder()
+
+
+pipeline = pipeline.map_table(factory=create_embedder)
+```
+
+The factory is not called while building, inspecting, or serializing the
+pipeline. Use `with_max_block_rows(...)` and
+`with_max_vectorized_block_bytes(...)` to bound the tables passed to the model.
+Exactly one of the positional callback or `factory` must be provided.
+
 ## When not to use vectorized transforms
 
 Use row transforms when you need:
@@ -64,4 +105,3 @@ operations.
 - [Expressions](expressions.md)
 - [Schemas and DTypes](schemas-and-dtypes.md)
 - [Episode Rows](../episode-data/episode-rows.md)
-

--- a/docs/writing-data/lance.md
+++ b/docs/writing-data/lance.md
@@ -133,7 +133,7 @@ pipeline = (
     mdr.load_lance(
         "s3://my-bucket/hands.lance",
         columns=["image"],
-        row_limit=200_000,
+        max_rows=200_000,
     )
     .map(
         embed_hand,
@@ -147,7 +147,7 @@ pipeline = (
 )
 ```
 
-Processed rows receive their computed values. Rows beyond `row_limit`, or rows
+Processed rows receive their computed values. Rows beyond `max_rows`, or rows
 removed by a filter, receive null. Supply one Arrow-compatible scalar for every
 column or a mapping for per-column defaults:
 

--- a/docs/writing-data/lance.md
+++ b/docs/writing-data/lance.md
@@ -32,7 +32,7 @@ Use `write_lance_dataset(...)` for committed Lance datasets:
 ```python
 pipeline = (
     mdr.read_parquet("s3://my-bucket/raw/*.parquet")
-    .write_lance_dataset("s3://my-bucket/clean.lance", mode="create")
+    .write_lance_dataset("s3://my-bucket/clean.lance", mode=mdr.Create())
 )
 ```
 
@@ -51,9 +51,10 @@ Here `1 << 30` selects a 1 GiB target block size. Refiner does not create
 Lance-native blob columns when writing; it writes generic block files and typed
 `{path, offset, size}` references that can be read with `mdr.read_blob(...)`.
 
-Supported modes are `create`, `overwrite`, `append`, and `add_columns`.
-Empty `create` and `overwrite` jobs fail explicitly. Empty `append` jobs are
-no-ops.
+Supported modes are `Create()`, `Overwrite()`, `Append()`, and `AddColumns()`.
+The legacy strings remain accepted for backward compatibility.
+Empty `Create()` and `Overwrite()` jobs fail explicitly. Empty `Append()` jobs
+are no-ops.
 
 Lance opens dataset URIs through its native storage layer. Configured fsspec
 filesystem objects and `storage_options` are therefore rejected instead of
@@ -65,7 +66,7 @@ pipeline plans do not serialize secrets.
 
 ## Adding columns
 
-Use `add_columns` for row-preserving enrichment such as model inference:
+Use `AddColumns()` for row-preserving enrichment such as model inference:
 
 ```python
 pipeline = (
@@ -83,7 +84,7 @@ pipeline = (
     )
     .write_lance_dataset(
         "s3://my-bucket/hands.lance",
-        mode="add_columns",
+        mode=mdr.AddColumns(),
         columns=["hand_boxes", "detector_score"],
     )
 )
@@ -94,7 +95,7 @@ New asset columns can use either output layout in the same operation:
 ```python
 pipeline.write_lance_dataset(
     "s3://my-bucket/hands.lance",
-    mode="add_columns",
+    mode=mdr.AddColumns(),
     columns=["crop"],
     assets=mdr.BlobAssetConfig(target_bytes=1 << 30),
 )
@@ -103,9 +104,11 @@ pipeline.write_lance_dataset(
 The `columns` argument is required and only those columns are written. Existing
 columns, including large blob columns, remain referenced by their original
 files. Results may arrive out of order; Refiner restores fragment-local source
-order before writing. Missing or duplicate results fail execution and do not
-create a new dataset version. `add_columns` also fails explicitly for a dataset
-with no rows because no fragment exists to receive the new column files.
+order before writing. Omitted results are filled with null by default, while
+duplicate source row identities fail execution and do not create a new dataset
+version. The legacy string `mode="add_columns"` retains its strict behavior and
+fails if any result is missing. `AddColumns()` also fails explicitly for a
+dataset with no rows because no fragment exists to receive the new column files.
 Fragments containing deleted rows are currently rejected because their physical
 row layout cannot yet be safely reconstructed by the column writer.
 
@@ -119,3 +122,40 @@ alongside `__shard_id`. Ordinary readers receive a shard-local row ordinal;
 Lance supplies its physical row address so `add_columns` can restore
 fragment-local order after asynchronous or batched transforms. Both columns are
 removed before user data is persisted.
+
+### Filling rows outside a bounded or filtered source
+
+Use `AddColumns` when inference should run on only part of the source while the
+new columns still need to align with every row in the existing dataset:
+
+```python
+pipeline = (
+    mdr.load_lance(
+        "s3://my-bucket/hands.lance",
+        columns=["image"],
+        row_limit=200_000,
+    )
+    .map(
+        embed_hand,
+        dtypes={"embedding": mdr.datatype.list(mdr.datatype.float32())},
+    )
+    .write_lance_dataset(
+        "s3://my-bucket/hands.lance",
+        mode=mdr.AddColumns(),
+        columns=["embedding"],
+    )
+)
+```
+
+Processed rows receive their computed values. Rows beyond `row_limit`, or rows
+removed by a filter, receive null. Supply one Arrow-compatible scalar for every
+column or a mapping for per-column defaults:
+
+```python
+mode=mdr.AddColumns(fill={"embedding": None, "status": "not_processed"})
+```
+
+Unknown fill-column names and values that cannot be converted to the declared
+Arrow type fail before the dataset commit. Duplicate source row identities also
+remain an error. Existing columns and data files are retained; the operation
+commits only the new column files as a new Lance dataset version.

--- a/docs/writing-data/lance.md
+++ b/docs/writing-data/lance.md
@@ -101,16 +101,10 @@ pipeline.write_lance_dataset(
 )
 ```
 
-The `columns` argument is required and only those columns are written. Existing
-columns, including large blob columns, remain referenced by their original
-files. Results may arrive out of order; Refiner restores fragment-local source
-order before writing. Omitted results are filled with null by default, while
-duplicate source row identities fail execution and do not create a new dataset
-version. The legacy string `mode="add_columns"` retains its strict behavior and
-fails if any result is missing. `AddColumns()` also fails explicitly for a
-dataset with no rows because no fragment exists to receive the new column files.
-Fragments containing deleted rows are currently rejected because their physical
-row layout cannot yet be safely reconstructed by the column writer.
+The `columns` argument is required and only those columns are written. Omitted
+results are filled with null by default. The legacy string
+`mode="add_columns"` retains its strict behavior and fails if any result is
+missing.
 
 Every finalized shard emits coordination metadata, including shards that
 produce no rows. The reducer requires complete metadata coverage before it
@@ -123,7 +117,7 @@ Lance supplies its physical row address so `add_columns` can restore
 fragment-local order after asynchronous or batched transforms. Both columns are
 removed before user data is persisted.
 
-### Filling rows outside a bounded or filtered source
+### Filling omitted rows
 
 Use `AddColumns` when inference should run on only part of the source while the
 new columns still need to align with every row in the existing dataset:
@@ -147,15 +141,9 @@ pipeline = (
 )
 ```
 
-Processed rows receive their computed values. Rows beyond `max_rows`, or rows
-removed by a filter, receive null. Supply one Arrow-compatible scalar for every
-column or a mapping for per-column defaults:
+Processed rows receive their computed values. Omitted rows receive null. Supply
+a mapping to use per-column defaults instead:
 
 ```python
 mode=mdr.AddColumns(fill={"embedding": None, "status": "not_processed"})
 ```
-
-Unknown fill-column names and values that cannot be converted to the declared
-Arrow type fail before the dataset commit. Duplicate source row identities also
-remain an error. Existing columns and data files are retained; the operation
-commits only the new column files as a new Lance dataset version.

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -15,6 +15,10 @@ _LAZY_MODULES = {
 }
 
 _LAZY_ATTRS = {
+    "AddColumns": "refiner.pipeline.sinks.lance",
+    "Append": "refiner.pipeline.sinks.lance",
+    "Create": "refiner.pipeline.sinks.lance",
+    "Overwrite": "refiner.pipeline.sinks.lance",
     "CUDAVersion": "refiner.pipeline",
     "BlobAssetConfig": "refiner.pipeline.sinks.assets",
     "FileAssetConfig": "refiner.pipeline.sinks.assets",
@@ -55,6 +59,10 @@ _LAZY_ATTRS = {
 
 __all__ = [
     # sources
+    "AddColumns",
+    "Append",
+    "Create",
+    "Overwrite",
     "CUDAVersion",
     "BlobAssetConfig",
     "FileAssetConfig",
@@ -131,6 +139,7 @@ if TYPE_CHECKING:
     import refiner.text as text
     import refiner.video as video
     from refiner.launchers.secrets import Secrets
+    from refiner.pipeline.sinks.lance import AddColumns, Append, Create, Overwrite
     from refiner.io import read_blob
     from refiner.pipeline import (
         CUDAVersion,

--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -135,6 +135,28 @@ def schema_after_segments(
     return schema
 
 
+def _declared_dtype_columns_after_segments(
+    segments: Sequence[Segment],
+) -> frozenset[str]:
+    """Return columns whose output types are explicitly constrained by steps."""
+    columns: set[str] = set()
+    for segment in segments:
+        steps = segment.ops if isinstance(segment, VectorSegment) else segment.steps
+        for step in steps:
+            dtypes = getattr(step, "dtypes", None)
+            if dtypes:
+                columns.update(dtypes)
+            if isinstance(step, FnTableStep):
+                columns.clear()
+            elif isinstance(step, SelectStep):
+                columns.intersection_update(step.columns)
+            elif isinstance(step, DropStep):
+                columns.difference_update(step.columns)
+            elif isinstance(step, RenameStep):
+                columns = {step.mapping.get(name, name) for name in columns}
+    return frozenset(columns)
+
+
 def _segment_schema(
     input_schema: pa.Schema | None,
     segment: Segment,

--- a/src/refiner/execution/engine.py
+++ b/src/refiner/execution/engine.py
@@ -14,6 +14,7 @@ from refiner.pipeline.steps import (
     CastStep,
     DropStep,
     FilterExprStep,
+    FnAsyncBatchStep,
     FnAsyncRowStep,
     FnBatchStep,
     FnFlatMapStep,
@@ -28,6 +29,7 @@ from refiner.pipeline.steps import (
 )
 from refiner.execution.buffer import RowBuffer
 from refiner.execution.operators.row import (
+    AsyncBatchWindowRegistry,
     AsyncWindowRegistry,
     ShardDeltaFn,
     execute_row_steps,
@@ -80,6 +82,7 @@ def execute_segments(
     on_shard_delta: ShardDeltaFn | None = None,
     input_schema: pa.Schema | None = None,
     async_window_registry: AsyncWindowRegistry | None = None,
+    async_batch_window_registry: AsyncBatchWindowRegistry | None = None,
 ) -> Iterator[Block]:
     """Execute segments and yield row or tabular blocks."""
     configured_block_rows = vectorized_chunk_rows
@@ -112,6 +115,7 @@ def execute_segments(
                 on_shard_delta=on_shard_delta,
                 output_schema=output_schema,
                 async_window_registry=async_window_registry,
+                async_batch_window_registry=async_batch_window_registry,
             )
             current_schema = output_schema
     yield from _limit_output_blocks(
@@ -212,6 +216,7 @@ def _execute_row_segment(
     on_shard_delta: ShardDeltaFn | None,
     output_schema: pa.Schema | None,
     async_window_registry: AsyncWindowRegistry | None,
+    async_batch_window_registry: AsyncBatchWindowRegistry | None,
 ) -> Iterator[Block]:
     # Row/UDF execution consumes row views and emits row blocks for downstream
     # vectorized segments (or final row iteration).
@@ -221,6 +226,7 @@ def _execute_row_segment(
         steps,
         on_shard_delta=on_shard_delta,
         async_window_registry=async_window_registry,
+        async_batch_window_registry=async_batch_window_registry,
     )
     if not output_tabular:
         yield from _chunk_output_rows(step_out, output_block_rows)
@@ -243,7 +249,16 @@ def _row_segment_schema(
     for step in steps:
         dtypes = (
             step.dtypes
-            if isinstance(step, (FnRowStep, FnAsyncRowStep, FnBatchStep, FnFlatMapStep))
+            if isinstance(
+                step,
+                (
+                    FnRowStep,
+                    FnAsyncRowStep,
+                    FnAsyncBatchStep,
+                    FnBatchStep,
+                    FnFlatMapStep,
+                ),
+            )
             else None
         )
         if not dtypes:

--- a/src/refiner/execution/factories.py
+++ b/src/refiner/execution/factories.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import Any
+
+from refiner.pipeline.steps import (
+    FnAsyncRowStep,
+    FnBatchStep,
+    FnTableStep,
+    RefinerStep,
+    VectorizedSegmentStep,
+)
+from refiner.worker.context import set_active_step_index
+
+FactoryStep = FnAsyncRowStep | FnBatchStep | FnTableStep
+
+
+def _factory_step(step: RefinerStep) -> FactoryStep | None:
+    if isinstance(step, FactoryStep):
+        return step
+    return None
+
+
+def _step_has_factory(step: RefinerStep) -> bool:
+    if isinstance(step, VectorizedSegmentStep):
+        return any(
+            op.factory is not None for op in step.ops if isinstance(op, FnTableStep)
+        )
+    factory_step = _factory_step(step)
+    return factory_step is not None and factory_step.factory is not None
+
+
+def has_worker_factories(steps: Sequence[RefinerStep]) -> bool:
+    """Return whether any step needs worker-local callable initialization."""
+    return any(_step_has_factory(step) for step in steps)
+
+
+def _initialize_factory_step(step: FactoryStep) -> FactoryStep:
+    factory = step.factory
+    if factory is None:
+        return step
+    with set_active_step_index(step.index):
+        fn: Any = factory()
+    if not callable(fn):
+        op_name = step.op_name or type(step).__name__
+        raise TypeError(f"{op_name} factory must return a callable, got {type(fn)!r}")
+    return replace(step, fn=fn, factory=None)
+
+
+def initialize_worker_steps(
+    steps: Sequence[RefinerStep],
+) -> tuple[RefinerStep, ...]:
+    """Instantiate each configured factory once for one worker execution."""
+    initialized: list[RefinerStep] = []
+    for step in steps:
+        if isinstance(step, VectorizedSegmentStep):
+            initialized.append(
+                replace(
+                    step,
+                    ops=tuple(
+                        _initialize_factory_step(op)
+                        if isinstance(op, FnTableStep)
+                        else op
+                        for op in step.ops
+                    ),
+                )
+            )
+            continue
+        factory_step = _factory_step(step)
+        initialized.append(
+            _initialize_factory_step(factory_step) if factory_step is not None else step
+        )
+    return tuple(initialized)
+
+
+__all__ = [
+    "has_worker_factories",
+    "initialize_worker_steps",
+]

--- a/src/refiner/execution/factories.py
+++ b/src/refiner/execution/factories.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from typing import Any
 
 from refiner.pipeline.steps import (
+    FnAsyncBatchStep,
     FnAsyncRowStep,
     FnBatchStep,
     FnTableStep,
@@ -13,7 +14,7 @@ from refiner.pipeline.steps import (
 )
 from refiner.worker.context import set_active_step_index
 
-FactoryStep = FnAsyncRowStep | FnBatchStep | FnTableStep
+FactoryStep = FnAsyncRowStep | FnAsyncBatchStep | FnBatchStep | FnTableStep
 
 
 def _factory_step(step: RefinerStep) -> FactoryStep | None:

--- a/src/refiner/execution/factories.py
+++ b/src/refiner/execution/factories.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any
 
+from refiner.execution.operators.row import close_async_steps
 from refiner.pipeline.steps import (
     FnAsyncBatchStep,
     FnAsyncRowStep,
@@ -12,7 +13,7 @@ from refiner.pipeline.steps import (
     RefinerStep,
     VectorizedSegmentStep,
 )
-from refiner.worker.context import set_active_step_index
+from refiner.worker.context import logger, set_active_step_index
 
 FactoryStep = FnAsyncRowStep | FnAsyncBatchStep | FnBatchStep | FnTableStep
 
@@ -54,24 +55,43 @@ def initialize_worker_steps(
 ) -> tuple[RefinerStep, ...]:
     """Instantiate each configured factory once for one worker execution."""
     initialized: list[RefinerStep] = []
-    for step in steps:
-        if isinstance(step, VectorizedSegmentStep):
-            initialized.append(
-                replace(
-                    step,
-                    ops=tuple(
-                        _initialize_factory_step(op)
-                        if isinstance(op, FnTableStep)
-                        else op
-                        for op in step.ops
-                    ),
+    try:
+        for step in steps:
+            if isinstance(step, VectorizedSegmentStep):
+                initialized.append(
+                    replace(
+                        step,
+                        ops=tuple(
+                            _initialize_factory_step(op)
+                            if isinstance(op, FnTableStep)
+                            else op
+                            for op in step.ops
+                        ),
+                    )
                 )
+                continue
+            factory_step = _factory_step(step)
+            initialized.append(
+                _initialize_factory_step(factory_step)
+                if factory_step is not None
+                else step
             )
-            continue
-        factory_step = _factory_step(step)
-        initialized.append(
-            _initialize_factory_step(factory_step) if factory_step is not None else step
-        )
+    except BaseException as initialization_error:
+        try:
+            close_async_steps(initialized)
+        except Exception as teardown_error:  # noqa: BLE001
+            logger.warning(
+                "factory cleanup failed after initialization error: {}: {}",
+                type(teardown_error).__name__,
+                teardown_error,
+            )
+            add_note = getattr(initialization_error, "add_note", None)
+            if callable(add_note):
+                add_note(
+                    "Factory cleanup also failed: "
+                    f"{type(teardown_error).__name__}: {teardown_error}"
+                )
+        raise
     return tuple(initialized)
 
 

--- a/src/refiner/execution/operators/row.py
+++ b/src/refiner/execution/operators/row.py
@@ -10,6 +10,7 @@ from refiner.execution.buffer import RowBuffer
 from refiner.execution.tracking.shards import ShardDeltaFn, ShardDeltaTracker
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.steps import (
+    AsyncBatchStep,
     AsyncRowStep,
     BatchStep,
     FilterRowStep,
@@ -23,6 +24,8 @@ from refiner.worker.metrics.api import register_gauge
 
 AsyncCloseFn = Callable[[], Coroutine[object, object, None]]
 AsyncWindowRegistry = dict[int, AsyncWindow[Row]]
+AsyncBatchResult = tuple[list[Row], list[Row]]
+AsyncBatchWindowRegistry = dict[int, AsyncWindow[AsyncBatchResult]]
 
 
 class AsyncStepTeardownError(RuntimeError):
@@ -33,7 +36,7 @@ def close_async_steps(steps: Sequence[RefinerStep]) -> None:
     """Close async callables owned by the provided pipeline steps."""
     close_fns: list[AsyncCloseFn] = []
     for step in steps:
-        if not isinstance(step, AsyncRowStep):
+        if not isinstance(step, AsyncRowStep | AsyncBatchStep):
             continue
         fn = getattr(step, "fn", None)
         close = getattr(fn, "aclose", None)
@@ -52,6 +55,7 @@ def execute_row_steps(
     *,
     on_shard_delta: ShardDeltaFn | None = None,
     async_window_registry: AsyncWindowRegistry | None = None,
+    async_batch_window_registry: AsyncBatchWindowRegistry | None = None,
 ) -> Iterator[Row]:
     """Execute row/batch/flatmap steps using per-step queues.
 
@@ -86,8 +90,35 @@ def execute_row_steps(
             )
         return window
 
+    def _async_batch_window(
+        step: AsyncBatchStep,
+    ) -> AsyncWindow[AsyncBatchResult]:
+        window = (
+            async_batch_window_registry.get(step.index)
+            if async_batch_window_registry is not None
+            else None
+        )
+        if window is None:
+            window = AsyncWindow[AsyncBatchResult](
+                max_in_flight=step.max_in_flight,
+                preserve_order=step.preserve_order,
+            )
+            if async_batch_window_registry is not None:
+                async_batch_window_registry[step.index] = window
+            register_gauge(
+                "in_flight_batches",
+                lambda window=window: len(window),
+                unit="batches",
+                step_index=step.index,
+            )
+        return window
+
     async_windows = [
         _async_window(step) if isinstance(step, AsyncRowStep) else None
+        for step in ordered
+    ]
+    async_batch_windows = [
+        _async_batch_window(step) if isinstance(step, AsyncBatchStep) else None
         for step in ordered
     ]
 
@@ -103,10 +134,25 @@ def execute_row_steps(
                 return row.update(result)
             raise TypeError(f"Unsupported map_async() result type: {type(result)!r}")
 
+    async def _run_async_batch(
+        *, step: AsyncBatchStep, rows: list[Row]
+    ) -> AsyncBatchResult:
+        with set_active_step_index(step.index):
+            result = step.apply_batch_async(rows)
+            if inspect.isawaitable(result):
+                result = await result
+            output = list(cast(Iterable[Row], result))
+            for item in output:
+                if not isinstance(item, Row):
+                    raise TypeError(
+                        f"Unsupported batch_map_async() result type: {type(item)!r}"
+                    )
+            return rows, output
+
     def _run_step(i: int, *, flush_all: bool) -> None:
         step = ordered[i]
         inp = queues[i]
-        if not inp and not isinstance(step, AsyncRowStep):
+        if not inp and not isinstance(step, AsyncRowStep | AsyncBatchStep):
             return
         out = queues[i + 1]
         with set_active_step_index(step.index):
@@ -139,6 +185,34 @@ def execute_row_steps(
                     for row in drained_rows:
                         row.log_throughput("rows_processed", 1, unit="rows")
                     out.extend(drained_rows)
+                return
+
+            if isinstance(step, AsyncBatchStep):
+                window = async_batch_windows[i]
+                if window is None:
+                    return
+
+                def emit(completed: list[AsyncBatchResult]) -> None:
+                    if not completed:
+                        return
+                    with ShardDeltaTracker(on_shard_delta) as delta:
+                        for batch_in, batch_out in completed:
+                            delta.remove_rows(batch_in)
+                            for item in batch_out:
+                                item.log_throughput("rows_out", 1, unit="rows")
+                                if item.shard_id is not None:
+                                    delta.add(item.shard_id, 1)
+                                out.append(item)
+
+                while len(inp) >= step.batch_size or (flush_all and inp):
+                    size = step.batch_size if len(inp) >= step.batch_size else len(inp)
+                    batch_in = inp.take(size)
+                    window.submit_blocking(_run_async_batch(step=step, rows=batch_in))
+                    emit(window.take_completed())
+                if flush_all:
+                    emit(window.drain())
+                else:
+                    emit(window.take_completed())
                 return
 
             if isinstance(step, FilterRowStep):
@@ -226,10 +300,14 @@ def execute_row_steps(
         for window in async_windows:
             if window is not None:
                 window.cancel_pending()
+        for window in async_batch_windows:
+            if window is not None:
+                window.cancel_pending()
 
 
 __all__ = [
     "AsyncWindowRegistry",
+    "AsyncBatchWindowRegistry",
     "AsyncStepTeardownError",
     "close_async_steps",
     "execute_row_steps",

--- a/src/refiner/execution/operators/row.py
+++ b/src/refiner/execution/operators/row.py
@@ -42,11 +42,15 @@ def close_async_steps(steps: Sequence[RefinerStep]) -> None:
         close = getattr(fn, "aclose", None)
         if close is not None:
             close_fns.append(cast(AsyncCloseFn, close))
+    first_error: Exception | None = None
     for close in close_fns:
         try:
             submit(close()).result()
         except Exception as e:
-            raise AsyncStepTeardownError(str(e)) from e
+            if first_error is None:
+                first_error = e
+    if first_error is not None:
+        raise AsyncStepTeardownError(str(first_error)) from first_error
 
 
 def execute_row_steps(

--- a/src/refiner/execution/operators/vectorized.py
+++ b/src/refiner/execution/operators/vectorized.py
@@ -143,7 +143,7 @@ def apply_vectorized_op(
                 pa.array(lineage, type=pa.int64()),
             )
         with set_active_step_index(op.index):
-            next_table = op.fn(table)
+            next_table = op.apply_table(table)
         if not isinstance(next_table, pa.Table):
             raise TypeError(
                 f"map_table() must return pa.Table, got {type(next_table)!r}"

--- a/src/refiner/pipeline/__init__.py
+++ b/src/refiner/pipeline/__init__.py
@@ -4,6 +4,10 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 _LAZY_ATTRS = {
+    "AddColumns": "refiner.pipeline.sinks.lance",
+    "Append": "refiner.pipeline.sinks.lance",
+    "Create": "refiner.pipeline.sinks.lance",
+    "Overwrite": "refiner.pipeline.sinks.lance",
     "Row": "refiner.pipeline.data.row",
     "Shard": "refiner.pipeline.data.shard",
     "RefinerPipeline": "refiner.pipeline.pipeline",
@@ -32,6 +36,10 @@ _LAZY_ATTRS = {
 }
 
 __all__ = [
+    "AddColumns",
+    "Append",
+    "Create",
+    "Overwrite",
     "CUDAVersion",
     "GPU",
     "GPUType",
@@ -75,6 +83,7 @@ def __dir__() -> list[str]:
 
 
 if TYPE_CHECKING:
+    from refiner.pipeline.sinks.lance import AddColumns, Append, Create, Overwrite
     from refiner.pipeline.data.row import Row
     from refiner.pipeline.data.shard import Shard
     from refiner.pipeline.pipeline import (

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -10,6 +10,8 @@ from refiner.pipeline.expressions import Expr, lit
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.resources import GPU
 from refiner.pipeline.steps import (
+    AsyncBatchFactory,
+    AsyncBatchFn,
     AsyncMapFactory,
     AsyncMapFn,
     BatchFactory,
@@ -20,6 +22,7 @@ from refiner.pipeline.steps import (
     FilterRowStep,
     FlatMapFn,
     FnAsyncRowStep,
+    FnAsyncBatchStep,
     FnBatchStep,
     FnFlatMapStep,
     FnRowStep,
@@ -83,6 +86,7 @@ from refiner.execution.factories import (
     initialize_worker_steps,
 )
 from refiner.execution.operators.row import (
+    AsyncBatchWindowRegistry,
     AsyncWindowRegistry,
     ShardDeltaFn,
     close_async_steps,
@@ -394,6 +398,40 @@ class RefinerPipeline:
             )
         )
 
+    def batch_map_async(
+        self,
+        fn: AsyncBatchFn | None = None,
+        *,
+        factory: AsyncBatchFactory | None = None,
+        batch_size: int,
+        max_in_flight: int = 2,
+        preserve_order: bool = True,
+        dtypes: DTypeMapping | None = None,
+    ) -> "RefinerPipeline":
+        """Apply bounded asynchronous work to fixed-size row batches.
+
+        At most ``max_in_flight`` batches are unresolved per worker. This enables
+        CPU preparation, remote I/O, or other asynchronous work for a later batch
+        to overlap processing of an earlier batch while preserving bounded memory.
+        The callback must return an iterable of ``Row`` objects.
+        """
+        if batch_size <= 1:
+            raise ValueError("batch_size for batch_map_async must be > 1")
+        if max_in_flight <= 0:
+            raise ValueError("max_in_flight must be > 0")
+        return self.add_step(
+            FnAsyncBatchStep(
+                fn=fn,
+                factory=factory,
+                batch_size=batch_size,
+                max_in_flight=max_in_flight,
+                preserve_order=preserve_order,
+                op_name="batch_map_async",
+                index=self._next_step_index(),
+                dtypes=dtypes,
+            )
+        )
+
     def flat_map(
         self,
         fn: FlatMapFn,
@@ -556,6 +594,7 @@ class RefinerPipeline:
         on_shard_delta: ShardDeltaFn | None = None,
     ) -> Iterable[Block]:
         async_window_registry: AsyncWindowRegistry = {}
+        async_batch_window_registry: AsyncBatchWindowRegistry = {}
         if has_worker_factories(self.pipeline_steps):
             runtime_steps = initialize_worker_steps(self.pipeline_steps)
             runtime_segments = compile_segments(runtime_steps)
@@ -572,6 +611,7 @@ class RefinerPipeline:
                     on_shard_delta=on_shard_delta,
                     input_schema=self.source.schema,
                     async_window_registry=async_window_registry,
+                    async_batch_window_registry=async_batch_window_registry,
                 )
         finally:
             close_async_steps(runtime_steps)

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -77,6 +77,7 @@ from refiner.execution.engine import (
     Block,
     Segment,
     compile_segments,
+    _declared_dtype_columns_after_segments,
     execute_segments,
     iter_rows,
     schema_after_segments,
@@ -260,6 +261,10 @@ class RefinerPipeline:
         fields not visible here unless they declare ``dtypes``.
         """
         return schema_after_segments(self.source.schema, self._get_compiled_segments())
+
+    def _output_dtype_columns(self) -> frozenset[str]:
+        """Return output columns constrained by explicit transform dtypes."""
+        return _declared_dtype_columns_after_segments(self._get_compiled_segments())
 
     def map(
         self, fn: MapFn, *, dtypes: DTypeMapping | None = None

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1362,11 +1362,14 @@ def load_lance(
     columns: Sequence[str] | None = None,
     batch_size: int = 65_536,
     num_shards: int | None = None,
+    max_rows: int | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline over one immutable version of a Lance dataset.
 
     ``num_shards`` groups whole, adjacent Lance fragments into the requested
     number of scheduling shards without splitting individual fragments.
+    ``max_rows`` bounds the source prefix before shard planning, so later
+    fragments are not scheduled or read.
     """
     return RefinerPipeline(
         source=LanceSource(
@@ -1375,6 +1378,7 @@ def load_lance(
             columns=columns,
             batch_size=batch_size,
             num_shards=num_shards,
+            max_rows=max_rows,
         )
     )
 

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -31,11 +31,13 @@ from refiner.pipeline.steps import (
     WithColumnsStep,
 )
 from refiner.pipeline.sinks import (
+    AddColumns,
     BaseSink,
+    Create,
     JsonlSink,
     LanceDatasetSink,
     LanceSink,
-    LanceWriteMode,
+    LanceWriteConfig,
     ParquetSink,
     ZarrSink,
 )
@@ -679,19 +681,27 @@ class RefinerPipeline:
         self,
         output: DataFolderLike,
         *,
-        mode: LanceWriteMode = "create",
+        mode: LanceWriteConfig = Create(),
         columns: Sequence[str] | None = None,
         assets: AssetWriteConfig | None = None,
     ) -> "RefinerPipeline":
-        """Attach a distributed Lance dataset writer or schema-evolution sink."""
+        """Attach a distributed Lance dataset writer or schema-evolution sink.
+
+        Use ``mode=AddColumns(fill=...)`` with a bounded or filtered
+        ``load_lance`` source. Computed rows receive the pipeline output and
+        omitted rows receive the configured scalar or per-column fill value.
+        The legacy ``mode="add_columns"`` remains strict and requires exactly
+        one output for every source row.
+        """
         source_uri: str | None = None
         source_version: int | None = None
-        if mode == "add_columns":
+        is_add_columns = mode == "add_columns" or isinstance(mode, AddColumns)
+        if is_add_columns:
             if not isinstance(self.source, LanceSource):
                 raise ValueError(
                     "add_columns requires a pipeline created by load_lance"
                 )
-            if self.source.row_limit is not None:
+            if self.source.row_limit is not None and not isinstance(mode, AddColumns):
                 raise ValueError("add_columns does not support a limited Lance source")
             source_uri = self.source.dataset_uri
             source_version = self.source.version

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -10,7 +10,9 @@ from refiner.pipeline.expressions import Expr, lit
 from refiner.io.fileset import DataFileSetLike
 from refiner.pipeline.resources import GPU
 from refiner.pipeline.steps import (
+    AsyncMapFactory,
     AsyncMapFn,
+    BatchFactory,
     BatchFn,
     CastStep,
     DropStep,
@@ -26,6 +28,8 @@ from refiner.pipeline.steps import (
     RenameStep,
     RefinerStep,
     SelectStep,
+    TableFactory,
+    TableFn,
     VectorizedOp,
     VectorizedSegmentStep,
     WithColumnsStep,
@@ -71,6 +75,10 @@ from refiner.execution.engine import (
     execute_segments,
     iter_rows,
     schema_after_segments,
+)
+from refiner.execution.factories import (
+    has_worker_factories,
+    initialize_worker_steps,
 )
 from refiner.execution.operators.row import (
     AsyncWindowRegistry,
@@ -324,8 +332,9 @@ class RefinerPipeline:
 
     def map_async(
         self,
-        fn: AsyncMapFn,
+        fn: AsyncMapFn | None = None,
         *,
+        factory: AsyncMapFactory | None = None,
         max_in_flight: int = 16,
         preserve_order: bool = True,
         dtypes: DTypeMapping | None = None,
@@ -333,7 +342,10 @@ class RefinerPipeline:
         """Apply an async Python function to each row.
 
         Args:
-            fn: Async callback receiving one row.
+            fn: Async callback receiving one row. Mutually exclusive with
+                ``factory``.
+            factory: Zero-argument callable initialized once per worker. It must
+                return the async callback reused by that worker.
             max_in_flight: Maximum unresolved callback tasks per worker.
             preserve_order: If True, emit rows in input order. If False, emit
                 rows as callbacks finish.
@@ -347,21 +359,25 @@ class RefinerPipeline:
                 op_name="map_async",
                 index=self._next_step_index(),
                 dtypes=dtypes,
+                factory=factory,
             )
         )
 
     def batch_map(
         self,
-        fn: BatchFn,
+        fn: BatchFn | None = None,
         *,
+        factory: BatchFactory | None = None,
         batch_size: int,
         dtypes: DTypeMapping | None = None,
     ) -> "RefinerPipeline":
         """Apply a Python function to fixed-size row batches.
 
         ``fn`` receives batches of rows and returns rows or row patches according
-        to the batch transform contract. Use this for APIs that are more
-        efficient when called on multiple rows at once.
+        to the batch transform contract. Alternatively, ``factory`` is called
+        once per worker and returns the callback reused for all of that worker's
+        batches. Use this for APIs that are more efficient when called on
+        multiple rows at once.
         """
         if batch_size <= 1:
             raise ValueError("batch_size for batch_map must be > 1")
@@ -372,6 +388,7 @@ class RefinerPipeline:
                 op_name="batch_map",
                 index=self._next_step_index(),
                 dtypes=dtypes,
+                factory=factory,
             )
         )
 
@@ -396,17 +413,27 @@ class RefinerPipeline:
             )
         )
 
-    def map_table(self, fn: Callable[[pa.Table], pa.Table]) -> "RefinerPipeline":
+    def map_table(
+        self,
+        fn: TableFn | None = None,
+        *,
+        factory: TableFactory | None = None,
+    ) -> "RefinerPipeline":
         """Apply a vectorized Arrow table transform.
 
         ``fn`` receives a ``pyarrow.Table`` and must return a ``pyarrow.Table``.
-        Adjacent vectorized operations are fused so they can run inside the same
-        Arrow segment. The returned table must preserve Refiner's internal shard
-        ID and source-row-ID columns so execution identity stays aligned through
-        filters and reordering.
+        Alternatively, ``factory`` is called once per worker and returns the
+        callback reused for all of that worker's tables. Adjacent vectorized
+        operations are fused so they can run inside the same Arrow segment. The
+        returned table must preserve Refiner's internal shard ID and source-row-ID
+        columns so execution identity stays aligned through filters and reordering.
         """
         return self._add_vectorized_op(
-            FnTableStep(fn=fn, index=self._next_step_index())
+            FnTableStep(
+                fn=fn,
+                factory=factory,
+                index=self._next_step_index(),
+            )
         )
 
     def filter(self, predicate: Callable[[Row], bool] | Expr) -> "RefinerPipeline":
@@ -527,11 +554,17 @@ class RefinerPipeline:
         on_shard_delta: ShardDeltaFn | None = None,
     ) -> Iterable[Block]:
         async_window_registry: AsyncWindowRegistry = {}
+        if has_worker_factories(self.pipeline_steps):
+            runtime_steps = initialize_worker_steps(self.pipeline_steps)
+            runtime_segments = compile_segments(runtime_steps)
+        else:
+            runtime_steps = self.pipeline_steps
+            runtime_segments = self._get_compiled_segments()
         try:
             for rows in windows:
                 yield from execute_segments(
                     rows,
-                    self._get_compiled_segments(),
+                    runtime_segments,
                     vectorized_chunk_rows=self.max_block_rows,
                     max_vectorized_block_bytes=self.max_vectorized_block_bytes,
                     on_shard_delta=on_shard_delta,
@@ -539,7 +572,7 @@ class RefinerPipeline:
                     async_window_registry=async_window_registry,
                 )
         finally:
-            close_async_steps(self.pipeline_steps)
+            close_async_steps(runtime_steps)
 
     def execute(
         self,

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -701,7 +701,7 @@ class RefinerPipeline:
                 raise ValueError(
                     "add_columns requires a pipeline created by load_lance"
                 )
-            if self.source.row_limit is not None and not isinstance(mode, AddColumns):
+            if self.source.max_rows is not None and not isinstance(mode, AddColumns):
                 raise ValueError("add_columns does not support a limited Lance source")
             source_uri = self.source.dataset_uri
             source_version = self.source.version
@@ -1378,15 +1378,13 @@ def load_lance(
     columns: Sequence[str] | None = None,
     batch_size: int = 65_536,
     num_shards: int | None = None,
-    row_limit: int | None = None,
     max_rows: int | None = None,
 ) -> RefinerPipeline:
     """Create a pipeline over one immutable version of a Lance dataset.
 
     ``num_shards`` groups whole, adjacent Lance fragments into the requested
     number of scheduling shards without splitting individual fragments.
-    ``row_limit`` reads at most that many leading rows from the pinned version.
-    ``max_rows`` is a backward-compatible alias that additionally permits zero.
+    ``max_rows`` reads at most that many leading rows from the pinned version.
     """
     return RefinerPipeline(
         source=LanceSource(
@@ -1395,7 +1393,6 @@ def load_lance(
             columns=columns,
             batch_size=batch_size,
             num_shards=num_shards,
-            row_limit=row_limit,
             max_rows=max_rows,
         )
     )

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -83,12 +83,13 @@ def _explicit_callable_name(fn: Any) -> str | None:
 def _callable_step_args(
     fn: Any,
     *,
+    callable_arg_name: str = "fn",
     extra_args: dict[str, Any] | None = None,
     builtin_extra_args: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     builtin_description = _builtin_description(fn)
     if builtin_description is None:
-        args: dict[str, Any] = {"fn": fn}
+        args: dict[str, Any] = {callable_arg_name: fn}
         if extra_args:
             args.update(extra_args)
     else:
@@ -96,6 +97,14 @@ def _callable_step_args(
         if builtin_extra_args:
             args.update(builtin_extra_args)
     return args
+
+
+def _step_callable(step: FnAsyncRowStep | FnBatchStep | FnTableStep) -> tuple[Any, str]:
+    if step.factory is not None:
+        return step.factory, "factory"
+    if step.fn is None:
+        raise AssertionError(f"{step.op_name or type(step).__name__} has no callable")
+    return step.fn, "fn"
 
 
 def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
@@ -112,16 +121,18 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
             _callable_step_args(step.fn),
         )
     if isinstance(step, FnAsyncRowStep):
+        fn, callable_arg_name = _step_callable(step)
         inferred_name = (
             explicit_name
             if explicit_name and explicit_name != "map_async"
-            else _explicit_callable_name(step.fn)
+            else _explicit_callable_name(fn)
         )
         return (
             (inferred_name or "map_async"),
             "async_map",
             _callable_step_args(
-                step.fn,
+                fn,
+                callable_arg_name=callable_arg_name,
                 extra_args={
                     "max_in_flight": step.max_in_flight,
                     "preserve_order": step.preserve_order,
@@ -133,16 +144,18 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
             ),
         )
     if isinstance(step, FnBatchStep):
+        fn, callable_arg_name = _step_callable(step)
         inferred_name = (
             explicit_name
             if explicit_name and explicit_name != "batch_map"
-            else _explicit_callable_name(step.fn)
+            else _explicit_callable_name(fn)
         )
         return (
             (inferred_name or "batch_map"),
             "batch_map",
             _callable_step_args(
-                step.fn,
+                fn,
+                callable_arg_name=callable_arg_name,
                 extra_args={"batch_size": step.batch_size},
                 builtin_extra_args={"batch_map.batch_size": step.batch_size},
             ),
@@ -169,15 +182,16 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
         step_name = inferred_name or "flat_map"
         return step_name, "flat_map", _callable_step_args(step.fn)
     if isinstance(step, FnTableStep):
+        fn, callable_arg_name = _step_callable(step)
         inferred_name = (
             explicit_name
             if explicit_name and explicit_name != "map_table"
-            else _explicit_callable_name(step.fn)
+            else _explicit_callable_name(fn)
         )
         return (
             (inferred_name or "map_table"),
             "table_map",
-            _callable_step_args(step.fn),
+            _callable_step_args(fn, callable_arg_name=callable_arg_name),
         )
     if isinstance(step, SelectStep):
         return (explicit_name or "select"), "select", {"columns": list(step.columns)}

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -12,6 +12,7 @@ from refiner.pipeline.steps import (
     DropStep,
     FilterExprStep,
     FilterRowStep,
+    FnAsyncBatchStep,
     FnAsyncRowStep,
     FnBatchStep,
     FnFlatMapStep,
@@ -99,7 +100,9 @@ def _callable_step_args(
     return args
 
 
-def _step_callable(step: FnAsyncRowStep | FnBatchStep | FnTableStep) -> tuple[Any, str]:
+def _step_callable(
+    step: FnAsyncRowStep | FnAsyncBatchStep | FnBatchStep | FnTableStep,
+) -> tuple[Any, str]:
     if step.factory is not None:
         return step.factory, "factory"
     if step.fn is None:
@@ -140,6 +143,26 @@ def _step_name_type(step: Any) -> tuple[str, str, dict[str, Any] | None]:
                 builtin_extra_args={
                     "async_map.max_in_flight": step.max_in_flight,
                     "async_map.preserve_order": step.preserve_order,
+                },
+            ),
+        )
+    if isinstance(step, FnAsyncBatchStep):
+        fn, callable_arg_name = _step_callable(step)
+        inferred_name = (
+            explicit_name
+            if explicit_name and explicit_name != "batch_map_async"
+            else _explicit_callable_name(fn)
+        )
+        return (
+            (inferred_name or "batch_map_async"),
+            "async_batch_map",
+            _callable_step_args(
+                fn,
+                callable_arg_name=callable_arg_name,
+                extra_args={
+                    "batch_size": step.batch_size,
+                    "max_in_flight": step.max_in_flight,
+                    "preserve_order": step.preserve_order,
                 },
             ),
         )

--- a/src/refiner/pipeline/sinks/__init__.py
+++ b/src/refiner/pipeline/sinks/__init__.py
@@ -1,18 +1,31 @@
 from refiner.pipeline.sinks.base import BaseSink, NullSink
 from refiner.pipeline.sinks.jsonl import JsonlSink
-from refiner.pipeline.sinks.lance import LanceDatasetSink, LanceWriteMode
+from refiner.pipeline.sinks.lance import (
+    AddColumns,
+    Append,
+    Create,
+    LanceDatasetSink,
+    LanceWriteConfig,
+    LanceWriteMode,
+    Overwrite,
+)
 from refiner.pipeline.sinks.lance_file import LanceSink
 from refiner.pipeline.sinks.parquet import ParquetSink
 from refiner.pipeline.sinks.reducer import FileCleanupReducerSink, LeRobotMetaReduceSink
 from refiner.pipeline.sinks.zarr import ZarrSink
 
 __all__ = [
+    "AddColumns",
+    "Append",
     "BaseSink",
+    "Create",
     "FileCleanupReducerSink",
     "LanceDatasetSink",
     "LanceSink",
     "LanceWriteMode",
+    "LanceWriteConfig",
     "NullSink",
+    "Overwrite",
     "JsonlSink",
     "LeRobotMetaReduceSink",
     "ParquetSink",

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -777,16 +777,26 @@ class BlobAssetManager:
                 [(offset, size) for _, offset, size in references], source_size
             ):
                 continue
-            block = self._block(shard_id, column_name, source_size)
-            output_offset = block.size
-            remaining = source_size
-            with source.open("rb") as stream:
-                while remaining:
-                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
-                    if not chunk:
-                        raise EOFError("asset ended before its declared size")
+            staged = tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024)
+            try:
+                remaining = source_size
+                with source.open("rb") as stream:
+                    while remaining:
+                        chunk = stream.read(min(remaining, 8 * 1024 * 1024))
+                        if not chunk:
+                            raise EOFError("asset ended before its declared size")
+                        staged.write(chunk)
+                        remaining -= len(chunk)
+                staged.seek(0)
+
+                # Opening a deterministic retry destination can truncate the
+                # source itself. Fully stage it before _block() mutates output.
+                block = self._block(shard_id, column_name, source_size)
+                output_offset = block.size
+                while chunk := staged.read(8 * 1024 * 1024):
                     block.stream.write(chunk)
-                    remaining -= len(chunk)
+            finally:
+                staged.close()
             block.size += source_size
             for index, offset, size in references:
                 rewritten[index] = {

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+import os
 import posixpath
 import re
 import tempfile
@@ -580,6 +581,36 @@ class BlobAssetManager:
             self._blocks[key] = block
         return block
 
+    def _block_output_path(
+        self,
+        shard_id: str,
+        column_name: str,
+        payload_size: int,
+    ) -> str:
+        key = (shard_id, column_name)
+        block = self._blocks.get(key)
+        if block is not None and not (
+            block.size > 0 and block.size + payload_size > self.config.target_bytes
+        ):
+            return block.path
+        next_index = block.index + 1 if block is not None else 0
+        return self.output.abs_path(
+            self._block_relpath(shard_id, column_name, next_index)
+        )
+
+    @staticmethod
+    def _same_file(source: DataFile, destination: str) -> bool:
+        target = DataFile.resolve(destination)
+        if source.abs_path() == target.abs_path():
+            return True
+        if source.is_local and target.is_local:
+            return os.path.realpath(source.abs_path()) == os.path.realpath(
+                target.abs_path()
+            )
+        return source.fs is target.fs and (
+            posixpath.normpath(source.path) == posixpath.normpath(target.path)
+        )
+
     @staticmethod
     def _source(value: object, storage: str) -> tuple[bytes | DataFile, int, int]:
         if storage == "bytes":
@@ -777,26 +808,22 @@ class BlobAssetManager:
                 [(offset, size) for _, offset, size in references], source_size
             ):
                 continue
-            staged = tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024)
-            try:
-                remaining = source_size
-                with source.open("rb") as stream:
-                    while remaining:
-                        chunk = stream.read(min(remaining, 8 * 1024 * 1024))
-                        if not chunk:
-                            raise EOFError("asset ended before its declared size")
-                        staged.write(chunk)
-                        remaining -= len(chunk)
-                staged.seek(0)
-
-                # Opening a deterministic retry destination can truncate the
-                # source itself. Fully stage it before _block() mutates output.
-                block = self._block(shard_id, column_name, source_size)
-                output_offset = block.size
-                while chunk := staged.read(8 * 1024 * 1024):
+            output_path = self._block_output_path(shard_id, column_name, source_size)
+            if self._same_file(source, output_path):
+                raise ValueError(
+                    "packed blob source and destination must differ: "
+                    f"{source.abs_path()}"
+                )
+            block = self._block(shard_id, column_name, source_size)
+            output_offset = block.size
+            remaining = source_size
+            with source.open("rb") as stream:
+                while remaining:
+                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
+                    if not chunk:
+                        raise EOFError("asset ended before its declared size")
                     block.stream.write(chunk)
-            finally:
-                staged.close()
+                    remaining -= len(chunk)
             block.size += source_size
             for index, offset, size in references:
                 rewritten[index] = {

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -755,9 +755,10 @@ class BlobAssetManager:
         for index, value in enumerate(values):
             if value is None or not isinstance(value, Mapping):
                 continue
-            path = value.get("path")
-            offset = value.get("offset")
-            size = value.get("size")
+            reference = cast(Mapping[str, object], value)
+            path = reference.get("path")
+            offset = reference.get("offset")
+            size = reference.get("size")
             if (
                 isinstance(path, str)
                 and path

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -5,10 +5,8 @@ from collections import deque
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 import posixpath
-import queue
 import re
 import tempfile
-import threading
 from typing import IO, Literal, TypeAlias, cast
 from urllib.parse import unquote, urlsplit
 
@@ -733,67 +731,6 @@ class BlobAssetManager:
             position = max(position, offset + size)
         return position == source_size
 
-    @staticmethod
-    def _stream_complete_blob(
-        source: DataFile,
-        *,
-        source_size: int,
-        destination: IO[bytes],
-    ) -> None:
-        """Copy a source blob with bounded source-read/upload overlap.
-
-        S3FS flushes multipart batches synchronously from ``write``. A small
-        reader thread keeps source chunks ready while such a flush is in
-        progress, without changing the writer contract or buffering a whole
-        source object.
-        """
-        chunk_bytes = 8 * 1024 * 1024
-        chunks: queue.Queue[bytes | BaseException | None] = queue.Queue(maxsize=16)
-        stopped = threading.Event()
-
-        def put(item: bytes | BaseException | None) -> bool:
-            while not stopped.is_set():
-                try:
-                    chunks.put(item, timeout=0.1)
-                    return True
-                except queue.Full:
-                    pass
-            return False
-
-        def read_chunks() -> None:
-            try:
-                remaining = source_size
-                with source.open("rb") as stream:
-                    while remaining and not stopped.is_set():
-                        chunk = stream.read(min(remaining, chunk_bytes))
-                        if not chunk:
-                            raise EOFError("asset ended before its declared size")
-                        remaining -= len(chunk)
-                        if not put(chunk):
-                            return
-            except BaseException as error:
-                put(error)
-            finally:
-                put(None)
-
-        reader = threading.Thread(
-            target=read_chunks,
-            name="refiner-blob-prefetch",
-            daemon=True,
-        )
-        reader.start()
-        try:
-            while True:
-                item = chunks.get()
-                if item is None:
-                    break
-                if isinstance(item, BaseException):
-                    raise item
-                destination.write(item)
-        finally:
-            stopped.set()
-            reader.join()
-
     def _coalesce_complete_blob_references(
         self,
         values: Sequence[object],
@@ -836,11 +773,14 @@ class BlobAssetManager:
                 continue
             block = self._block(shard_id, column_name, source_size)
             output_offset = block.size
-            self._stream_complete_blob(
-                source,
-                source_size=source_size,
-                destination=block.stream,
-            )
+            remaining = source_size
+            with source.open("rb") as stream:
+                while remaining:
+                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
+                    if not chunk:
+                        raise EOFError("asset ended before its declared size")
+                    block.stream.write(chunk)
+                    remaining -= len(chunk)
             block.size += source_size
             for index, offset, size in references:
                 rewritten[index] = {

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -4,7 +4,6 @@ import asyncio
 from collections import deque
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-import os
 import posixpath
 import re
 import tempfile
@@ -566,6 +565,11 @@ class BlobAssetManager:
         if block is None:
             next_index = self._blocks[key].index + 1 if key in self._blocks else 0
             relpath = self._block_relpath(shard_id, column_name, next_index)
+            if self.output.exists(relpath):
+                raise FileExistsError(
+                    "packed blob destination already exists; refusing to overwrite it: "
+                    f"{self.output.abs_path(relpath)}"
+                )
             open_kwargs = (
                 {"size": max(self.config.target_bytes, payload_size)}
                 if is_s3fs(self.output.fs)
@@ -580,36 +584,6 @@ class BlobAssetManager:
             )
             self._blocks[key] = block
         return block
-
-    def _block_output_path(
-        self,
-        shard_id: str,
-        column_name: str,
-        payload_size: int,
-    ) -> str:
-        key = (shard_id, column_name)
-        block = self._blocks.get(key)
-        if block is not None and not (
-            block.size > 0 and block.size + payload_size > self.config.target_bytes
-        ):
-            return block.path
-        next_index = block.index + 1 if block is not None else 0
-        return self.output.abs_path(
-            self._block_relpath(shard_id, column_name, next_index)
-        )
-
-    @staticmethod
-    def _same_file(source: DataFile, destination: str) -> bool:
-        target = DataFile.resolve(destination)
-        if source.abs_path() == target.abs_path():
-            return True
-        if source.is_local and target.is_local:
-            return os.path.realpath(source.abs_path()) == os.path.realpath(
-                target.abs_path()
-            )
-        return source.fs is target.fs and (
-            posixpath.normpath(source.path) == posixpath.normpath(target.path)
-        )
 
     @staticmethod
     def _source(value: object, storage: str) -> tuple[bytes | DataFile, int, int]:
@@ -808,12 +782,6 @@ class BlobAssetManager:
                 [(offset, size) for _, offset, size in references], source_size
             ):
                 continue
-            output_path = self._block_output_path(shard_id, column_name, source_size)
-            if self._same_file(source, output_path):
-                raise ValueError(
-                    "packed blob source and destination must differ: "
-                    f"{source.abs_path()}"
-                )
             block = self._block(shard_id, column_name, source_size)
             output_offset = block.size
             remaining = source_size

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -5,8 +5,10 @@ from collections import deque
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 import posixpath
+import queue
 import re
 import tempfile
+import threading
 from typing import IO, Literal, TypeAlias, cast
 from urllib.parse import unquote, urlsplit
 
@@ -731,6 +733,67 @@ class BlobAssetManager:
             position = max(position, offset + size)
         return position == source_size
 
+    @staticmethod
+    def _stream_complete_blob(
+        source: DataFile,
+        *,
+        source_size: int,
+        destination: IO[bytes],
+    ) -> None:
+        """Copy a source blob with bounded source-read/upload overlap.
+
+        S3FS flushes multipart batches synchronously from ``write``. A small
+        reader thread keeps source chunks ready while such a flush is in
+        progress, without changing the writer contract or buffering a whole
+        source object.
+        """
+        chunk_bytes = 8 * 1024 * 1024
+        chunks: queue.Queue[bytes | BaseException | None] = queue.Queue(maxsize=16)
+        stopped = threading.Event()
+
+        def put(item: bytes | BaseException | None) -> bool:
+            while not stopped.is_set():
+                try:
+                    chunks.put(item, timeout=0.1)
+                    return True
+                except queue.Full:
+                    pass
+            return False
+
+        def read_chunks() -> None:
+            try:
+                remaining = source_size
+                with source.open("rb") as stream:
+                    while remaining and not stopped.is_set():
+                        chunk = stream.read(min(remaining, chunk_bytes))
+                        if not chunk:
+                            raise EOFError("asset ended before its declared size")
+                        remaining -= len(chunk)
+                        if not put(chunk):
+                            return
+            except BaseException as error:
+                put(error)
+            finally:
+                put(None)
+
+        reader = threading.Thread(
+            target=read_chunks,
+            name="refiner-blob-prefetch",
+            daemon=True,
+        )
+        reader.start()
+        try:
+            while True:
+                item = chunks.get()
+                if item is None:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                destination.write(item)
+        finally:
+            stopped.set()
+            reader.join()
+
     def _coalesce_complete_blob_references(
         self,
         values: Sequence[object],
@@ -773,14 +836,11 @@ class BlobAssetManager:
                 continue
             block = self._block(shard_id, column_name, source_size)
             output_offset = block.size
-            remaining = source_size
-            with source.open("rb") as stream:
-                while remaining:
-                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
-                    if not chunk:
-                        raise EOFError("asset ended before its declared size")
-                    block.stream.write(chunk)
-                    remaining -= len(chunk)
+            self._stream_complete_blob(
+                source,
+                source_size=source_size,
+                destination=block.stream,
+            )
             block.size += source_size
             for index, offset, size in references:
                 rewritten[index] = {

--- a/src/refiner/pipeline/sinks/assets.py
+++ b/src/refiner/pipeline/sinks/assets.py
@@ -716,6 +716,82 @@ class BlobAssetManager:
             valid = valid and copied
         return rewritten, valid
 
+    @staticmethod
+    def _covers_entire_blob(
+        references: Sequence[tuple[int, int]],
+        source_size: int,
+    ) -> bool:
+        """Whether the union of byte references is exactly one source blob."""
+        position = 0
+        for offset, size in sorted(references):
+            if size < 0 or offset < 0 or offset > source_size or size > source_size - offset:
+                return False
+            if offset > position:
+                return False
+            position = max(position, offset + size)
+        return position == source_size
+
+    def _coalesce_complete_blob_references(
+        self,
+        values: Sequence[object],
+        *,
+        shard_id: str,
+        column_name: str,
+    ) -> dict[int, object]:
+        """Copy complete classic blob sources once and translate their offsets.
+
+        This is deliberately an internal optimization of the existing blob
+        reference writer.  A partial selection still uses the established
+        per-range copier below, preserving its missing-asset policies.
+        """
+        if self.missing_asset_policy != "error":
+            return {}
+        grouped: dict[str, list[tuple[int, int, int]]] = {}
+        for index, value in enumerate(values):
+            if value is None or not isinstance(value, Mapping):
+                continue
+            path = value.get("path")
+            offset = value.get("offset")
+            size = value.get("size")
+            if (
+                isinstance(path, str)
+                and path
+                and isinstance(offset, int)
+                and not isinstance(offset, bool)
+                and isinstance(size, int)
+                and not isinstance(size, bool)
+            ):
+                grouped.setdefault(path, []).append((index, offset, size))
+
+        rewritten: dict[int, object] = {}
+        for path, references in grouped.items():
+            source = DataFile.resolve(path)
+            source_size = int(source.fs.size(source.path))
+            if not self._covers_entire_blob(
+                [(offset, size) for _, offset, size in references], source_size
+            ):
+                continue
+            block = self._block(shard_id, column_name, source_size)
+            output_offset = block.size
+            remaining = source_size
+            with source.open("rb") as stream:
+                while remaining:
+                    chunk = stream.read(min(remaining, 8 * 1024 * 1024))
+                    if not chunk:
+                        raise EOFError("asset ended before its declared size")
+                    block.stream.write(chunk)
+                    remaining -= len(chunk)
+            block.size += source_size
+            for index, offset, size in references:
+                rewritten[index] = {
+                    "path": block.path,
+                    "offset": output_offset + offset,
+                    "size": size,
+                }
+            log_throughput("source_blobs_coalesced", 1, shard_id, unit="blobs")
+            log_throughput("assets_uploaded", len(references), shard_id, unit="assets")
+        return rewritten
+
     def rewrite_table(self, shard_id: str, table: pa.Table) -> pa.Table:
         columns = dict(self._asset_columns)
         columns.update(_asset_columns_from_schema(table.schema))
@@ -727,15 +803,26 @@ class BlobAssetManager:
             index = out.schema.get_field_index(column_name)
             if index < 0:
                 continue
-            values: list[object] = []
-            for row_offset, value in enumerate(out.column(index).to_pylist()):
-                rewritten, valid = self._rewrite_value(
-                    value,
-                    shard_id=shard_id,
-                    column_name=column_name,
-                    kind=kind,
-                    storage=storage,
+            original_values = out.column(index).to_pylist()
+            coalesced = (
+                self._coalesce_complete_blob_references(
+                    original_values, shard_id=shard_id, column_name=column_name
                 )
+                if kind == "scalar" and storage == "blob_reference"
+                else {}
+            )
+            values: list[object] = []
+            for row_offset, value in enumerate(original_values):
+                if row_offset in coalesced:
+                    rewritten, valid = coalesced[row_offset], True
+                else:
+                    rewritten, valid = self._rewrite_value(
+                        value,
+                        shard_id=shard_id,
+                        column_name=column_name,
+                        kind=kind,
+                        storage=storage,
+                    )
                 values.append(rewritten)
                 if not valid and self.missing_asset_policy == "drop_row":
                     keep[row_offset] = False

--- a/src/refiner/pipeline/sinks/base.py
+++ b/src/refiner/pipeline/sinks/base.py
@@ -90,6 +90,10 @@ class BaseSink(ABC):
         """Receive the schema expected at this sink boundary before writing starts."""
         del schema
 
+    def set_input_dtype_columns(self, columns: frozenset[str]) -> None:
+        """Receive columns whose output types were explicitly declared."""
+        del columns
+
     @property
     def counts_output_rows(self) -> bool:
         """Whether blocks written into this sink should count toward output_rows."""

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -130,7 +130,12 @@ def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
     return "; ".join(details) or "unknown schema difference"
 
 
-def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
+def _cast_to_planned_schema(
+    table: pa.Table,
+    schema: pa.Schema,
+    *,
+    declared_columns: frozenset[str] = frozenset(),
+) -> pa.Table:
     """Normalize known fields without overriding dynamic row-map changes.
 
     Dynamic row maps may drop fields or replace their values with another type;
@@ -143,7 +148,10 @@ def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
         fields.append(
             actual_field
             if planned_index < 0
-            or actual_field.type != schema.field(planned_index).type
+            or (
+                actual_field.name not in declared_columns
+                and actual_field.type != schema.field(planned_index).type
+            )
             else schema.field(planned_index)
         )
     target = pa.schema(fields, metadata=schema.metadata)
@@ -863,6 +871,7 @@ class LanceDatasetSink(BaseSink):
         ] = {}
         self._add_columns_schema: pa.Schema | None = None
         self._planned_output_schema: pa.Schema | None = None
+        self._declared_output_columns: frozenset[str] = frozenset()
         self._existing_schema: pa.Schema | None = None
         self._existing_version: int | None = None
         self._source_dataset_cache: Any | None = None
@@ -952,6 +961,9 @@ class LanceDatasetSink(BaseSink):
                 [schema.field(column) for column in self.columns]
             )
 
+    def set_input_dtype_columns(self, columns: frozenset[str]) -> None:
+        self._declared_output_columns = columns
+
     def _write_add_columns_block(self, shard_id: str, block: Block) -> None:
         if not isinstance(block, Tabular) and not block:
             return
@@ -1039,7 +1051,11 @@ class LanceDatasetSink(BaseSink):
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
         if self._planned_output_schema is not None:
-            table = _cast_to_planned_schema(table, self._planned_output_schema)
+            table = _cast_to_planned_schema(
+                table,
+                self._planned_output_schema,
+                declared_columns=self._declared_output_columns,
+            )
         if self.mode == "append":
             existing_schema = self._load_existing_schema()
             _validate_append_asset_layout(table.schema, existing_schema)

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -98,17 +98,21 @@ def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
 
 
 def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
-    """Normalize every worker's materialized output to the planned schema."""
-    actual_names = set(table.schema.names)
-    expected_names = set(schema.names)
-    if actual_names != expected_names:
-        raise ValueError(
-            "Lance output columns differ from planned schema: "
-            + _schema_difference(schema, table.schema)
+    """Normalize fields known to the planner without forbidding row-map drops.
+
+    Python row maps may use ``row.drop(...)``; their dynamic removal is not
+    visible to the static pipeline schema.  Every surviving field that *is*
+    known to the planner is nevertheless cast to its declared field, which
+    makes dtypes and metadata deterministic across workers.
+    """
+    fields: list[pa.Field] = []
+    for actual_field in table.schema:
+        planned_index = schema.get_field_index(actual_field.name)
+        fields.append(
+            actual_field if planned_index < 0 else schema.field(planned_index)
         )
-    # Selecting establishes the planner's deterministic column order; cast uses
-    # the target fields/metadata rather than preserving worker-local inference.
-    return table.select(schema.names).cast(schema, safe=True)
+    target = pa.schema(fields, metadata=schema.metadata)
+    return table.cast(target, safe=True)
 
 
 def _validate_write_mode(mode: str) -> None:

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -73,6 +73,44 @@ def _import_lance() -> Any:
     return lance
 
 
+def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
+    """Return a compact, actionable schema difference for distributed commits."""
+    details: list[str] = []
+    expected_names = set(expected.names)
+    actual_names = set(actual.names)
+    if missing := sorted(expected_names - actual_names):
+        details.append("missing=" + ", ".join(missing))
+    if extra := sorted(actual_names - expected_names):
+        details.append("unexpected=" + ", ".join(extra))
+    for name in expected.names:
+        actual_index = actual.get_field_index(name)
+        if actual_index < 0:
+            continue
+        expected_field = expected.field(name)
+        actual_field = actual.field(actual_index)
+        if not expected_field.equals(actual_field, check_metadata=True):
+            details.append(
+                f"{name}: expected={expected_field!s}, actual={actual_field!s}"
+            )
+    if expected.metadata != actual.metadata:
+        details.append("schema metadata differs")
+    return "; ".join(details) or "unknown schema difference"
+
+
+def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Normalize every worker's materialized output to the planned schema."""
+    actual_names = set(table.schema.names)
+    expected_names = set(schema.names)
+    if actual_names != expected_names:
+        raise ValueError(
+            "Lance output columns differ from planned schema: "
+            + _schema_difference(schema, table.schema)
+        )
+    # Selecting establishes the planner's deterministic column order; cast uses
+    # the target fields/metadata rather than preserving worker-local inference.
+    return table.select(schema.names).cast(schema, safe=True)
+
+
 def _validate_write_mode(mode: str) -> None:
     valid_modes = get_args(LanceWriteMode)
     if mode not in valid_modes:
@@ -684,6 +722,7 @@ class LanceDatasetSink(BaseSink):
             str, dict[int, _StreamingAddColumnsWriter]
         ] = {}
         self._add_columns_schema: pa.Schema | None = None
+        self._planned_output_schema: pa.Schema | None = None
         self._existing_schema: pa.Schema | None = None
         self._existing_version: int | None = None
         self._source_dataset_cache: Any | None = None
@@ -750,6 +789,10 @@ class LanceDatasetSink(BaseSink):
         if self._assets is not None:
             self._assets.set_input_schema(schema)
             schema = self._assets.output_schema(schema)
+        # The planner has a complete schema for Lance-backed sources and for
+        # maps with dtypes.  Keep it so independent cloud workers cannot leak
+        # local Arrow inference or metadata into their output fragments.
+        self._planned_output_schema = schema
         if self.mode != "add_columns":
             return
         assert self.columns is not None
@@ -853,6 +896,8 @@ class LanceDatasetSink(BaseSink):
             return
         if self._assets is not None:
             table = self._assets.rewrite_table(shard_id, table)
+        if self._planned_output_schema is not None:
+            table = _cast_to_planned_schema(table, self._planned_output_schema)
         if self.mode == "append":
             existing_schema = self._load_existing_schema()
             _validate_append_asset_layout(table.schema, existing_schema)
@@ -1398,7 +1443,8 @@ class LanceDatasetCommitReducerSink(BaseSink):
                     schema = next_schema
                 elif not schema.equals(next_schema, check_metadata=True):
                     raise ValueError(
-                        "Cannot commit Lance fragments with inconsistent schemas."
+                        "Cannot commit Lance fragments with inconsistent schemas: "
+                        + _schema_difference(schema, next_schema)
                     )
             fragment_json.extend(next_fragments)
             if next_source_version is not None:

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -131,18 +131,20 @@ def _schema_difference(expected: pa.Schema, actual: pa.Schema) -> str:
 
 
 def _cast_to_planned_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
-    """Normalize fields known to the planner without forbidding row-map drops.
+    """Normalize known fields without overriding dynamic row-map changes.
 
-    Python row maps may use ``row.drop(...)``; their dynamic removal is not
-    visible to the static pipeline schema.  Every surviving field that *is*
-    known to the planner is nevertheless cast to its declared field, which
-    makes dtypes and metadata deterministic across workers.
+    Dynamic row maps may drop fields or replace their values with another type;
+    neither change is visible to the static pipeline schema. Fields whose
+    runtime types match the plan still receive deterministic planned metadata.
     """
     fields: list[pa.Field] = []
     for actual_field in table.schema:
         planned_index = schema.get_field_index(actual_field.name)
         fields.append(
-            actual_field if planned_index < 0 else schema.field(planned_index)
+            actual_field
+            if planned_index < 0
+            or actual_field.type != schema.field(planned_index).type
+            else schema.field(planned_index)
         )
     target = pa.schema(fields, metadata=schema.metadata)
     return table.cast(target, safe=True)

--- a/src/refiner/pipeline/sinks/lance.py
+++ b/src/refiner/pipeline/sinks/lance.py
@@ -9,7 +9,8 @@ import posixpath
 import queue as queue_module
 import re
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Literal, get_args
 
 import pyarrow as pa
@@ -49,7 +50,38 @@ from refiner.worker.context import (
 from refiner.worker.lifecycle import sort_finalized_workers
 from refiner.worker.metrics.api import log_throughput
 
-LanceWriteMode = Literal["create", "append", "overwrite", "add_columns"]
+LanceWriteModeName = Literal["create", "append", "overwrite", "add_columns"]
+
+
+@dataclass(frozen=True, slots=True)
+class Create:
+    """Create a Lance dataset and fail if the destination already exists."""
+
+
+@dataclass(frozen=True, slots=True)
+class Append:
+    """Append rows to an existing Lance dataset."""
+
+
+@dataclass(frozen=True, slots=True)
+class Overwrite:
+    """Replace a Lance dataset's logical contents with the pipeline output."""
+
+
+@dataclass(frozen=True, slots=True)
+class AddColumns:
+    """Add columns while filling rows omitted by a bounded or filtered source.
+
+    ``fill`` may be one Arrow-compatible scalar used for every output column, or
+    a mapping from output-column name to scalar. Mapping entries omitted by the
+    caller default to null.
+    """
+
+    fill: object | Mapping[str, object] = None
+
+
+LanceWriteMode = Create | Append | Overwrite | AddColumns
+LanceWriteConfig = LanceWriteMode | LanceWriteModeName
 _METADATA_FILENAME_TEMPLATE = (
     "_refiner_lance_fragments/{job_id}/{shard_id}__w{worker_id}.jsonl"
 )
@@ -62,6 +94,7 @@ _LANCE_WRITER_POOL = concurrent.futures.ThreadPoolExecutor(
 )
 _LANCE_ROW_ADDRESS_FRAGMENT_SHIFT = 32
 _LANCE_ROW_ADDRESS_POSITION_MASK = (1 << _LANCE_ROW_ADDRESS_FRAGMENT_SHIFT) - 1
+_ADD_COLUMNS_FILL_BATCH_ROWS = 65_536
 
 
 def _import_lance() -> Any:
@@ -74,9 +107,69 @@ def _import_lance() -> Any:
 
 
 def _validate_write_mode(mode: str) -> None:
-    valid_modes = get_args(LanceWriteMode)
+    valid_modes = get_args(LanceWriteModeName)
     if mode not in valid_modes:
         raise ValueError("mode must be one of: " + ", ".join(sorted(valid_modes)))
+
+
+def _normalize_write_mode(
+    mode: LanceWriteConfig,
+) -> tuple[LanceWriteModeName, bool, object | Mapping[str, object]]:
+    if isinstance(mode, Create):
+        return "create", False, None
+    if isinstance(mode, Append):
+        return "append", False, None
+    if isinstance(mode, Overwrite):
+        return "overwrite", False, None
+    if isinstance(mode, AddColumns):
+        return "add_columns", True, mode.fill
+    _validate_write_mode(mode)
+    return mode, False, None
+
+
+def _validate_fill_mapping(
+    fill: object | Mapping[str, object], columns: Sequence[str] | None
+) -> None:
+    if not isinstance(fill, Mapping):
+        return
+    if not all(isinstance(name, str) for name in fill):
+        raise TypeError("AddColumns fill mapping keys must be column names")
+    unexpected = sorted(set(fill).difference(columns or ()))
+    if unexpected:
+        raise ValueError(
+            "AddColumns fill contains unknown columns: " + ", ".join(unexpected)
+        )
+
+
+def _filled_table(
+    schema: pa.Schema,
+    num_rows: int,
+    fill: object | Mapping[str, object],
+) -> pa.Table:
+    arrays: list[pa.Array] = []
+    for field in schema:
+        value = fill.get(field.name) if isinstance(fill, Mapping) else fill
+        if value is None:
+            arrays.append(pa.nulls(num_rows, type=field.type))
+        else:
+            try:
+                arrays.append(pa.repeat(pa.scalar(value, type=field.type), num_rows))
+            except (pa.ArrowException, TypeError, ValueError) as err:
+                raise ValueError(
+                    f"Cannot use AddColumns fill value for column {field.name!r}"
+                ) from err
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def _fill_fingerprint(
+    schema: pa.Schema,
+    fill: object | Mapping[str, object],
+) -> str:
+    table = _filled_table(schema, 1, fill)
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, schema) as writer:
+        writer.write_table(table)
+    return hashlib.sha256(sink.getvalue().to_pybytes()).hexdigest()
 
 
 def _asset_value_field(field: pa.Field) -> pa.Field | None:
@@ -339,7 +432,7 @@ class _StreamingShardWriter:
         *,
         dataset_uri: str,
         schema: pa.Schema,
-        mode: LanceWriteMode,
+        mode: LanceWriteModeName,
     ) -> None:
         self.dataset_uri = dataset_uri
         self.schema = schema
@@ -436,12 +529,16 @@ class _StreamingAddColumnsWriter:
         num_rows: int,
         schema: pa.Schema,
         output: DataFolder,
+        fill_missing: bool = False,
+        fill: object | Mapping[str, object] = None,
     ) -> None:
         self.fragment = fragment
         self.fragment_id = fragment_id
         self.num_rows = num_rows
         self.schema = schema
         self.output = output
+        self.fill_missing = fill_missing
+        self.fill = fill
         self.base_json = _json_dumps(fragment.metadata.to_json())
         self.queue: queue_module.Queue[pa.RecordBatch | object] = queue_module.Queue(
             maxsize=8
@@ -502,6 +599,38 @@ class _StreamingAddColumnsWriter:
             for batch in table.to_batches():
                 self._put_batch(batch)
             self.next_position = end
+
+    def _emit_fill(self, end: int) -> None:
+        while self.next_position < end:
+            batch_end = min(end, self.next_position + _ADD_COLUMNS_FILL_BATCH_ROWS)
+            table = _filled_table(
+                self.schema,
+                batch_end - self.next_position,
+                self.fill,
+            )
+            for batch in table.to_batches():
+                self._put_batch(batch)
+            self.next_position = batch_end
+
+    def _fill_missing_positions(self) -> None:
+        while self.next_position < self.num_rows:
+            next_pending = min(self.pending, default=self.num_rows)
+            if next_pending < self.next_position:
+                raise ValueError(
+                    f"Lance fragment {self.fragment_id} has invalid or duplicate "
+                    "row positions"
+                )
+            if next_pending > self.next_position:
+                self._emit_fill(next_pending)
+            if self.next_position == self.num_rows:
+                break
+            previous_position = self.next_position
+            self._emit_ready()
+            if self.next_position == previous_position:
+                raise ValueError(
+                    f"Lance fragment {self.fragment_id} could not fill missing "
+                    "row positions"
+                )
 
     def put(self, positions: pa.ChunkedArray, output: pa.Table) -> None:
         if self.closed:
@@ -578,6 +707,8 @@ class _StreamingAddColumnsWriter:
         )
 
     def finish(self) -> tuple[Any, Any]:
+        if self.fill_missing:
+            self._fill_missing_positions()
         complete = self.next_position == self.num_rows and not self.pending
         self._close_input()
         if not complete:
@@ -619,13 +750,13 @@ class LanceDatasetSink(BaseSink):
         self,
         output: DataFolderLike,
         *,
-        mode: LanceWriteMode = "create",
+        mode: LanceWriteConfig = Create(),
         columns: Sequence[str] | None = None,
         source_uri: str | None = None,
         source_version: int | None = None,
         assets: AssetWriteConfig | None = None,
     ) -> None:
-        _validate_write_mode(mode)
+        mode, fill_missing, fill = _normalize_write_mode(mode)
         if mode == "add_columns" and not columns:
             raise ValueError("add_columns requires at least one output column")
         if columns is not None and len(set(columns)) != len(columns):
@@ -638,6 +769,7 @@ class LanceDatasetSink(BaseSink):
             raise ValueError("columns is only supported with mode='add_columns'")
         if mode == "add_columns" and (source_uri is None or source_version is None):
             raise ValueError("add_columns requires a version-pinned Lance source")
+        _validate_fill_mapping(fill, columns)
         if (
             mode == "add_columns"
             and assets is not None
@@ -656,6 +788,8 @@ class LanceDatasetSink(BaseSink):
         if source_uri is not None:
             validate_lance_uri(source_uri)
         self.mode = mode
+        self.fill_missing = fill_missing
+        self.fill = fill
         self.columns = tuple(columns) if columns is not None else None
         self.source_uri = source_uri
         self.source_version = source_version
@@ -830,6 +964,8 @@ class LanceDatasetSink(BaseSink):
                     num_rows=int(fragment.physical_rows),
                     schema=output_schema,
                     output=self.output,
+                    fill_missing=self.fill_missing,
+                    fill=self.fill,
                 )
                 writers[fragment_id] = writer
             positions = pc.call_function(
@@ -909,6 +1045,8 @@ class LanceDatasetSink(BaseSink):
             payload["source_version"] = self._existing_version
         elif self.mode == "add_columns":
             payload["source_version"] = self.source_version
+            if self._add_columns_schema is not None:
+                payload["output_schema"] = _schema_to_base64(self._add_columns_schema)
         self._write_sidecar(shard_id, payload)
 
     def on_shard_complete(self, shard_id: str) -> None:
@@ -984,6 +1122,7 @@ class LanceDatasetSink(BaseSink):
             raise
         assert merged_schema is not None
         assert lance_schema_payload is not None
+        assert self._add_columns_schema is not None
         payload = {
             "schema": _schema_to_base64(merged_schema.to_pyarrow()),
             "lance_schema": lance_schema_payload,
@@ -991,6 +1130,7 @@ class LanceDatasetSink(BaseSink):
             "created_files": sorted(created_files),
             "source_version": self.source_version,
             "source_fragment_ids": sorted(writers),
+            "output_schema": _schema_to_base64(self._add_columns_schema),
         }
         self._write_sidecar(
             shard_id,
@@ -1031,6 +1171,8 @@ class LanceDatasetSink(BaseSink):
             args["columns"] = list(self.columns)
         if self.source_version is not None:
             args["source_version"] = self.source_version
+        if self.fill_missing:
+            args["fill_missing"] = True
         if self.assets is not None:
             args["assets"] = asset_config_to_plan(self.assets)
         return ("write_lance_dataset", "writer", args)
@@ -1041,6 +1183,9 @@ class LanceDatasetSink(BaseSink):
             mode=self.mode,
             source_version=self.source_version,
             assets_subdir=self.assets.subdir if self.assets is not None else None,
+            columns=self.columns,
+            fill_missing=self.fill_missing,
+            fill=self.fill,
         )
 
 
@@ -1049,9 +1194,12 @@ class LanceDatasetCommitReducerSink(BaseSink):
         self,
         output: DataFolderLike,
         *,
-        mode: LanceWriteMode,
+        mode: LanceWriteModeName,
         source_version: int | None = None,
         assets_subdir: str | None = None,
+        columns: Sequence[str] | None = None,
+        fill_missing: bool = False,
+        fill: object | Mapping[str, object] = None,
     ) -> None:
         _validate_write_mode(mode)
         self.output = DataFolder.resolve(output)
@@ -1059,6 +1207,10 @@ class LanceDatasetCommitReducerSink(BaseSink):
         self.mode = mode
         self.source_version = source_version
         self.assets_subdir = assets_subdir
+        self.columns = tuple(columns) if columns is not None else None
+        self.fill_missing = fill_missing
+        self.fill = fill
+        _validate_fill_mapping(fill, columns)
         self._managed_path_pattern = _compile_output_path_patterns(
             _METADATA_FILENAME_TEMPLATE
         )[-1]
@@ -1084,6 +1236,8 @@ class LanceDatasetCommitReducerSink(BaseSink):
             args["source_version"] = self.source_version
         if self.assets_subdir is not None:
             args["assets_subdir"] = self.assets_subdir
+        if self.fill_missing:
+            args["fill_missing"] = True
         return ("write_lance_dataset_commit", "writer", args)
 
     def write_shard_block(self, shard_id: str, block: Block) -> None:
@@ -1106,6 +1260,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
         fragments: Sequence[str],
         source_versions: set[int],
         lance_schema_payload: dict[str, object] | None,
+        fill_fingerprint: str | None = None,
     ) -> str:
         payload = {
             "mode": self.mode,
@@ -1113,6 +1268,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
             "fragments": sorted(fragments),
             "source_versions": sorted(source_versions),
             "lance_schema": lance_schema_payload,
+            "fill_fingerprint": fill_fingerprint,
         }
         digest = hashlib.sha256(_json_dumps(payload).encode("utf-8")).hexdigest()
         return f"refiner:{digest}"
@@ -1157,6 +1313,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
         int | None,
         list[int],
         dict[str, object] | None,
+        pa.Schema | None,
     ]:
         with self.output.open(rel_path, mode="rt", encoding="utf-8") as f:
             payload = json.load(f)
@@ -1180,10 +1337,16 @@ class LanceDatasetCommitReducerSink(BaseSink):
         lance_schema_raw = (
             payload.get("lance_schema") if isinstance(payload, dict) else None
         )
+        output_schema_raw = (
+            payload.get("output_schema") if isinstance(payload, dict) else None
+        )
         if (
             not isinstance(empty_raw, bool)
             or not isinstance(fragment_raw, list)
             or not all(isinstance(fragment, str) for fragment in fragment_raw)
+            or (
+                output_schema_raw is not None and not isinstance(output_schema_raw, str)
+            )
         ):
             raise ValueError(f"Invalid Lance metadata payload: {rel_path}")
         if not isinstance(created_raw, list):
@@ -1207,6 +1370,9 @@ class LanceDatasetCommitReducerSink(BaseSink):
             int(source_version_raw) if source_version_raw is not None else None,
             [int(fragment_id) for fragment_id in source_fragments_raw],
             lance_schema_raw if isinstance(lance_schema_raw, dict) else None,
+            _schema_from_base64(output_schema_raw)
+            if isinstance(output_schema_raw, str)
+            else None,
         )
 
     def _load_existing_dataset(self, lance: Any) -> Any | None:
@@ -1301,6 +1467,86 @@ class LanceDatasetCommitReducerSink(BaseSink):
                 + ", ".join(str(fragment_id) for fragment_id in unexpected)
             )
 
+    def _fill_add_columns_fragments(
+        self,
+        lance: Any,
+        source_fragment_ids: set[int],
+        output_schema: pa.Schema | None,
+        lance_schema: Any | None,
+    ) -> tuple[list[str], list[str], pa.Schema | None, Any | None]:
+        if not self.fill_missing:
+            return [], [], None, lance_schema
+        if self.mode != "add_columns" or self.source_version is None:
+            raise ValueError("AddColumns(fill=...) requires an add_columns source")
+        if output_schema is None:
+            raise ValueError("AddColumns(fill=...) could not determine output schema")
+        if self.columns is None:
+            raise ValueError("AddColumns(fill=...) requires output columns")
+
+        source = lance.dataset(self._dataset_uri(), version=self.source_version)
+        missing_fragments = [
+            fragment
+            for fragment in source.get_fragments()
+            if int(fragment.count_rows()) > 0
+            and int(fragment.fragment_id) not in source_fragment_ids
+        ]
+        fragment_json: list[str] = []
+        created_files: list[str] = []
+        merged_schema: pa.Schema | None = None
+        active_writer: _StreamingAddColumnsWriter | None = None
+        try:
+            for fragment in missing_fragments:
+                fragment_id = int(fragment.fragment_id)
+                if int(fragment.num_deletions) > 0:
+                    raise ValueError(
+                        f"Lance fragment {fragment_id} has deletions; add_columns "
+                        "does not yet support deletion-bearing fragments"
+                    )
+                active_writer = _StreamingAddColumnsWriter(
+                    fragment=fragment,
+                    fragment_id=fragment_id,
+                    num_rows=int(fragment.physical_rows),
+                    schema=output_schema,
+                    output=self.output,
+                    fill_missing=True,
+                    fill=self.fill,
+                )
+                updated_fragment, next_schema = active_writer.finish()
+                active_writer = None
+                updated_json = _json_dumps(updated_fragment.to_json())
+                base_json = _json_dumps(fragment.metadata.to_json())
+                next_created_files = sorted(
+                    set(_fragment_data_paths(updated_json)).difference(
+                        _fragment_data_paths(base_json)
+                    )
+                )
+                fragment_json.append(updated_json)
+                created_files.extend(next_created_files)
+                if lance_schema is None:
+                    lance_schema = next_schema
+                elif lance_schema != next_schema:
+                    raise ValueError(
+                        "Cannot fill Lance fragments with inconsistent field IDs."
+                    )
+                next_arrow_schema = next_schema.to_pyarrow()
+                if merged_schema is None:
+                    merged_schema = next_arrow_schema
+                elif not merged_schema.equals(next_arrow_schema, check_metadata=True):
+                    raise ValueError(
+                        "Cannot fill Lance fragments with inconsistent schemas."
+                    )
+                source_fragment_ids.add(fragment_id)
+        except Exception:
+            if active_writer is not None:
+                active_writer.abort()
+            _remove_paths_best_effort(
+                self.output,
+                created_files,
+                operation="failed Lance fill cleanup",
+            )
+            raise
+        return fragment_json, created_files, merged_schema, lance_schema
+
     def _commit_empty_output(self, lance: Any) -> None:
         existing = self._load_existing_dataset(lance)
         if self.mode == "append":
@@ -1344,6 +1590,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
                     next_source_version,
                     next_source_fragment_ids,
                     _,
+                    _,
                 ) = self._read_metadata(rel_path)
                 next_created_files = self._verified_created_files(
                     cleanup_lance,
@@ -1376,6 +1623,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
         source_fragment_ids: set[int] = set()
         lance_schema_payload: dict[str, object] | None = None
         lance_schema: Any | None = None
+        output_schema: pa.Schema | None = None
         for rel_path in metadata_paths:
             (
                 next_schema,
@@ -1384,6 +1632,7 @@ class LanceDatasetCommitReducerSink(BaseSink):
                 next_source_version,
                 next_source_fragment_ids,
                 next_lance_schema,
+                next_output_schema,
             ) = self._read_metadata(rel_path)
             self._verified_created_files(
                 lance,
@@ -1420,6 +1669,40 @@ class LanceDatasetCommitReducerSink(BaseSink):
                     raise ValueError(
                         "Cannot commit Lance fragments with inconsistent field IDs."
                     )
+            if next_output_schema is not None:
+                if output_schema is None:
+                    output_schema = next_output_schema
+                elif not output_schema.equals(next_output_schema, check_metadata=True):
+                    raise ValueError(
+                        "Cannot commit Lance fragments with inconsistent output schemas."
+                    )
+        worker_fragment_json = tuple(fragment_json)
+        (
+            filled_fragments,
+            filled_created_files,
+            filled_schema,
+            lance_schema,
+        ) = self._fill_add_columns_fragments(
+            lance,
+            source_fragment_ids,
+            output_schema,
+            lance_schema,
+        )
+        fragment_json.extend(filled_fragments)
+        if filled_schema is not None:
+            if schema is None:
+                schema = filled_schema
+            elif not schema.equals(filled_schema, check_metadata=True):
+                _remove_paths_best_effort(
+                    self.output,
+                    filled_created_files,
+                    operation="rejected Lance fill cleanup",
+                )
+                raise ValueError(
+                    "Cannot commit filled Lance fragments with inconsistent schemas."
+                )
+        if lance_schema is not None:
+            lance_schema_payload = _lance_schema_to_payload(lance_schema)
         self._validate_add_columns_fragment_coverage(lance, source_fragment_ids)
 
         if not fragment_json:
@@ -1433,9 +1716,14 @@ class LanceDatasetCommitReducerSink(BaseSink):
             raise ValueError("Lance fragment metadata is missing its schema")
         commit_message = self._commit_message(
             schema=schema,
-            fragments=fragment_json,
+            fragments=worker_fragment_json if self.fill_missing else fragment_json,
             source_versions=source_versions,
             lance_schema_payload=lance_schema_payload,
+            fill_fingerprint=(
+                _fill_fingerprint(output_schema, self.fill)
+                if self.fill_missing and output_schema is not None
+                else None
+            ),
         )
         expected_versions = (
             [next(iter(source_versions)) + 1]
@@ -1449,6 +1737,11 @@ class LanceDatasetCommitReducerSink(BaseSink):
         if self._was_committed(
             lance, commit_message, expected_versions=expected_versions
         ):
+            _remove_paths_best_effort(
+                self.output,
+                filled_created_files,
+                operation="redundant Lance fill cleanup",
+            )
             self._cleanup_rejected_data(rejected_created_files)
             self._pending_metadata_cleanup = tuple(
                 sorted(set(cleanup_paths).union(metadata_paths))
@@ -1531,13 +1824,21 @@ class LanceDatasetCommitReducerSink(BaseSink):
             )
             read_version = 0
 
-        lance.LanceDataset.commit(
-            self._dataset_uri(),
-            operation,
-            read_version=read_version,
-            commit_message=commit_message,
-            max_retries=0,
-        )
+        try:
+            lance.LanceDataset.commit(
+                self._dataset_uri(),
+                operation,
+                read_version=read_version,
+                commit_message=commit_message,
+                max_retries=0,
+            )
+        except Exception:
+            _remove_paths_best_effort(
+                self.output,
+                filled_created_files,
+                operation="failed Lance fill commit cleanup",
+            )
+            raise
         self._cleanup_rejected_data(rejected_created_files)
         self._pending_metadata_cleanup = tuple(
             sorted(set(cleanup_paths).union(metadata_paths))
@@ -1554,4 +1855,14 @@ class LanceDatasetCommitReducerSink(BaseSink):
         )
 
 
-__all__ = ["LanceDatasetCommitReducerSink", "LanceDatasetSink", "LanceWriteMode"]
+__all__ = [
+    "AddColumns",
+    "Append",
+    "Create",
+    "LanceDatasetCommitReducerSink",
+    "LanceDatasetSink",
+    "LanceWriteConfig",
+    "LanceWriteMode",
+    "LanceWriteModeName",
+    "Overwrite",
+]

--- a/src/refiner/pipeline/sources/lance.py
+++ b/src/refiner/pipeline/sources/lance.py
@@ -69,7 +69,6 @@ class LanceSource(BaseSource):
         columns: Sequence[str] | None = None,
         batch_size: int = 65_536,
         num_shards: int | None = None,
-        row_limit: int | None = None,
         max_rows: int | None = None,
     ) -> None:
         if batch_size <= 0:
@@ -77,10 +76,6 @@ class LanceSource(BaseSource):
         if columns is not None and len(set(columns)) != len(columns):
             raise ValueError("Lance columns must be unique")
         validate_explicit_num_shards(num_shards)
-        if row_limit is not None and max_rows is not None:
-            raise ValueError("row_limit and max_rows are mutually exclusive")
-        if row_limit is not None and row_limit <= 0:
-            raise ValueError("row_limit must be > 0")
         if max_rows is not None and max_rows < 0:
             raise ValueError("max_rows must be >= 0")
 
@@ -95,13 +90,9 @@ class LanceSource(BaseSource):
         self.columns = tuple(columns) if columns is not None else None
         self.batch_size = int(batch_size)
         self.num_shards = num_shards
-        effective_row_limit = row_limit if row_limit is not None else max_rows
-        self.row_limit = (
-            int(effective_row_limit) if effective_row_limit is not None else None
-        )
         self.max_rows = int(max_rows) if max_rows is not None else None
         self._dataset_cache: Any | None = None
-        self._fragment_row_limits: tuple[int, ...] | None = None
+        self._planned_rows_by_fragment: tuple[int, ...] | None = None
 
         dataset = _import_lance().dataset(self.dataset_uri, version=version)
         self.version = int(dataset.version)
@@ -173,14 +164,14 @@ class LanceSource(BaseSource):
         state["_dataset_cache"] = None
         return state
 
-    def _planned_fragment_row_limits(self) -> tuple[int, ...]:
-        if self._fragment_row_limits is not None:
-            return self._fragment_row_limits
+    def _planned_fragment_rows(self) -> tuple[int, ...]:
+        if self._planned_rows_by_fragment is not None:
+            return self._planned_rows_by_fragment
         fragments = self._dataset().get_fragments()
-        if self.row_limit is None:
+        if self.max_rows is None:
             limits = tuple(-1 for _ in fragments)
         else:
-            remaining = self.row_limit
+            remaining = self.max_rows
             planned: list[int] = []
             for fragment in fragments:
                 if remaining <= 0:
@@ -193,11 +184,11 @@ class LanceSource(BaseSource):
                 planned.append(take_rows)
                 remaining -= take_rows
             limits = tuple(planned)
-        self._fragment_row_limits = limits
+        self._planned_rows_by_fragment = limits
         return limits
 
     def list_shards(self) -> list[Shard]:
-        fragment_count = len(self._planned_fragment_row_limits())
+        fragment_count = len(self._planned_fragment_rows())
         if fragment_count == 0:
             return []
         shard_count = (
@@ -291,10 +282,10 @@ class LanceSource(BaseSource):
             or descriptor.end > len(fragments)
         ):
             raise ValueError("Lance shard fragment range is invalid")
-        fragment_row_limits = self._planned_fragment_row_limits()
+        planned_fragment_rows = self._planned_fragment_rows()
         for fragment_index in range(descriptor.start, descriptor.end):
             fragment = fragments[fragment_index]
-            planned_rows = fragment_row_limits[fragment_index]
+            planned_rows = planned_fragment_rows[fragment_index]
             expected_rows = (
                 int(fragment.count_rows()) if planned_rows < 0 else planned_rows
             )
@@ -338,7 +329,6 @@ class LanceSource(BaseSource):
             "columns": list(self.columns) if self.columns is not None else None,
             "batch_size": self.batch_size,
             "num_shards": self.num_shards,
-            "row_limit": self.row_limit,
             "max_rows": self.max_rows,
         }
 

--- a/src/refiner/pipeline/sources/lance.py
+++ b/src/refiner/pipeline/sources/lance.py
@@ -69,9 +69,12 @@ class LanceSource(BaseSource):
         columns: Sequence[str] | None = None,
         batch_size: int = 65_536,
         num_shards: int | None = None,
+        max_rows: int | None = None,
     ) -> None:
         if batch_size <= 0:
             raise ValueError("batch_size must be > 0")
+        if max_rows is not None and max_rows < 0:
+            raise ValueError("max_rows must be >= 0 or None")
         if columns is not None and len(set(columns)) != len(columns):
             raise ValueError("Lance columns must be unique")
         validate_num_shards(num_shards)
@@ -87,6 +90,7 @@ class LanceSource(BaseSource):
         self.columns = tuple(columns) if columns is not None else None
         self.batch_size = int(batch_size)
         self.num_shards = num_shards
+        self.max_rows = max_rows
         self._dataset_cache: Any | None = None
 
         dataset = _import_lance().dataset(self.dataset_uri, version=version)
@@ -160,9 +164,21 @@ class LanceSource(BaseSource):
         return state
 
     def list_shards(self) -> list[Shard]:
-        fragment_count = len(self._dataset().get_fragments())
+        fragments = self._dataset().get_fragments()
+        fragment_count = len(fragments)
         if fragment_count == 0:
             return []
+        max_rows = getattr(self, "max_rows", None)
+        if max_rows == 0:
+            return []
+        if max_rows is not None:
+            rows = 0
+            fragment_count = 0
+            for fragment in fragments:
+                fragment_count += 1
+                rows += int(fragment.count_rows())
+                if rows >= max_rows:
+                    break
         if self.num_shards is None or self.num_shards <= 0:
             validate_shard_count(fragment_count, source="Lance automatic")
         shard_count = (
@@ -256,7 +272,19 @@ class LanceSource(BaseSource):
             or descriptor.end > len(fragments)
         ):
             raise ValueError("Lance shard fragment range is invalid")
+        rows_before_shard = (
+            sum(int(fragment.count_rows()) for fragment in fragments[: descriptor.start])
+            if self.max_rows is not None
+            else 0
+        )
         for fragment in fragments[descriptor.start : descriptor.end]:
+            remaining = (
+                self.max_rows - rows_before_shard
+                if self.max_rows is not None
+                else None
+            )
+            if remaining is not None and remaining <= 0:
+                return
             blob_paths = self._fragment_blob_paths(fragment)
             expected_rows = int(fragment.count_rows())
             rows_read = 0
@@ -266,12 +294,19 @@ class LanceSource(BaseSource):
                 with_row_address=True,
                 blob_handling="blobs_descriptions",
             ):
+                if remaining is not None:
+                    batch = batch.slice(0, min(batch.num_rows, remaining))
+                    if batch.num_rows == 0:
+                        break
                 table = self._normalize_blob_columns(
                     pa.Table.from_batches([batch]),
                     blob_paths,
                 )
                 row_addresses = table.column(_LANCE_ROW_ADDRESS_COLUMN)
                 rows_read += batch.num_rows
+                rows_before_shard += batch.num_rows
+                if remaining is not None:
+                    remaining -= batch.num_rows
                 yield Tabular(
                     set_or_append_column(
                         table.drop_columns([_LANCE_ROW_ADDRESS_COLUMN]),
@@ -279,7 +314,11 @@ class LanceSource(BaseSource):
                         row_addresses,
                     )
                 )
-            if rows_read != expected_rows:
+                if remaining == 0:
+                    break
+            if rows_read != expected_rows and (
+                self.max_rows is None or rows_before_shard < self.max_rows
+            ):
                 raise ValueError(
                     f"Lance fragment {fragment.fragment_id} yielded {rows_read} rows; "
                     f"expected {expected_rows}"
@@ -292,6 +331,7 @@ class LanceSource(BaseSource):
             "columns": list(self.columns) if self.columns is not None else None,
             "batch_size": self.batch_size,
             "num_shards": self.num_shards,
+            "max_rows": self.max_rows,
         }
 
 

--- a/src/refiner/pipeline/steps.py
+++ b/src/refiner/pipeline/steps.py
@@ -26,6 +26,10 @@ AsyncMapFactory: TypeAlias = Callable[[], AsyncMapFn]
 PredicateFn: TypeAlias = Callable[[Row], bool]
 BatchFn: TypeAlias = Callable[[list[Row]], Iterable[Row]]
 BatchFactory: TypeAlias = Callable[[], BatchFn]
+AsyncBatchFn: TypeAlias = Callable[
+    [list[Row]], Awaitable[Iterable[Row]] | Iterable[Row]
+]
+AsyncBatchFactory: TypeAlias = Callable[[], AsyncBatchFn]
 FlatMapFn: TypeAlias = Callable[[Row], Iterable[MapResult]]
 TableResult: TypeAlias = pa.Table
 TableFn: TypeAlias = Callable[[pa.Table], TableResult]
@@ -116,6 +120,44 @@ class FnBatchStep(BatchStep):
             raise RuntimeError("batch_map factory was not initialized")
         for i in range(0, len(rows), self.batch_size):
             yield from self.fn(rows[i : i + self.batch_size])
+
+
+class AsyncBatchStep(RefinerStep, ABC):
+    batch_size: int
+    max_in_flight: int
+    preserve_order: bool
+
+    @abstractmethod
+    def apply_batch_async(
+        self, rows: list[Row]
+    ) -> Awaitable[Iterable[Row]] | Iterable[Row]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class FnAsyncBatchStep(AsyncBatchStep):
+    fn: AsyncBatchFn | None
+    index: int
+    batch_size: int
+    max_in_flight: int = 2
+    preserve_order: bool = True
+    op_name: str | None = None
+    dtypes: DTypeMapping | None = None
+    factory: AsyncBatchFactory | None = None
+
+    def __post_init__(self) -> None:
+        _validate_fn_or_factory(self.fn, self.factory, op_name="batch_map_async")
+        if self.batch_size <= 1:
+            raise ValueError("batch_size for async batch steps must be > 1")
+        if self.max_in_flight <= 0:
+            raise ValueError("max_in_flight must be > 0")
+
+    def apply_batch_async(
+        self, rows: list[Row]
+    ) -> Awaitable[Iterable[Row]] | Iterable[Row]:
+        if self.fn is None:
+            raise RuntimeError("batch_map_async factory was not initialized")
+        return self.fn(rows)
 
 
 class FlatMapStep(RefinerStep, ABC):
@@ -236,6 +278,8 @@ __all__ = [
     "AsyncRowStep",
     "FnAsyncRowStep",
     "FnBatchStep",
+    "AsyncBatchStep",
+    "FnAsyncBatchStep",
     "FnFlatMapStep",
     "FilterRowStep",
     "MapResult",
@@ -245,6 +289,8 @@ __all__ = [
     "PredicateFn",
     "BatchFn",
     "BatchFactory",
+    "AsyncBatchFn",
+    "AsyncBatchFactory",
     "FlatMapFn",
     "TableResult",
     "TableFn",

--- a/src/refiner/pipeline/steps.py
+++ b/src/refiner/pipeline/steps.py
@@ -22,11 +22,24 @@ class RefinerStep(ABC):
 MapResult: TypeAlias = Row | dict[str, Any]
 MapFn: TypeAlias = Callable[[Row], MapResult]
 AsyncMapFn: TypeAlias = Callable[[Row], Awaitable[MapResult] | MapResult]
+AsyncMapFactory: TypeAlias = Callable[[], AsyncMapFn]
 PredicateFn: TypeAlias = Callable[[Row], bool]
 BatchFn: TypeAlias = Callable[[list[Row]], Iterable[Row]]
+BatchFactory: TypeAlias = Callable[[], BatchFn]
 FlatMapFn: TypeAlias = Callable[[Row], Iterable[MapResult]]
 TableResult: TypeAlias = pa.Table
 TableFn: TypeAlias = Callable[[pa.Table], TableResult]
+TableFactory: TypeAlias = Callable[[], TableFn]
+
+
+def _validate_fn_or_factory(
+    fn: Callable[..., Any] | None,
+    factory: Callable[[], Callable[..., Any]] | None,
+    *,
+    op_name: str,
+) -> None:
+    if (fn is None) == (factory is None):
+        raise ValueError(f"{op_name} requires exactly one of fn or factory")
 
 
 class RowStep(RefinerStep, ABC):
@@ -57,18 +70,22 @@ class AsyncRowStep(RefinerStep, ABC):
 
 @dataclass(frozen=True, slots=True)
 class FnAsyncRowStep(AsyncRowStep):
-    fn: AsyncMapFn
+    fn: AsyncMapFn | None
     index: int
     max_in_flight: int = 16
     preserve_order: bool = True
     op_name: str | None = None
     dtypes: DTypeMapping | None = None
+    factory: AsyncMapFactory | None = None
 
     def __post_init__(self) -> None:
+        _validate_fn_or_factory(self.fn, self.factory, op_name="map_async")
         if self.max_in_flight <= 0:
             raise ValueError("max_in_flight must be > 0")
 
     def apply_row_async(self, row: Row) -> Awaitable[MapResult] | MapResult:
+        if self.fn is None:
+            raise RuntimeError("map_async factory was not initialized")
         return self.fn(row)
 
 
@@ -82,17 +99,21 @@ class BatchStep(RefinerStep, ABC):
 
 @dataclass(frozen=True, slots=True)
 class FnBatchStep(BatchStep):
-    fn: BatchFn
+    fn: BatchFn | None
     index: int
     batch_size: int
     op_name: str | None = None
     dtypes: DTypeMapping | None = None
+    factory: BatchFactory | None = None
 
     def __post_init__(self) -> None:
+        _validate_fn_or_factory(self.fn, self.factory, op_name="batch_map")
         if self.batch_size <= 1:
             raise ValueError("batch_size for batch steps must be > 1")
 
     def apply_batch(self, rows: list[Row]) -> Iterable[Row]:
+        if self.fn is None:
+            raise RuntimeError("batch_map factory was not initialized")
         for i in range(0, len(rows), self.batch_size):
             yield from self.fn(rows[i : i + self.batch_size])
 
@@ -168,9 +189,18 @@ class FilterExprStep(RefinerStep):
 
 @dataclass(frozen=True, slots=True)
 class FnTableStep(RefinerStep):
-    fn: TableFn
+    fn: TableFn | None
     index: int
     op_name: str | None = "map_table"
+    factory: TableFactory | None = None
+
+    def __post_init__(self) -> None:
+        _validate_fn_or_factory(self.fn, self.factory, op_name="map_table")
+
+    def apply_table(self, table: pa.Table) -> pa.Table:
+        if self.fn is None:
+            raise RuntimeError("map_table factory was not initialized")
+        return self.fn(table)
 
 
 VectorizedOp: TypeAlias = (
@@ -211,11 +241,14 @@ __all__ = [
     "MapResult",
     "MapFn",
     "AsyncMapFn",
+    "AsyncMapFactory",
     "PredicateFn",
     "BatchFn",
+    "BatchFactory",
     "FlatMapFn",
     "TableResult",
     "TableFn",
+    "TableFactory",
     "SelectStep",
     "WithColumnsStep",
     "DropStep",

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -233,7 +233,30 @@ def refiner_ref_exists_on_remote(ref: str) -> bool:
         with urllib_request.urlopen(request):
             return True
     except (urllib_error.HTTPError, urllib_error.URLError):
-        return False
+        # The commit endpoint is rate limited for unauthenticated callers.
+        # A public branch-head SHA remains verifiable through the git transport,
+        # which avoids turning a transient GitHub API quota into a forced PyPI
+        # downgrade (and therefore a possible source-version regression).
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "ls-remote",
+                    "https://github.com/macrodata-labs/refiner.git",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return False
+        if result.returncode != 0:
+            return False
+        return any(
+            line.split("\t", 1)[0].strip() == ref
+            for line in result.stdout.splitlines()
+            if "\t" in line
+        )
 
 
 def build_run_manifest(

--- a/src/refiner/platform/manifest.py
+++ b/src/refiner/platform/manifest.py
@@ -233,30 +233,7 @@ def refiner_ref_exists_on_remote(ref: str) -> bool:
         with urllib_request.urlopen(request):
             return True
     except (urllib_error.HTTPError, urllib_error.URLError):
-        # The commit endpoint is rate limited for unauthenticated callers.
-        # A public branch-head SHA remains verifiable through the git transport,
-        # which avoids turning a transient GitHub API quota into a forced PyPI
-        # downgrade (and therefore a possible source-version regression).
-        try:
-            result = subprocess.run(
-                [
-                    "git",
-                    "ls-remote",
-                    "https://github.com/macrodata-labs/refiner.git",
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-        except FileNotFoundError:
-            return False
-        if result.returncode != 0:
-            return False
-        return any(
-            line.split("\t", 1)[0].strip() == ref
-            for line in result.stdout.splitlines()
-            if "\t" in line
-        )
+        return False
 
 
 def build_run_manifest(

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from refiner.pipeline.steps import (
+    FnAsyncBatchStep,
     FnAsyncRowStep,
     FnBatchStep,
     FnFlatMapStep,
@@ -55,7 +56,12 @@ def collect_pipeline_services(
         for callable_step in callable_steps:
             if isinstance(
                 callable_step,
-                FnRowStep | FnAsyncRowStep | FnBatchStep | FnFlatMapStep | FnTableStep,
+                FnRowStep
+                | FnAsyncRowStep
+                | FnAsyncBatchStep
+                | FnBatchStep
+                | FnFlatMapStep
+                | FnTableStep,
             ):
                 factory = getattr(callable_step, "factory", None)
                 candidate = (

--- a/src/refiner/services/discovery.py
+++ b/src/refiner/services/discovery.py
@@ -10,6 +10,7 @@ from refiner.pipeline.steps import (
     FnFlatMapStep,
     FnRowStep,
     FnTableStep,
+    VectorizedSegmentStep,
 )
 from refiner.services.base import RuntimeServiceSpec
 
@@ -48,13 +49,24 @@ def collect_pipeline_services(
 
     for step in pipeline.pipeline_steps:
         candidates: list[Any] = []
-        if isinstance(
-            step,
-            FnRowStep | FnAsyncRowStep | FnBatchStep | FnFlatMapStep | FnTableStep,
-        ):
-            candidates.append(step.fn)
-        elif (fn := getattr(step, "fn", None)) is not None:
-            candidates.append(fn)
+        callable_steps = (
+            step.ops if isinstance(step, VectorizedSegmentStep) else (step,)
+        )
+        for callable_step in callable_steps:
+            if isinstance(
+                callable_step,
+                FnRowStep | FnAsyncRowStep | FnBatchStep | FnFlatMapStep | FnTableStep,
+            ):
+                factory = getattr(callable_step, "factory", None)
+                candidate = (
+                    factory
+                    if factory is not None
+                    else getattr(callable_step, "fn", None)
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+            elif (fn := getattr(callable_step, "fn", None)) is not None:
+                candidates.append(fn)
 
         for candidate in candidates:
             builtin = _builtin_description(candidate)

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -331,7 +331,9 @@ class Worker:
                     self.user_metrics_emitter.force_flush_logs()
                     failed_inflight = _fail_inflight_shards(lifecycle_error)
                     failed += failed_inflight
-                    if isinstance(e, AsyncStepTeardownError) and failed_inflight == 0:
+                    if failed_inflight == 0 and (
+                        claimed == 0 or isinstance(e, AsyncStepTeardownError)
+                    ):
                         raise
                 else:
                     _heartbeat_once()

--- a/src/refiner/worker/runner.py
+++ b/src/refiner/worker/runner.py
@@ -94,6 +94,7 @@ class Worker:
         sink = self.pipeline.sink or NullSink()
         sink_schema = self.pipeline.output_schema()
         sink.set_input_schema(sink_schema)
+        sink.set_input_dtype_columns(self.pipeline._output_dtype_columns())
         sink_step_index = (
             self.pipeline._next_step_index() if self.pipeline.sink is not None else None
         )

--- a/tests/pipeline/test_async_batch_map.py
+++ b/tests/pipeline/test_async_batch_map.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+
+import pytest
+
+from refiner.execution.operators.row import execute_row_steps
+from refiner.pipeline import from_items
+from refiner.pipeline.data.row import DictRow, Row
+from refiner.pipeline.planning import compile_pipeline_plan
+from refiner.pipeline.steps import FnAsyncBatchStep
+
+
+def test_async_batch_map_is_bounded_and_preserves_order() -> None:
+    active = 0
+    max_active = 0
+    batch_sizes: list[int] = []
+
+    async def mapper(rows: list[Row]) -> Iterable[Row]:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        values = [int(row["x"]) for row in rows]
+        batch_sizes.append(len(rows))
+        await asyncio.sleep(0.03 if values[0] == 0 else 0.005)
+        active -= 1
+        return [row.update({"mapped": int(row["x"]) + 10}) for row in rows]
+
+    pipeline = from_items([{"x": value} for value in range(5)]).batch_map_async(
+        mapper,
+        batch_size=2,
+        max_in_flight=2,
+    )
+
+    rows = list(pipeline.iter_rows())
+
+    assert max_active == 2
+    assert sorted(batch_sizes) == [1, 2, 2]
+    assert [int(row["mapped"]) for row in rows] == [10, 11, 12, 13, 14]
+
+
+def test_async_batch_map_can_emit_completion_order() -> None:
+    async def mapper(rows: list[Row]) -> Iterable[Row]:
+        first = int(rows[0]["x"])
+        await asyncio.sleep(0.03 if first == 0 else 0.001)
+        return rows
+
+    rows = list(
+        from_items([{"x": value} for value in range(6)])
+        .batch_map_async(
+            mapper,
+            batch_size=2,
+            max_in_flight=2,
+            preserve_order=False,
+        )
+        .iter_rows()
+    )
+
+    assert [int(row["x"]) for row in rows[:2]] == [2, 3]
+    assert sorted(int(row["x"]) for row in rows) == list(range(6))
+
+
+def test_async_batch_factory_is_deferred_reused_and_closed() -> None:
+    instances: list[Mapper] = []
+
+    class Mapper:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.close_calls = 0
+
+        async def __call__(self, rows: list[Row]) -> Iterable[Row]:
+            self.calls += 1
+            return rows
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+
+    def create_mapper() -> Mapper:
+        mapper = Mapper()
+        instances.append(mapper)
+        return mapper
+
+    pipeline = from_items([{"x": value} for value in range(5)]).batch_map_async(
+        factory=create_mapper,
+        batch_size=2,
+        max_in_flight=2,
+    )
+    plan = compile_pipeline_plan(pipeline)
+    args = plan["stages"][0]["steps"][1]["args"]
+
+    assert args["batch_size"] == 2
+    assert args["max_in_flight"] == 2
+    assert "factory" in args
+    assert "fn" not in args
+    assert instances == []
+
+    assert len(list(pipeline.iter_rows())) == 5
+    assert len(instances) == 1
+    assert instances[0].calls == 3
+    assert instances[0].close_calls == 1
+
+
+def test_async_batch_map_updates_shard_cardinality_on_completion() -> None:
+    deltas: list[dict[str, int]] = []
+
+    async def keep_first(rows: list[Row]) -> Iterable[Row]:
+        return rows[:1]
+
+    output = list(
+        execute_row_steps(
+            [
+                DictRow({"x": 1}, shard_id="s1"),
+                DictRow({"x": 2}, shard_id="s1"),
+            ],
+            [
+                FnAsyncBatchStep(
+                    fn=keep_first,
+                    index=1,
+                    batch_size=2,
+                    max_in_flight=2,
+                )
+            ],
+            on_shard_delta=deltas.append,
+        )
+    )
+
+    assert [int(row["x"]) for row in output] == [1]
+    assert deltas == [{"s1": -1}]
+
+
+def test_async_batch_map_rejects_non_row_output() -> None:
+    async def invalid(_rows: list[Row]) -> Iterable[Row]:
+        return [{"x": 1}]  # type: ignore[list-item]
+
+    pipeline = from_items([{"x": 1}, {"x": 2}]).batch_map_async(
+        invalid,
+        batch_size=2,
+    )
+
+    with pytest.raises(TypeError, match="batch_map_async.*dict"):
+        list(pipeline.iter_rows())
+
+
+@pytest.mark.parametrize("max_in_flight", [0, -1])
+def test_async_batch_map_requires_positive_window(max_in_flight: int) -> None:
+    async def mapper(rows: list[Row]) -> Iterable[Row]:
+        return rows
+
+    with pytest.raises(ValueError, match="max_in_flight must be > 0"):
+        from_items([{"x": 1}]).batch_map_async(
+            mapper,
+            batch_size=2,
+            max_in_flight=max_in_flight,
+        )

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1563,6 +1563,100 @@ def test_parquet_sink_packs_embedded_assets_into_blob_files(tmp_path) -> None:
     assert datatype.asset_storage(out.schema.field("image")) == "blob_reference"
 
 
+def test_blob_writer_coalesces_complete_source_blob_references(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "source.blob"
+    source.write_bytes(b"abcdef")
+    output = DataFolder.resolve(tmp_path / "coalesced-assets")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(source), "offset": 0, "size": 3},
+                    {"path": str(source), "offset": 3, "size": 3},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=1024),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+
+    def unexpected_range_copy(*_args, **_kwargs):
+        raise AssertionError("complete source blob should not use per-range copies")
+
+    monkeypatch.setattr(manager, "_append", unexpected_range_copy)
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        rewritten = manager.rewrite_table("0123456789ab", table)
+        manager.close()
+
+    references = rewritten.column("video").to_pylist()
+    assert [read_blob(reference) for reference in references] == [b"abc", b"def"]
+    assert references[0]["path"] == references[1]["path"]
+    assert references[0]["offset"] == 0
+    assert references[1]["offset"] == 3
+
+
+def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "source.blob"
+    source.write_bytes(b"abcdef")
+    output = DataFolder.resolve(tmp_path / "partial-assets")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(source), "offset": 0, "size": 3},
+                    {"path": str(source), "offset": 3, "size": 2},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=1024),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+    calls = 0
+    original_append = manager._append
+
+    def count_range_copy(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_append(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "_append", count_range_copy)
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id="worker-1",
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        rewritten = manager.rewrite_table("0123456789ab", table)
+        manager.close()
+
+    assert calls == 2
+    assert [read_blob(reference) for reference in rewritten.column("video").to_pylist()] == [
+        b"abc",
+        b"de",
+    ]
+
+
 def test_file_asset_copy_removes_partial_output_when_source_disappears(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1796,13 +1796,61 @@ def test_blob_writer_rejects_same_complete_source_and_retry_destination(
             worker_name=None,
             runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
         ),
-        pytest.raises(
-            ValueError, match="packed blob source and destination must differ"
-        ),
+        pytest.raises(FileExistsError, match="packed blob destination already exists"),
     ):
         manager.rewrite_table(shard_id, table)
 
     assert source.read_bytes() == b"abcdef"
+
+
+def test_blob_writer_rejects_cross_blob_overwrite_before_reordered_copy(
+    tmp_path,
+) -> None:
+    output_path = tmp_path / "retry-assets"
+    output = DataFolder.resolve(output_path)
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    worker = worker_token_for(worker_id)
+    asset_dir = output_path / "assets" / f"{shard_id}__w{worker}" / "video"
+    asset_dir.mkdir(parents=True)
+    first = asset_dir / "00000.blob"
+    second = asset_dir / "00001.blob"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(second), "offset": 0, "size": 6},
+                    {"path": str(first), "offset": 0, "size": 5},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=6),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+
+    with (
+        set_active_run_context(
+            job_id="job",
+            stage_index=0,
+            worker_id=worker_id,
+            worker_name=None,
+            runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+        ),
+        pytest.raises(FileExistsError, match="packed blob destination already exists"),
+    ):
+        manager.rewrite_table(shard_id, table)
+
+    assert first.read_bytes() == b"first"
+    assert second.read_bytes() == b"second"
 
 
 def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -29,6 +29,7 @@ from refiner.pipeline.sinks.lance import (
     LanceDatasetCommitReducerSink,
     LanceDatasetSink,
     _StreamingAddColumnsWriter,
+    _cast_to_planned_schema,
     _job_token,
     _schema_to_base64,
 )
@@ -80,6 +81,23 @@ def test_iter_rows_ignores_sink(tmp_path) -> None:
     out = list(pipeline.iter_rows())
     assert [int(row["x"]) for row in out] == [1, 2]
     assert list(tmp_path.iterdir()) == []
+
+
+def test_lance_writer_normalizes_worker_schema_metadata() -> None:
+    planned = pa.schema(
+        [pa.field("x", pa.int64(), metadata={b"unit": b"planned"})],
+        metadata={b"schema": b"planned"},
+    )
+    worker_local = pa.schema(
+        [pa.field("x", pa.int64(), metadata={b"unit": b"worker"})],
+        metadata={b"schema": b"worker"},
+    )
+    table = pa.Table.from_arrays([pa.array([1, 2])], schema=worker_local)
+
+    normalized = _cast_to_planned_schema(table, planned)
+
+    assert normalized.schema.equals(planned, check_metadata=True)
+    assert normalized.to_pydict() == {"x": [1, 2]}
 
 
 def test_launch_local_writes_jsonl_per_shard(tmp_path) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1757,7 +1757,7 @@ def test_blob_writer_coalesces_complete_source_blob_references(
     assert references[1]["offset"] == 3
 
 
-def test_blob_writer_stages_complete_source_before_retry_destination_is_opened(
+def test_blob_writer_rejects_same_complete_source_and_retry_destination(
     tmp_path,
 ) -> None:
     output_path = tmp_path / "retry-assets"
@@ -1788,18 +1788,20 @@ def test_blob_writer_stages_complete_source_before_retry_destination_is_opened(
     )
     manager.set_input_schema(table.schema)
 
-    with set_active_run_context(
-        job_id="job",
-        stage_index=0,
-        worker_id=worker_id,
-        worker_name=None,
-        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    with (
+        set_active_run_context(
+            job_id="job",
+            stage_index=0,
+            worker_id=worker_id,
+            worker_name=None,
+            runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+        ),
+        pytest.raises(
+            ValueError, match="packed blob source and destination must differ"
+        ),
     ):
-        rewritten = manager.rewrite_table(shard_id, table)
-        manager.close()
+        manager.rewrite_table(shard_id, table)
 
-    references = rewritten.column("video").to_pylist()
-    assert [read_blob(reference) for reference in references] == [b"abc", b"def"]
     assert source.read_bytes() == b"abcdef"
 
 

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -100,6 +100,16 @@ def test_lance_writer_normalizes_worker_schema_metadata() -> None:
     assert normalized.to_pydict() == {"x": [1, 2]}
 
 
+def test_lance_writer_allows_row_map_dropped_planned_fields() -> None:
+    planned = pa.schema([pa.field("x", pa.int64()), pa.field("dropped", pa.string())])
+    table = pa.table({"x": [1, 2]})
+
+    normalized = _cast_to_planned_schema(table, planned)
+
+    assert normalized.schema.names == ["x"]
+    assert normalized.schema.field("x").type == pa.int64()
+
+
 def test_launch_local_writes_jsonl_per_shard(tmp_path) -> None:
     output_dir = tmp_path / "jsonl-output"
     pipeline = (

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -108,6 +108,16 @@ def test_lance_writer_normalizes_worker_schema_metadata() -> None:
     assert normalized.to_pydict() == {"x": [1, 2]}
 
 
+def test_lance_writer_preserves_runtime_inferred_type_changes() -> None:
+    planned = pa.schema([pa.field("value", pa.int64())])
+    runtime = pa.table({"value": ["chunk-1", "chunk-2"]})
+
+    normalized = _cast_to_planned_schema(runtime, planned)
+
+    assert normalized.schema == pa.schema([pa.field("value", pa.string())])
+    assert normalized.to_pydict() == {"value": ["chunk-1", "chunk-2"]}
+
+
 def test_lance_writer_allows_row_map_dropped_planned_fields() -> None:
     planned = pa.schema([pa.field("x", pa.int64()), pa.field("dropped", pa.string())])
     table = pa.table({"x": [1, 2]})
@@ -290,6 +300,30 @@ def test_launch_local_writes_lance_dataset(tmp_path) -> None:
         20,
         30,
     ]
+
+
+def test_lance_dataset_writer_preserves_undeclared_row_map_type_change(
+    tmp_path,
+) -> None:
+    lance = pytest.importorskip("lance")
+    source_uri = tmp_path / "dynamic-type-source.lance"
+    output_uri = tmp_path / "dynamic-type-output.lance"
+    source = lance.write_dataset(pa.table({"value": [1, 2]}), str(source_uri))
+
+    (
+        load_lance(source_uri, version=source.version)
+        .map(lambda row: {"value": f"chunk-{int(row['value'])}"})
+        .write_lance_dataset(output_uri)
+        .launch_local(
+            name="lance-dynamic-type",
+            num_workers=1,
+            rundir=str(tmp_path / "dynamic-type-run"),
+        )
+    )
+
+    table = lance.dataset(str(output_uri)).to_table()
+    assert table.schema.field("value").type == pa.string()
+    assert table.column("value").to_pylist() == ["chunk-1", "chunk-2"]
 
 
 def test_lance_dataset_writer_handles_more_shards_than_io_threads(tmp_path) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -118,6 +118,18 @@ def test_lance_writer_preserves_runtime_inferred_type_changes() -> None:
     assert normalized.to_pydict() == {"value": ["chunk-1", "chunk-2"]}
 
 
+def test_lance_writer_honors_explicitly_declared_type_changes() -> None:
+    planned = pa.schema([pa.field("value", pa.int64())])
+    runtime = pa.table({"value": ["1", "2"]})
+
+    normalized = _cast_to_planned_schema(
+        runtime, planned, declared_columns=frozenset({"value"})
+    )
+
+    assert normalized.schema == planned
+    assert normalized.to_pydict() == {"value": [1, 2]}
+
+
 def test_lance_writer_allows_row_map_dropped_planned_fields() -> None:
     planned = pa.schema([pa.field("x", pa.int64()), pa.field("dropped", pa.string())])
     table = pa.table({"x": [1, 2]})
@@ -324,6 +336,31 @@ def test_lance_dataset_writer_preserves_undeclared_row_map_type_change(
     table = lance.dataset(str(output_uri)).to_table()
     assert table.schema.field("value").type == pa.string()
     assert table.column("value").to_pylist() == ["chunk-1", "chunk-2"]
+
+
+def test_lance_dataset_writer_enforces_declared_row_map_dtype(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    source_uri = tmp_path / "declared-type-source.lance"
+    output_uri = tmp_path / "declared-type-output.lance"
+    source = lance.write_dataset(pa.table({"value": [1, 2]}), str(source_uri))
+
+    (
+        load_lance(source_uri, version=source.version)
+        .map(
+            lambda row: {"value": str(int(row["value"]))},
+            dtypes={"value": pa.int64()},
+        )
+        .write_lance_dataset(output_uri)
+        .launch_local(
+            name="lance-declared-type",
+            num_workers=1,
+            rundir=str(tmp_path / "declared-type-run"),
+        )
+    )
+
+    table = lance.dataset(str(output_uri)).to_table()
+    assert table.schema.field("value").type == pa.int64()
+    assert table.column("value").to_pylist() == [1, 2]
 
 
 def test_lance_dataset_writer_handles_more_shards_than_io_threads(tmp_path) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -1757,6 +1757,52 @@ def test_blob_writer_coalesces_complete_source_blob_references(
     assert references[1]["offset"] == 3
 
 
+def test_blob_writer_stages_complete_source_before_retry_destination_is_opened(
+    tmp_path,
+) -> None:
+    output_path = tmp_path / "retry-assets"
+    output = DataFolder.resolve(output_path)
+    shard_id = "0123456789ab"
+    worker_id = "worker-1"
+    worker = worker_token_for(worker_id)
+    source = output_path / "assets" / f"{shard_id}__w{worker}" / "video" / "00000.blob"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"abcdef")
+    field = datatype.blob_reference("video").with_name("video")
+    table = pa.Table.from_arrays(
+        [
+            pa.array(
+                [
+                    {"path": str(source), "offset": 0, "size": 3},
+                    {"path": str(source), "offset": 3, "size": 3},
+                ],
+                type=field.type,
+            )
+        ],
+        schema=pa.schema([field]),
+    )
+    manager = BlobAssetManager(
+        output,
+        config=BlobAssetConfig(target_bytes=1024),
+        filename_template="{shard_id}.parquet",
+    )
+    manager.set_input_schema(table.schema)
+
+    with set_active_run_context(
+        job_id="job",
+        stage_index=0,
+        worker_id=worker_id,
+        worker_name=None,
+        runtime_lifecycle=cast(RuntimeLifecycle, _FinalizedWorkersRuntime([])),
+    ):
+        rewritten = manager.rewrite_table(shard_id, table)
+        manager.close()
+
+    references = rewritten.column("video").to_pylist()
+    assert [read_blob(reference) for reference in references] == [b"abc", b"def"]
+    assert source.read_bytes() == b"abcdef"
+
+
 def test_blob_writer_keeps_partial_source_blob_on_range_copy_path(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/pipeline/test_sinks.py
+++ b/tests/pipeline/test_sinks.py
@@ -11,7 +11,7 @@ import pyarrow.parquet as pq
 import pytest
 from fsspec.implementations.memory import MemoryFileSystem
 
-from refiner import col, read_blob
+from refiner import AddColumns, Append, Create, Overwrite, col, read_blob
 from refiner.io import DataFolder
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.row import DictRow, Row
@@ -48,6 +48,14 @@ class _FinalizedWorkersRuntime:
     ) -> list[FinalizedShardWorker]:
         assert stage_index == 0
         return self._rows
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [(Create(), "create"), (Append(), "append"), (Overwrite(), "overwrite")],
+)
+def test_lance_write_mode_dataclasses_normalize(mode, expected, tmp_path) -> None:
+    assert LanceDatasetSink(tmp_path / "output.lance", mode=mode).mode == expected
 
 
 class _PartialMissingStream:
@@ -483,6 +491,83 @@ def test_lance_add_columns_handles_more_fragments_than_io_threads(tmp_path) -> N
         "x": list(range(12)),
         "y": [value * 10 for value in range(12)],
     }
+
+
+def test_lance_add_columns_fills_filtered_rows(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "filtered-column-fill.lance"
+    base = lance.write_dataset(
+        pa.table({"x": list(range(6))}),
+        str(dataset_uri),
+        max_rows_per_file=2,
+    )
+
+    (
+        load_lance(dataset_uri, version=base.version)
+        .filter(lambda row: int(row["x"]) % 2 == 0)
+        .map(lambda row: {"y": int(row["x"]) * 10}, dtypes={"y": datatype.int64()})
+        .write_lance_dataset(
+            dataset_uri,
+            mode=AddColumns(fill={"y": -1}),
+            columns=["y"],
+        )
+        .launch_local(
+            name="lance-filtered-column-fill",
+            num_workers=1,
+            rundir=str(tmp_path / "filtered-column-fill-run"),
+        )
+    )
+
+    assert lance.dataset(str(dataset_uri)).to_table().to_pydict() == {
+        "x": list(range(6)),
+        "y": [0, -1, 20, -1, 40, -1],
+    }
+
+
+def test_lance_add_columns_fills_when_every_row_is_filtered(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "all-filtered-column-fill.lance"
+    base = lance.write_dataset(
+        pa.table({"x": list(range(4))}),
+        str(dataset_uri),
+        max_rows_per_file=2,
+    )
+
+    (
+        load_lance(dataset_uri, version=base.version)
+        .map(lambda _row: {"y": 0}, dtypes={"y": datatype.int64()})
+        .filter(lambda _row: False)
+        .write_lance_dataset(
+            dataset_uri,
+            mode=AddColumns(fill={"y": -1}),
+            columns=["y"],
+        )
+        .launch_local(
+            name="lance-all-filtered-column-fill",
+            num_workers=1,
+            rundir=str(tmp_path / "all-filtered-column-fill-run"),
+        )
+    )
+
+    assert lance.dataset(str(dataset_uri)).to_table().to_pydict() == {
+        "x": list(range(4)),
+        "y": [-1, -1, -1, -1],
+    }
+
+
+def test_lance_add_columns_rejects_unknown_fill_column(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "unknown-fill-column.lance"
+    base = lance.write_dataset(pa.table({"x": [1]}), str(dataset_uri))
+
+    with pytest.raises(ValueError, match="unknown columns: z"):
+        LanceDatasetSink(
+            dataset_uri,
+            mode=AddColumns(fill={"z": 0}),
+            columns=["y"],
+            source_uri=str(dataset_uri),
+            source_version=base.version,
+        )
 
 
 def test_lance_add_columns_accepts_equivalent_nested_metadata_order(tmp_path) -> None:

--- a/tests/pipeline/test_worker_factories.py
+++ b/tests/pipeline/test_worker_factories.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+from refiner.pipeline import from_items
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.planning import compile_pipeline_plan
+
+
+def test_map_table_factory_is_deferred_and_reused_per_execution() -> None:
+    factory_calls = 0
+    mapper_calls: list[int] = []
+
+    class Mapper:
+        def __call__(self, table: pa.Table) -> pa.Table:
+            mapper_calls.append(table.num_rows)
+            return table.append_column(
+                "call_rows",
+                pa.array([table.num_rows] * table.num_rows),
+            )
+
+    def create_mapper() -> Mapper:
+        nonlocal factory_calls
+        factory_calls += 1
+        return Mapper()
+
+    pipeline = (
+        from_items([{"x": value} for value in range(5)], items_per_shard=2)
+        .with_max_block_rows(2)
+        .map_table(factory=create_mapper)
+    )
+
+    assert pipeline.output_schema() is None
+    plan = compile_pipeline_plan(pipeline)
+    step_args = plan["stages"][0]["steps"][1]["args"]
+    assert "factory" in step_args
+    assert "fn" not in step_args
+    cloudpickle.dumps(pipeline)
+    assert factory_calls == 0
+
+    rows = list(pipeline.iter_rows())
+
+    assert factory_calls == 1
+    assert mapper_calls == [2, 2, 1]
+    assert [int(row["call_rows"]) for row in rows] == [2, 2, 2, 2, 1]
+
+    list(pipeline.iter_rows())
+    assert factory_calls == 2
+    assert mapper_calls == [2, 2, 1, 2, 2, 1]
+
+
+def test_batch_map_factory_is_reused_across_batches_and_shards() -> None:
+    instances: list[BatchMapper] = []
+
+    class BatchMapper:
+        def __init__(self) -> None:
+            self.batch_sizes: list[int] = []
+
+        def __call__(self, rows: list[Row]) -> Iterable[Row]:
+            self.batch_sizes.append(len(rows))
+            return [row.update({"batch_size": len(rows)}) for row in rows]
+
+    def create_mapper() -> BatchMapper:
+        mapper = BatchMapper()
+        instances.append(mapper)
+        return mapper
+
+    pipeline = from_items(
+        [{"x": value} for value in range(5)], items_per_shard=1
+    ).batch_map(factory=create_mapper, batch_size=2)
+
+    rows = list(pipeline.iter_rows())
+
+    assert len(instances) == 1
+    assert instances[0].batch_sizes == [2, 2, 1]
+    assert [int(row["batch_size"]) for row in rows] == [2, 2, 2, 2, 1]
+
+
+def test_map_async_factory_is_reused_and_closed() -> None:
+    instances: list[AsyncMapper] = []
+
+    class AsyncMapper:
+        def __init__(self) -> None:
+            self.values: list[int] = []
+            self.close_calls = 0
+
+        async def __call__(self, row: Row) -> dict[str, int]:
+            value = int(row["x"])
+            self.values.append(value)
+            return {"mapped": value + 1}
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+
+    def create_mapper() -> AsyncMapper:
+        mapper = AsyncMapper()
+        instances.append(mapper)
+        return mapper
+
+    pipeline = from_items(
+        [{"x": value} for value in range(4)], items_per_shard=1
+    ).map_async(
+        factory=create_mapper,
+        max_in_flight=2,
+    )
+
+    rows = list(pipeline.iter_rows())
+
+    assert [int(row["mapped"]) for row in rows] == [1, 2, 3, 4]
+    assert len(instances) == 1
+    assert instances[0].values == [0, 1, 2, 3]
+    assert instances[0].close_calls == 1
+
+
+@pytest.mark.parametrize("operation", ["map_table", "batch_map", "map_async"])
+def test_worker_factory_must_return_callable(operation: str) -> None:
+    pipeline = from_items([{"x": 1}])
+    if operation == "map_table":
+        pipeline = pipeline.map_table(factory=lambda: object())
+    elif operation == "batch_map":
+        pipeline = pipeline.batch_map(factory=lambda: object(), batch_size=2)
+    else:
+        pipeline = pipeline.map_async(factory=lambda: object())
+
+    with pytest.raises(TypeError, match="factory must return a callable"):
+        list(pipeline.iter_rows())
+
+
+def test_transforms_require_exactly_one_callback_or_factory() -> None:
+    pipeline = from_items([{"x": 1}])
+
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.map_table()
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.map_table(lambda table: table, factory=lambda: lambda table: table)
+
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.batch_map(batch_size=2)
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.batch_map(
+            lambda rows: rows,
+            factory=lambda: lambda rows: rows,
+            batch_size=2,
+        )
+
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.map_async()
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.map_async(lambda row: row, factory=lambda: lambda row: row)

--- a/tests/pipeline/test_worker_factories.py
+++ b/tests/pipeline/test_worker_factories.py
@@ -116,13 +116,17 @@ def test_map_async_factory_is_reused_and_closed() -> None:
     assert instances[0].close_calls == 1
 
 
-@pytest.mark.parametrize("operation", ["map_table", "batch_map", "map_async"])
+@pytest.mark.parametrize(
+    "operation", ["map_table", "batch_map", "batch_map_async", "map_async"]
+)
 def test_worker_factory_must_return_callable(operation: str) -> None:
     pipeline = from_items([{"x": 1}])
     if operation == "map_table":
         pipeline = pipeline.map_table(factory=lambda: object())
     elif operation == "batch_map":
         pipeline = pipeline.batch_map(factory=lambda: object(), batch_size=2)
+    elif operation == "batch_map_async":
+        pipeline = pipeline.batch_map_async(factory=lambda: object(), batch_size=2)
     else:
         pipeline = pipeline.map_async(factory=lambda: object())
 
@@ -142,6 +146,15 @@ def test_transforms_require_exactly_one_callback_or_factory() -> None:
         pipeline.batch_map(batch_size=2)
     with pytest.raises(ValueError, match="exactly one of fn or factory"):
         pipeline.batch_map(
+            lambda rows: rows,
+            factory=lambda: lambda rows: rows,
+            batch_size=2,
+        )
+
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.batch_map_async(batch_size=2)
+    with pytest.raises(ValueError, match="exactly one of fn or factory"):
+        pipeline.batch_map_async(
             lambda rows: rows,
             factory=lambda: lambda rows: rows,
             batch_size=2,

--- a/tests/pipeline/test_worker_factories.py
+++ b/tests/pipeline/test_worker_factories.py
@@ -116,6 +116,37 @@ def test_map_async_factory_is_reused_and_closed() -> None:
     assert instances[0].close_calls == 1
 
 
+def test_factory_initialization_failure_closes_earlier_async_callable() -> None:
+    instances: list[AsyncMapper] = []
+
+    class AsyncMapper:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def __call__(self, row: Row) -> Row:
+            return row
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+
+    def create_mapper() -> AsyncMapper:
+        mapper = AsyncMapper()
+        instances.append(mapper)
+        return mapper
+
+    pipeline = (
+        from_items([{"x": 1}])
+        .map_async(factory=create_mapper)
+        .map_async(factory=lambda: object())
+    )
+
+    with pytest.raises(TypeError, match="factory must return a callable"):
+        list(pipeline.iter_rows())
+
+    assert len(instances) == 1
+    assert instances[0].close_calls == 1
+
+
 @pytest.mark.parametrize(
     "operation", ["map_table", "batch_map", "batch_map_async", "map_async"]
 )

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -4,7 +4,7 @@ import pyarrow as pa
 import pytest
 from fsspec.implementations.memory import MemoryFileSystem
 
-from refiner import load_lance, read_blob
+from refiner import AddColumns, load_lance, read_blob
 from refiner.pipeline.data import datatype
 from refiner.pipeline.data.shard import SOURCE_ROW_ID_COLUMN, RowRangeDescriptor
 from refiner.pipeline.sources.lance import LanceSource
@@ -195,6 +195,36 @@ def test_limited_lance_source_rejects_add_columns(tmp_path) -> None:
             mode="add_columns",
             columns=["y"],
         )
+
+
+def test_limited_lance_source_adds_columns_with_null_fill(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "limited-add-columns-fill.lance"
+    base = lance.write_dataset(
+        pa.table({"x": list(range(8))}),
+        str(dataset_uri),
+        max_rows_per_file=3,
+    )
+
+    (
+        load_lance(dataset_uri, version=base.version, row_limit=4, batch_size=2)
+        .map(lambda row: {"y": int(row["x"]) * 10}, dtypes={"y": datatype.int64()})
+        .write_lance_dataset(
+            dataset_uri,
+            mode=AddColumns(),
+            columns=["y"],
+        )
+        .launch_local(
+            name="limited-add-columns-fill",
+            num_workers=1,
+            rundir=str(tmp_path / "limited-add-columns-fill-run"),
+        )
+    )
+
+    assert lance.dataset(str(dataset_uri)).to_table().to_pydict() == {
+        "x": list(range(8)),
+        "y": [0, 10, 20, 30, None, None, None, None],
+    }
 
 
 def test_load_lance_uses_physical_row_addresses_as_source_row_ids(tmp_path) -> None:

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -19,8 +19,8 @@ def test_load_lance_rejects_explicit_shard_count_above_limit() -> None:
 def test_load_lance_caps_automatic_shards_without_dropping_fragments() -> None:
     source = object.__new__(LanceSource)
     source.num_shards = None
-    source.row_limit = None
-    source._fragment_row_limits = None
+    source.max_rows = None
+    source._planned_rows_by_fragment = None
     source._dataset_cache = type(
         "Dataset",
         (),
@@ -208,28 +208,22 @@ def test_load_lance_limits_leading_rows_across_fragments(tmp_path) -> None:
         dataset_uri,
         batch_size=2,
         num_shards=2,
-        row_limit=5,
+        max_rows=5,
     )
 
     assert [int(row["x"]) for row in pipeline.iter_rows()] == list(range(5))
     assert len(pipeline.list_shards()) == 2
-    assert pipeline.source.describe()["row_limit"] == 5
+    assert pipeline.source.describe()["max_rows"] == 5
 
 
-def test_load_lance_row_limit_allows_short_dataset(tmp_path) -> None:
+def test_load_lance_max_rows_allows_short_dataset(tmp_path) -> None:
     lance = pytest.importorskip("lance")
     dataset_uri = tmp_path / "short.lance"
     lance.write_dataset(pa.table({"x": [1, 2]}), str(dataset_uri))
 
     assert [
-        int(row["x"]) for row in load_lance(dataset_uri, row_limit=10).iter_rows()
+        int(row["x"]) for row in load_lance(dataset_uri, max_rows=10).iter_rows()
     ] == [1, 2]
-
-
-@pytest.mark.parametrize("row_limit", [0, -1])
-def test_load_lance_rejects_nonpositive_row_limit(row_limit: int) -> None:
-    with pytest.raises(ValueError, match="row_limit must be > 0"):
-        LanceSource("unused.lance", row_limit=row_limit)
 
 
 def test_limited_lance_source_rejects_add_columns(tmp_path) -> None:
@@ -238,7 +232,7 @@ def test_limited_lance_source_rejects_add_columns(tmp_path) -> None:
     lance.write_dataset(pa.table({"x": [1, 2]}), str(dataset_uri))
 
     with pytest.raises(ValueError, match="limited Lance source"):
-        load_lance(dataset_uri, row_limit=1).write_lance_dataset(
+        load_lance(dataset_uri, max_rows=1).write_lance_dataset(
             dataset_uri,
             mode="add_columns",
             columns=["y"],
@@ -255,7 +249,7 @@ def test_limited_lance_source_adds_columns_with_null_fill(tmp_path) -> None:
     )
 
     (
-        load_lance(dataset_uri, version=base.version, row_limit=4, batch_size=2)
+        load_lance(dataset_uri, version=base.version, max_rows=4, batch_size=2)
         .map(lambda row: {"y": int(row["x"]) * 10}, dtypes={"y": datatype.int64()})
         .write_lance_dataset(
             dataset_uri,

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -62,6 +62,54 @@ def test_load_lance_pins_version_and_shards_by_fragment(tmp_path) -> None:
     assert [int(row["x"]) for row in pipeline.iter_rows()] == [1, 2, 3]
 
 
+def test_load_lance_max_rows_bounds_fragment_plan_and_final_batch(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "limited.lance"
+    lance.write_dataset(
+        pa.table({"x": list(range(6))}),
+        str(dataset_uri),
+        max_rows_per_file=2,
+    )
+
+    pipeline = load_lance(dataset_uri, batch_size=2, max_rows=3)
+    shards = pipeline.list_shards()
+
+    assert [(shard.descriptor.start, shard.descriptor.end) for shard in shards] == [
+        (0, 1),
+        (1, 2),
+    ]
+    assert [int(row["x"]) for row in pipeline.iter_rows()] == [0, 1, 2]
+    assert pipeline.source.describe()["max_rows"] == 3
+
+
+def test_load_lance_max_rows_zero_and_negative(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "zero.lance"
+    lance.write_dataset(pa.table({"x": [1]}), str(dataset_uri))
+
+    assert load_lance(dataset_uri, max_rows=0).list_shards() == []
+    assert list(load_lance(dataset_uri, max_rows=0).iter_rows()) == []
+    with pytest.raises(ValueError, match="max_rows must be >= 0"):
+        load_lance(dataset_uri, max_rows=-1)
+
+
+def test_load_lance_max_rows_groups_only_required_fragments(tmp_path) -> None:
+    lance = pytest.importorskip("lance")
+    dataset_uri = tmp_path / "grouped-limited.lance"
+    lance.write_dataset(
+        pa.table({"x": list(range(6))}),
+        str(dataset_uri),
+        max_rows_per_file=2,
+    )
+
+    pipeline = load_lance(dataset_uri, max_rows=3, num_shards=1)
+    shards = pipeline.list_shards()
+
+    assert len(shards) == 1
+    assert (shards[0].descriptor.start, shards[0].descriptor.end) == (0, 2)
+    assert [int(row["x"]) for row in pipeline.iter_rows()] == [0, 1, 2]
+
+
 def test_load_lance_normalizes_classic_blobs_to_references(tmp_path) -> None:
     lance = pytest.importorskip("lance")
     dataset_uri = tmp_path / "blobs.lance"

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -574,6 +574,31 @@ def test_worker_propagates_async_teardown_failure_after_completion() -> None:
     assert runtime_lifecycle.failed_ids == []
 
 
+def test_worker_propagates_factory_failure_before_claiming_a_shard() -> None:
+    def fail_factory():
+        raise RuntimeError("factory initialization failed")
+
+    pipeline = task(
+        lambda rank, _world_size: {"rank": rank},
+        num_tasks=1,
+    ).map_async(factory=fail_factory)
+    runtime_lifecycle = _FakeRuntimeLifecycle(pipeline.list_shards())
+    worker = Worker(
+        pipeline=pipeline,
+        job_id="job",
+        stage_index=0,
+        worker_id="local",
+        runtime_lifecycle=runtime_lifecycle,
+    )
+
+    with pytest.raises(RuntimeError, match="factory initialization failed"):
+        worker.run()
+
+    assert runtime_lifecycle.claim_previous == []
+    assert runtime_lifecycle.completed_ids == []
+    assert runtime_lifecycle.failed_ids == []
+
+
 def test_task_worker_stops_claiming_after_heartbeat_failure() -> None:
     heartbeat_should_fail = threading.Event()
 


### PR DESCRIPTION
## Summary

This consolidates the Refiner primitives needed by the production hand-feature pipeline:

- add bounded Lance reads with the single `max_rows` name
- add `AddColumns(fill=...)` for row-aligned partial Lance column updates, including bounded/filtered sources and retry-stable untouched-fragment synthesis
- add worker-local transform factories so expensive model state initializes once per worker
- add bounded asynchronous batch transforms for overlapping CPU preparation, serialized GPU inference, and downstream work without making the whole engine async
- coalesce complete references to the same packed blob and normalize distributed Lance-writer schemas
- allow dynamic row-map field removal and fix blob-reference type narrowing
- document each public primitive and its intended bounded-inference usage

The intentionally unsafe attempted overlap of packed-blob reads/uploads remains reverted.

## Validation

- Full CI: passing
- CodeQL: passing
- Local suite previously: `1204 passed, 22 skipped`
- Dedicated coverage added for:
  - bounded/filtered filled Lance updates
  - worker-local stateful factories
  - bounded async batch ordering, backpressure, and failure propagation
  - Lance source `max_rows` behavior
