### PR TITLE
Add global max_rows limits to built-in readers

### DIFF
--- a/docs/reading-data/index.md
+++ b/docs/reading-data/index.md
@@ -77,14 +77,3 @@ it. A reader may still need to load one indivisible physical unit to produce a
 row—for example, one whole-file JSON document, HDF5 group, MCAP episode, or
 LeRobot episode. The limit bounds later work but cannot make that first logical
 row smaller.
-
-## Internal Notes
-
-Spark, Daft, and Ray Data can represent a limit as a distributed logical-plan
-node, with their schedulers coordinating partitions and ordering. Beam/Dataflow
-treats collections as unordered, so a deterministic leading-row limit requires
-additional ordering or runner-specific behavior. Hugging Face Datasets offers
-simple local selection or iterable `take` operations. Refiner follows the latter
-DX but exposes one deterministic scheduling shard for limited runs. This trades
-parallelism—which is not useful for a small smoke test—for an exact global cap
-without adding distributed limit coordination to the worker protocol.

--- a/docs/reading-data/index.md
+++ b/docs/reading-data/index.md
@@ -66,15 +66,17 @@ cannot each emit the requested number of rows. Consequently,
 
 The option is available on `read_csv`, `read_json`, `read_jsonl`, `read_files`,
 `read_videos`, `read_hdf5`, `read_zarr`, `read_mcap`, `read_parquet`,
-`read_hf_dataset`, `read_lerobot`, `read_tfrecords`, and `read_tfds`.
-`load_lance` provides the same public option through its native indexed limit.
+`read_hf_dataset`, `read_lerobot`, `read_tfrecords`, `read_tfds`, and
+`load_lance`. All use the same bounded-source wrapper.
 
 Readers stop before opening later source shards and slice the final Arrow batch.
-Refiner also reduces configurable batch or concurrency windows for Parquet,
-Hugging Face, file-content, Zarr, TFRecord, and TFDS readers. A reader may still
-need to load one indivisible physical unit to produce a row—for example, one
-whole-file JSON document, HDF5 group, MCAP episode, or LeRobot episode. The
-limit bounds later work but cannot make that first logical row smaller.
+Refiner also reduces configurable batch or concurrency windows for Lance,
+Parquet, Hugging Face, file-content, Zarr, LeRobot, TFRecord, and TFDS readers;
+bounded split MCAP reads stream one episode at a time when the input supports
+it. A reader may still need to load one indivisible physical unit to produce a
+row—for example, one whole-file JSON document, HDF5 group, MCAP episode, or
+LeRobot episode. The limit bounds later work but cannot make that first logical
+row smaller.
 
 ## Internal Notes
 

--- a/docs/reading-data/index.md
+++ b/docs/reading-data/index.md
@@ -39,3 +39,50 @@ pipeline = mdr.read_lerobot("hf://datasets/lerobot/aloha_sim_transfer_cube_human
 
 Read [Reader Model](reader-model.md) and [Sharding](sharding.md) before writing
 large jobs.
+
+## Run a bounded quick test
+
+Pass `max_rows` to a built-in reader before testing transforms or allocating a
+full cloud run:
+
+```python
+import refiner as mdr
+
+pipeline = mdr.read_parquet(
+    "s3://my-bucket/episodes/*.parquet",
+    columns_to_read=["episode_id", "video"],
+    max_rows=100,
+)
+
+rows = pipeline.take(5)
+```
+
+`max_rows` is a global source-output cap, not a per-worker cap. It applies after
+reader-level operations such as Parquet or Hugging Face filtering, but before
+pipeline transforms. A positive limit uses one source shard so multiple workers
+cannot each emit the requested number of rows. Consequently,
+`num_workers="auto"` starts at most one worker for a limited source. Set
+`max_rows=0` to execute no source shards.
+
+The option is available on `read_csv`, `read_json`, `read_jsonl`, `read_files`,
+`read_videos`, `read_hdf5`, `read_zarr`, `read_mcap`, `read_parquet`,
+`read_hf_dataset`, `read_lerobot`, `read_tfrecords`, and `read_tfds`.
+`load_lance` provides the same public option through its native indexed limit.
+
+Readers stop before opening later source shards and slice the final Arrow batch.
+Refiner also reduces configurable batch or concurrency windows for Parquet,
+Hugging Face, file-content, Zarr, TFRecord, and TFDS readers. A reader may still
+need to load one indivisible physical unit to produce a row—for example, one
+whole-file JSON document, HDF5 group, MCAP episode, or LeRobot episode. The
+limit bounds later work but cannot make that first logical row smaller.
+
+## Internal Notes
+
+Spark, Daft, and Ray Data can represent a limit as a distributed logical-plan
+node, with their schedulers coordinating partitions and ordering. Beam/Dataflow
+treats collections as unordered, so a deterministic leading-row limit requires
+additional ordering or runner-specific behavior. Hugging Face Datasets offers
+simple local selection or iterable `take` operations. Refiner follows the latter
+DX but exposes one deterministic scheduling shard for limited runs. This trades
+parallelism—which is not useful for a small smoke test—for an exact global cap
+without adding distributed limit coordination to the worker protocol.

--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -33,8 +33,10 @@ controls the streamed Arrow batch size.
 ## Limit the number of rows
 
 Set `max_rows` to a non-negative integer to read only that many leading rows from
-the pinned dataset version. Refiner stops scanning inside the final fragment;
-datasets with fewer rows simply yield all available rows.
+the pinned dataset version. Refiner uses the same global bounded-source wrapper
+as other built-in readers, stops after the final required Arrow batch, and
+slices that batch when necessary. Datasets with fewer rows simply yield all
+available rows.
 
 The limit is applied before pipeline transforms. Omit `max_rows` to read the
 entire pinned version, or use `max_rows=0` to produce no source rows. For

--- a/docs/reading-data/mcap.md
+++ b/docs/reading-data/mcap.md
@@ -321,6 +321,10 @@ stream non-seekable or unindexed files in physical file order instead. When
 `episode_splitting="single"`, `stream_episodes` is ignored because the single
 episode is the whole file.
 
+Bounded split reads enable this mode automatically. For example,
+`read_mcap(..., episode_splitting={"time_gap_s": 5}, max_rows=1)` stops after
+the first episode without buffering every episode in a seekable indexed file.
+
 For non-seekable streams without an MCAP summary, explicit dotted selections may
 still require scanning all topics because the reader cannot resolve source
 strings to exact MCAP topics before reading.

--- a/docs/reading-data/sharding.md
+++ b/docs/reading-data/sharding.md
@@ -62,6 +62,11 @@ plan within the 10,000-shard hard limit.
 Do not overfit shard count before measuring. Too few shards leave workers idle;
 too many shards add scheduling and output overhead.
 
+When a built-in reader receives `max_rows`, Refiner exposes one bounded source
+shard regardless of `num_shards`. This is intentional: the limit is global, so
+running several independently capped shards could emit `max_rows` from every
+worker. Remove `max_rows` for the production shard plan.
+
 ## Shards and writers
 
 Writers usually write shard-local files first. Some writers add a reducer stage

--- a/src/refiner/pipeline/data/shard.py
+++ b/src/refiner/pipeline/data/shard.py
@@ -145,7 +145,51 @@ class RowRangeDescriptor:
         return None
 
 
-ShardDescriptor = FilePartsDescriptor | RowRangeDescriptor
+@dataclass(frozen=True, slots=True)
+class ShardGroupDescriptor:
+    """Ordered source shards executed as one scheduling unit.
+
+    This keeps a wrapper source's physical plan attached to the claimed shard,
+    so remote workers do not need to discover or re-plan the child shards.
+    """
+
+    shards: tuple[Shard, ...]
+
+    def __post_init__(self) -> None:
+        if not self.shards:
+            raise ValueError("shard group must be non-empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "shard_group",
+            "shards": [shard.to_dict() for shard in self.shards],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ShardGroupDescriptor:
+        shards = payload["shards"]
+        if not isinstance(shards, list):
+            raise ValueError("shard-group descriptor must contain a shards list")
+        if any(not isinstance(shard, dict) for shard in shards):
+            raise ValueError("shard-group descriptor shards must be objects")
+        return cls(tuple(Shard.from_dict(shard) for shard in shards))
+
+    def update_hash(self, h: _HashWriter) -> None:
+        h.update(b"shard_group\0")
+        for shard in self.shards:
+            h.update(shard.id.encode("ascii"))
+            h.update(b"\0")
+
+    @property
+    def descriptor_start_key(self) -> str | None:
+        return self.shards[0].start_key
+
+    @property
+    def descriptor_end_key(self) -> str | None:
+        return self.shards[-1].end_key
+
+
+ShardDescriptor = FilePartsDescriptor | RowRangeDescriptor | ShardGroupDescriptor
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,6 +281,8 @@ class Shard:
             )
         elif kind == "row_range":
             parsed_descriptor = RowRangeDescriptor.from_dict(descriptor)
+        elif kind == "shard_group":
+            parsed_descriptor = ShardGroupDescriptor.from_dict(descriptor)
         else:
             raise ValueError(f"unsupported shard descriptor kind: {kind!r}")
         global_ordinal = payload.get("global_ordinal")
@@ -270,5 +316,6 @@ __all__ = [
     "RowRangeDescriptor",
     "Shard",
     "ShardDescriptor",
+    "ShardGroupDescriptor",
     "path_hash",
 ]

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -57,6 +57,7 @@ from refiner.pipeline.sources import (
     Hdf5Reader,
     JsonReader,
     LanceSource,
+    LimitedSource,
     limit_source,
     McapReader,
     ParquetReader,
@@ -776,14 +777,20 @@ class RefinerPipeline:
         source_version: int | None = None
         is_add_columns = mode == "add_columns" or isinstance(mode, AddColumns)
         if is_add_columns:
-            if not isinstance(self.source, LanceSource):
+            source = self.source
+            if isinstance(source, LimitedSource):
+                is_limited = True
+                source = source.source
+            else:
+                is_limited = False
+            if not isinstance(source, LanceSource):
                 raise ValueError(
                     "add_columns requires a pipeline created by load_lance"
                 )
-            if self.source.max_rows is not None and not isinstance(mode, AddColumns):
+            if is_limited and not isinstance(mode, AddColumns):
                 raise ValueError("add_columns does not support a limited Lance source")
-            source_uri = self.source.dataset_uri
-            source_version = self.source.version
+            source_uri = source.dataset_uri
+            source_version = source.version
         return self.with_sink(
             LanceDatasetSink(
                 output=output,
@@ -1535,14 +1542,17 @@ def load_lance(
     number of scheduling shards without splitting individual fragments.
     ``max_rows`` reads at most that many leading rows from the pinned version.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=LanceSource(
-            input,
-            version=version,
-            columns=columns,
-            batch_size=batch_size,
-            num_shards=num_shards,
-            max_rows=max_rows,
+        source=limit_source(
+            LanceSource(
+                input,
+                version=version,
+                columns=columns,
+                batch_size=_bounded_reader_window(batch_size, max_rows),
+                num_shards=num_shards,
+            ),
+            max_rows,
         )
     )
 

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1467,7 +1467,8 @@ def read_mcap(
                 num_shards=num_shards,
                 file_path_column=file_path_column,
                 episode_splitting=episode_splitting,
-                stream_episodes=stream_episodes,
+                stream_episodes=stream_episodes
+                or (max_rows is not None and episode_splitting != "single"),
                 assume_log_time_order=assume_log_time_order,
                 fields=fields,
                 videos=videos,

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1688,9 +1688,7 @@ def read_tfrecords(
                     else num_parallel_calls
                 ),
                 prefetch=(
-                    min(prefetch, 1)
-                    if max_rows is not None and prefetch is not None
-                    else prefetch
+                    1 if max_rows is not None and prefetch is not None else prefetch
                 ),
                 file_path_column=file_path_column,
             ),

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -57,6 +57,7 @@ from refiner.pipeline.sources import (
     Hdf5Reader,
     JsonReader,
     LanceSource,
+    limit_source,
     McapReader,
     ParquetReader,
     TfdsReader,
@@ -1010,6 +1011,27 @@ class RefinerPipeline:
 
 
 ## readers
+def _validated_max_rows(max_rows: int | None) -> int | None:
+    if max_rows is not None and max_rows < 0:
+        raise ValueError("max_rows must be >= 0")
+    return int(max_rows) if max_rows is not None else None
+
+
+def _bounded_reader_window(value: int, max_rows: int | None) -> int:
+    if max_rows is None:
+        return value
+    return min(value, max(1, int(max_rows)))
+
+
+def _bounded_optional_reader_window(
+    value: int | None, max_rows: int | None
+) -> int | None:
+    if max_rows is None:
+        return value
+    limit = max(1, int(max_rows))
+    return limit if value is None else min(value, limit)
+
+
 def read_csv(
     inputs: DataFileSetLike,
     *,
@@ -1018,6 +1040,7 @@ def read_csv(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "file_path",
     multiline_rows: bool = False,
     encoding: str = "utf-8",
@@ -1028,20 +1051,25 @@ def read_csv(
 
     `num_shards` and `target_shard_bytes` affect input shard planning on the
     reader side. `parse_use_threads` controls Arrow's intra-shard CSV parsing.
+    `max_rows` caps emitted source rows before pipeline transforms.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=CsvReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            file_path_column=file_path_column,
-            multiline_rows=multiline_rows,
-            encoding=encoding,
-            parse_use_threads=parse_use_threads,
-            dtypes=dtypes,
+        source=limit_source(
+            CsvReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                file_path_column=file_path_column,
+                multiline_rows=multiline_rows,
+                encoding=encoding,
+                parse_use_threads=parse_use_threads,
+                dtypes=dtypes,
+            ),
+            max_rows,
         )
     )
 
@@ -1054,6 +1082,7 @@ def read_json(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "file_path",
     parse_use_threads: bool = False,
     dtypes: DTypeMapping | None = None,
@@ -1063,20 +1092,25 @@ def read_json(
 
     `num_shards` and `target_shard_bytes` affect input shard planning on the
     reader side. `parse_use_threads` controls Arrow's intra-shard JSON parsing
-    when `lines=True`.
+    when `lines=True`. `max_rows` caps emitted source rows before pipeline
+    transforms.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=JsonReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            file_path_column=file_path_column,
-            parse_use_threads=parse_use_threads,
-            dtypes=dtypes,
-            lines=lines,
+        source=limit_source(
+            JsonReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                file_path_column=file_path_column,
+                parse_use_threads=parse_use_threads,
+                dtypes=dtypes,
+                lines=lines,
+            ),
+            max_rows,
         )
     )
 
@@ -1089,6 +1123,7 @@ def read_jsonl(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "file_path",
     parse_use_threads: bool = False,
     dtypes: DTypeMapping | None = None,
@@ -1096,7 +1131,7 @@ def read_jsonl(
     """Create a pipeline with a JSON Lines reader source.
 
     This is equivalent to ``read_json(..., lines=True)`` and exposes the same
-    sharding, parsing, file path, and dtype options.
+    sharding, parsing, file path, dtype, and `max_rows` options.
     """
     return read_json(
         inputs,
@@ -1105,6 +1140,7 @@ def read_jsonl(
         recursive=recursive,
         target_shard_bytes=target_shard_bytes,
         num_shards=num_shards,
+        max_rows=max_rows,
         file_path_column=file_path_column,
         parse_use_threads=parse_use_threads,
         dtypes=dtypes,
@@ -1120,6 +1156,7 @@ def read_files(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "file_path",
     content_column: str | None = None,
     size_column: str | None = "size",
@@ -1142,6 +1179,7 @@ def read_files(
         recursive: Whether directory inputs are listed recursively.
         target_shard_bytes: Approximate target bytes per planned shard.
         num_shards: Optional requested number of planned shards.
+        max_rows: Maximum emitted source rows for a bounded quick test.
         file_path_column: Path output column, or `None` to omit it.
         content_column: Raw bytes output column, or `None` for path-only rows.
         size_column: File size output column, or `None` to omit it.
@@ -1149,20 +1187,24 @@ def read_files(
         max_in_flight: Concurrent content reads per shard when reading bytes.
         dtypes: Optional dtype overrides exposed through the source schema.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=FilesReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            file_path_column=file_path_column,
-            content_column=content_column,
-            size_column=size_column,
-            decode_fn=decode_fn,
-            max_in_flight=max_in_flight,
-            dtypes=dtypes,
+        source=limit_source(
+            FilesReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                file_path_column=file_path_column,
+                content_column=content_column,
+                size_column=size_column,
+                decode_fn=decode_fn,
+                max_in_flight=_bounded_reader_window(max_in_flight, max_rows),
+                dtypes=dtypes,
+            ),
+            max_rows,
         )
     )
 
@@ -1175,6 +1217,7 @@ def read_videos(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "video_path",
     size_column: str | None = "size",
     dtypes: DTypeMapping | None = None,
@@ -1191,6 +1234,7 @@ def read_videos(
         recursive: Whether directory inputs are listed recursively.
         target_shard_bytes: Approximate target bytes per planned shard.
         num_shards: Optional requested number of planned shards.
+        max_rows: Maximum emitted video rows for a bounded quick test.
         file_path_column: Path output column, or `None` to omit it.
         size_column: File size output column, or `None` to omit it.
         dtypes: Optional dtype overrides exposed through the source schema.
@@ -1205,6 +1249,7 @@ def read_videos(
         recursive=recursive,
         target_shard_bytes=target_shard_bytes,
         num_shards=num_shards,
+        max_rows=max_rows,
         file_path_column=file_path_column,
         size_column=size_column,
         dtypes=video_dtypes,
@@ -1219,6 +1264,7 @@ def read_hdf5(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     groups: str | Sequence[str] | None = None,
     datasets: PathSelection | None = None,
     attrs: PathSelection | None = None,
@@ -1241,6 +1287,7 @@ def read_hdf5(
         target_shard_bytes: Target shard size used when planning file shards.
         num_shards: Requested number of planned shards. HDF5 files are atomic,
             so readers may emit fewer shards when there are fewer files.
+        max_rows: Maximum emitted HDF5 group rows for a bounded quick test.
         groups: HDF5 group selector to emit as rows. Accepts `"/"`, one glob
             string, or a sequence of exact group paths. Defaults to the root group.
         datasets: Dataset selections relative to each matched group. Accepts a
@@ -1261,22 +1308,26 @@ def read_hdf5(
             reads against object stores at the cost of downloading each file once.
         dtypes: Optional dtype overrides for output columns.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=Hdf5Reader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            groups=groups,
-            datasets=datasets,
-            attrs=attrs,
-            file_path_column=file_path_column,
-            group_path_column=group_path_column,
-            missing_policy=missing_policy,
-            cache_remote_files=cache_remote_files,
-            dtypes=dtypes,
+        source=limit_source(
+            Hdf5Reader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                groups=groups,
+                datasets=datasets,
+                attrs=attrs,
+                file_path_column=file_path_column,
+                group_path_column=group_path_column,
+                missing_policy=missing_policy,
+                cache_remote_files=cache_remote_files,
+                dtypes=dtypes,
+            ),
+            max_rows,
         )
     )
 
@@ -1291,6 +1342,7 @@ def read_zarr(
     leading_axis_row_size: int = 1,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     row_batch_size: int | None = None,
     index_column: str | None = "index",
     file_path_column: str | None = "file_path",
@@ -1310,21 +1362,28 @@ def read_zarr(
 
     Args:
         input: Zarr group path, glob, or sequence of Zarr group paths.
+        max_rows: Maximum emitted logical rows for a bounded quick test.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=ZarrReader(
-            input,
-            arrays=arrays,
-            attrs=attrs,
-            row_ends=row_ends,
-            split_leading_axis=split_leading_axis,
-            leading_axis_row_size=leading_axis_row_size,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            row_batch_size=row_batch_size,
-            index_column=index_column,
-            file_path_column=file_path_column,
-            dtypes=dtypes,
+        source=limit_source(
+            ZarrReader(
+                input,
+                arrays=arrays,
+                attrs=attrs,
+                row_ends=row_ends,
+                split_leading_axis=split_leading_axis,
+                leading_axis_row_size=leading_axis_row_size,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                row_batch_size=_bounded_optional_reader_window(
+                    row_batch_size, max_rows
+                ),
+                index_column=index_column,
+                file_path_column=file_path_column,
+                dtypes=dtypes,
+            ),
+            max_rows,
         )
     )
 
@@ -1337,6 +1396,7 @@ def read_mcap(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     file_path_column: str | None = "file_path",
     episode_splitting: str | Mapping[str, Any] = "single",
     stream_episodes: bool = False,
@@ -1364,6 +1424,7 @@ def read_mcap(
         target_shard_bytes: Target shard size used when planning files.
         num_shards: Requested number of planned shards. MCAP files are atomic,
             so readers may emit fewer shards when there are fewer files.
+        max_rows: Maximum emitted episode rows for a bounded quick test.
         file_path_column: Output column for the source file path, or `None` to
             omit it.
         episode_splitting: `"single"`, `{"time_gap_s": seconds}`, or
@@ -1387,24 +1448,28 @@ def read_mcap(
         fps: Positive explicit video/frame rate. If omitted, aligned reads infer
             it from `sync_primary` timestamps when possible.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=McapReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            file_path_column=file_path_column,
-            episode_splitting=episode_splitting,
-            stream_episodes=stream_episodes,
-            assume_log_time_order=assume_log_time_order,
-            fields=fields,
-            videos=videos,
-            sync_primary=sync_primary,
-            sync_method=sync_method,
-            include_skew=include_skew,
-            fps=fps,
+        source=limit_source(
+            McapReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                file_path_column=file_path_column,
+                episode_splitting=episode_splitting,
+                stream_episodes=stream_episodes,
+                assume_log_time_order=assume_log_time_order,
+                fields=fields,
+                videos=videos,
+                sync_primary=sync_primary,
+                sync_method=sync_method,
+                include_skew=include_skew,
+                fps=fps,
+            ),
+            max_rows,
         )
     )
 
@@ -1417,6 +1482,7 @@ def read_parquet(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     arrow_batch_size: int = 65536,
     columns_to_read: Sequence[str] | None = None,
     filter: Expr | None = None,
@@ -1429,22 +1495,27 @@ def read_parquet(
     `num_shards` and `target_shard_bytes` affect input shard planning on the
     reader side. Parquet always plans byte/file spans first and resolves them
     to row groups or row ranges at read time. `filter` uses Arrow expressions
-    for row-group pruning plus row-level filtering during reads.
+    for row-group pruning plus row-level filtering during reads. `max_rows`
+    applies after that reader-level filter and before pipeline transforms.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=ParquetReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            arrow_batch_size=arrow_batch_size,
-            columns_to_read=columns_to_read,
-            filter=filter,
-            split_row_groups=split_row_groups,
-            file_path_column=file_path_column,
-            dtypes=dtypes,
+        source=limit_source(
+            ParquetReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                arrow_batch_size=_bounded_reader_window(arrow_batch_size, max_rows),
+                columns_to_read=columns_to_read,
+                filter=filter,
+                split_row_groups=split_row_groups,
+                file_path_column=file_path_column,
+                dtypes=dtypes,
+            ),
+            max_rows,
         )
     )
 
@@ -1485,6 +1556,7 @@ def read_hf_dataset(
     timeout: float = 30.0,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     arrow_batch_size: int = 65536,
     columns_to_read: Sequence[str] | None = None,
     filter: Expr | None = None,
@@ -1497,21 +1569,26 @@ def read_hf_dataset(
         repo: Hugging Face dataset repository ID.
         config: Dataset config name. If omitted, Hugging Face datasets resolves it.
         split: Dataset split to read.
+        max_rows: Maximum emitted rows for a bounded quick test.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=HFDatasetReader(
-            repo,
-            config=config,
-            split=split,
-            dtypes=dtypes,
-            timeout=timeout,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            arrow_batch_size=arrow_batch_size,
-            columns_to_read=columns_to_read,
-            filter=filter,
-            split_row_groups=split_row_groups,
-            file_path_column=file_path_column,
+        source=limit_source(
+            HFDatasetReader(
+                repo,
+                config=config,
+                split=split,
+                dtypes=dtypes,
+                timeout=timeout,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                arrow_batch_size=_bounded_reader_window(arrow_batch_size, max_rows),
+                columns_to_read=columns_to_read,
+                filter=filter,
+                split_row_groups=split_row_groups,
+                file_path_column=file_path_column,
+            ),
+            max_rows,
         )
     )
 
@@ -1523,6 +1600,7 @@ def read_lerobot(
     storage_options: Mapping[str, Any] | None = None,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     split_row_groups: bool = True,
     skip_malformed_rows: bool = False,
 ) -> RefinerPipeline:
@@ -1534,17 +1612,21 @@ def read_lerobot(
     refined to row ranges inside an episode parquet file. Media loading stays
     unchanged. By default, malformed episode rows whose declared frame count
     does not match loaded frames raise an error; `skip_malformed_rows=True`
-    skips them with a warning and metric.
+    skips them with a warning and metric. `max_rows` caps emitted episodes.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=LeRobotEpisodeReader(
-            inputs,
-            fs=fs,
-            storage_options=storage_options,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            split_row_groups=split_row_groups,
-            skip_malformed_rows=skip_malformed_rows,
+        source=limit_source(
+            LeRobotEpisodeReader(
+                inputs,
+                fs=fs,
+                storage_options=storage_options,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                split_row_groups=split_row_groups,
+                skip_malformed_rows=skip_malformed_rows,
+            ),
+            max_rows,
         )
     )
 
@@ -1558,6 +1640,7 @@ def read_tfrecords(
     recursive: bool = False,
     target_shard_bytes: int = DEFAULT_TARGET_SHARD_BYTES,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     batch_size: int = 1024,
     compression: str | None = "auto",
     num_parallel_calls: int | None = None,
@@ -1579,26 +1662,39 @@ def read_tfrecords(
         recursive: Whether directory inputs should be expanded recursively.
         target_shard_bytes: Target shard size used when grouping whole files.
         num_shards: Optional requested number of planned file shards.
+        max_rows: Maximum emitted records for a bounded quick test.
         batch_size: Number of serialized examples parsed per batch.
         compression: `None`, `"auto"`, `"gzip"`, or `"zlib"`.
         num_parallel_calls: Optional TensorFlow map parallelism.
         prefetch: Optional TensorFlow prefetch depth.
         file_path_column: Source file path column, or `None` to omit it.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=TfrecordReader(
-            inputs,
-            features=features,
-            fs=fs,
-            storage_options=storage_options,
-            recursive=recursive,
-            target_shard_bytes=target_shard_bytes,
-            num_shards=num_shards,
-            batch_size=batch_size,
-            compression=compression,
-            num_parallel_calls=num_parallel_calls,
-            prefetch=prefetch,
-            file_path_column=file_path_column,
+        source=limit_source(
+            TfrecordReader(
+                inputs,
+                features=features,
+                fs=fs,
+                storage_options=storage_options,
+                recursive=recursive,
+                target_shard_bytes=target_shard_bytes,
+                num_shards=num_shards,
+                batch_size=_bounded_reader_window(batch_size, max_rows),
+                compression=compression,
+                num_parallel_calls=(
+                    1
+                    if max_rows is not None and num_parallel_calls is not None
+                    else num_parallel_calls
+                ),
+                prefetch=(
+                    min(prefetch, 1)
+                    if max_rows is not None and prefetch is not None
+                    else prefetch
+                ),
+                file_path_column=file_path_column,
+            ),
+            max_rows,
         )
     )
 
@@ -1613,6 +1709,7 @@ def read_tfds(
     batch_size: int = 1024,
     examples_per_shard: int = 10_000,
     num_shards: int | None = None,
+    max_rows: int | None = None,
     shuffle_files: bool = False,
     read_config: Any | None = None,
     decoders: Mapping[str, Any] | None = None,
@@ -1636,6 +1733,7 @@ def read_tfds(
         examples_per_shard: Target examples per shard when `num_shards` is
             omitted.
         num_shards: Optional requested number of row-range shards.
+        max_rows: Maximum emitted examples for a bounded quick test.
         shuffle_files: Passed to `builder.as_dataset`.
         read_config: Optional TFDS read config.
         decoders: Optional TFDS feature decoders.
@@ -1643,22 +1741,26 @@ def read_tfds(
         videos: Optional video-name to nested dataset frame path mapping.
         fps: Frame rate used for `videos`.
     """
+    max_rows = _validated_max_rows(max_rows)
     return RefinerPipeline(
-        source=TfdsReader(
-            input,
-            config=config,
-            split=split,
-            data_dir=data_dir,
-            download=download,
-            batch_size=batch_size,
-            examples_per_shard=examples_per_shard,
-            num_shards=num_shards,
-            shuffle_files=shuffle_files,
-            read_config=read_config,
-            decoders=decoders,
-            as_supervised=as_supervised,
-            videos=videos,
-            fps=fps,
+        source=limit_source(
+            TfdsReader(
+                input,
+                config=config,
+                split=split,
+                data_dir=data_dir,
+                download=download,
+                batch_size=_bounded_reader_window(batch_size, max_rows),
+                examples_per_shard=examples_per_shard,
+                num_shards=num_shards,
+                shuffle_files=shuffle_files,
+                read_config=read_config,
+                decoders=decoders,
+                as_supervised=as_supervised,
+                videos=videos,
+                fps=fps,
+            ),
+            max_rows,
         )
     )
 

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1623,6 +1623,7 @@ def read_lerobot(
                 storage_options=storage_options,
                 target_shard_bytes=target_shard_bytes,
                 num_shards=num_shards,
+                arrow_batch_size=_bounded_reader_window(65536, max_rows),
                 split_row_groups=split_row_groups,
                 skip_malformed_rows=skip_malformed_rows,
             ),

--- a/src/refiner/pipeline/sources/__init__.py
+++ b/src/refiner/pipeline/sources/__init__.py
@@ -14,6 +14,7 @@ from refiner.pipeline.sources.readers import (
     ZarrReader,
 )
 from refiner.pipeline.sources.lance import LanceSource
+from refiner.pipeline.sources.limited import LimitedSource, limit_source
 
 __all__ = [
     "BaseSource",
@@ -24,10 +25,12 @@ __all__ = [
     "Hdf5Reader",
     "JsonReader",
     "LanceSource",
+    "LimitedSource",
     "LeRobotEpisodeReader",
     "McapReader",
     "ParquetReader",
     "TfdsReader",
     "TfrecordReader",
     "ZarrReader",
+    "limit_source",
 ]

--- a/src/refiner/pipeline/sources/lance.py
+++ b/src/refiner/pipeline/sources/lance.py
@@ -69,15 +69,12 @@ class LanceSource(BaseSource):
         columns: Sequence[str] | None = None,
         batch_size: int = 65_536,
         num_shards: int | None = None,
-        max_rows: int | None = None,
     ) -> None:
         if batch_size <= 0:
             raise ValueError("batch_size must be > 0")
         if columns is not None and len(set(columns)) != len(columns):
             raise ValueError("Lance columns must be unique")
         validate_explicit_num_shards(num_shards)
-        if max_rows is not None and max_rows < 0:
-            raise ValueError("max_rows must be >= 0")
 
         self.input = DataFolder.resolve(input)
         if self.input.has_explicit_filesystem_configuration:
@@ -90,9 +87,7 @@ class LanceSource(BaseSource):
         self.columns = tuple(columns) if columns is not None else None
         self.batch_size = int(batch_size)
         self.num_shards = num_shards
-        self.max_rows = int(max_rows) if max_rows is not None else None
         self._dataset_cache: Any | None = None
-        self._planned_rows_by_fragment: tuple[int, ...] | None = None
 
         dataset = _import_lance().dataset(self.dataset_uri, version=version)
         self.version = int(dataset.version)
@@ -164,31 +159,8 @@ class LanceSource(BaseSource):
         state["_dataset_cache"] = None
         return state
 
-    def _planned_fragment_rows(self) -> tuple[int, ...]:
-        if self._planned_rows_by_fragment is not None:
-            return self._planned_rows_by_fragment
-        fragments = self._dataset().get_fragments()
-        if self.max_rows is None:
-            limits = tuple(-1 for _ in fragments)
-        else:
-            remaining = self.max_rows
-            planned: list[int] = []
-            for fragment in fragments:
-                if remaining <= 0:
-                    break
-                rows = int(fragment.count_rows())
-                if rows <= 0:
-                    planned.append(0)
-                    continue
-                take_rows = min(rows, remaining)
-                planned.append(take_rows)
-                remaining -= take_rows
-            limits = tuple(planned)
-        self._planned_rows_by_fragment = limits
-        return limits
-
     def list_shards(self) -> list[Shard]:
-        fragment_count = len(self._planned_fragment_rows())
+        fragment_count = len(self._dataset().get_fragments())
         if fragment_count == 0:
             return []
         shard_count = (
@@ -282,13 +254,9 @@ class LanceSource(BaseSource):
             or descriptor.end > len(fragments)
         ):
             raise ValueError("Lance shard fragment range is invalid")
-        planned_fragment_rows = self._planned_fragment_rows()
         for fragment_index in range(descriptor.start, descriptor.end):
             fragment = fragments[fragment_index]
-            planned_rows = planned_fragment_rows[fragment_index]
-            expected_rows = (
-                int(fragment.count_rows()) if planned_rows < 0 else planned_rows
-            )
+            expected_rows = int(fragment.count_rows())
             if expected_rows == 0:
                 continue
             blob_paths = self._fragment_blob_paths(fragment)
@@ -299,8 +267,6 @@ class LanceSource(BaseSource):
                 with_row_address=True,
                 blob_handling="blobs_descriptions",
             ):
-                if rows_read + batch.num_rows > expected_rows:
-                    batch = batch.slice(0, expected_rows - rows_read)
                 table = self._normalize_blob_columns(
                     pa.Table.from_batches([batch]),
                     blob_paths,
@@ -314,8 +280,6 @@ class LanceSource(BaseSource):
                         row_addresses,
                     )
                 )
-                if rows_read >= expected_rows:
-                    break
             if rows_read != expected_rows:
                 raise ValueError(
                     f"Lance fragment {fragment.fragment_id} yielded {rows_read} rows; "
@@ -329,7 +293,6 @@ class LanceSource(BaseSource):
             "columns": list(self.columns) if self.columns is not None else None,
             "batch_size": self.batch_size,
             "num_shards": self.num_shards,
-            "max_rows": self.max_rows,
         }
 
 

--- a/src/refiner/pipeline/sources/limited.py
+++ b/src/refiner/pipeline/sources/limited.py
@@ -6,7 +6,7 @@ from typing import Any
 import pyarrow as pa
 
 from refiner.pipeline.data.row import Row
-from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
+from refiner.pipeline.data.shard import Shard, ShardGroupDescriptor
 from refiner.pipeline.data.tabular import Tabular
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
 
@@ -54,27 +54,21 @@ class LimitedSource(BaseSource):
         if not source_shards:
             return []
         return [
-            Shard.from_row_range(
-                start=0,
-                end=1,
+            Shard(
+                descriptor=ShardGroupDescriptor(source_shards),
                 global_ordinal=0,
-                start_key=source_shards[0].start_key,
-                end_key=source_shards[-1].end_key,
             )
         ]
 
     def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
         descriptor = shard.descriptor
-        if not isinstance(descriptor, RowRangeDescriptor) or (
-            descriptor.start,
-            descriptor.end,
-        ) != (0, 1):
-            raise ValueError("LimitedSource requires its synthetic row-range shard")
+        if not isinstance(descriptor, ShardGroupDescriptor):
+            raise ValueError("LimitedSource requires a shard-group descriptor")
 
         remaining = self.max_rows
         if remaining == 0:
             return
-        for source_shard in self._planned_source_shards():
+        for source_shard in descriptor.shards:
             source_units = iter(self.source.read_shard(source_shard))
             try:
                 for unit in source_units:

--- a/src/refiner/pipeline/sources/limited.py
+++ b/src/refiner/pipeline/sources/limited.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pyarrow as pa
+
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
+from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.sources.base import BaseSource, SourceUnit
+
+
+class LimitedSource(BaseSource):
+    """Apply one deterministic global row cap to another source.
+
+    Limited runs expose one scheduling shard. That lets one worker consume the
+    wrapped source shards in their deterministic order and stop at exactly the
+    requested number of emitted source rows. Applying the cap independently in
+    multiple workers would allow every worker to emit up to ``max_rows``.
+    """
+
+    claim_shards_sequentially = True
+
+    def __init__(self, source: BaseSource, *, max_rows: int) -> None:
+        if max_rows < 0:
+            raise ValueError("max_rows must be >= 0")
+        self.source = source
+        self.max_rows = int(max_rows)
+        self.name = source.name
+        self._source_shards: tuple[Shard, ...] | None = None
+
+    @property
+    def schema(self) -> pa.Schema | None:
+        return self.source.schema
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return self.source.required_refiner_extras()
+
+    def describe(self) -> dict[str, Any]:
+        description = dict(self.source.describe())
+        description["max_rows"] = self.max_rows
+        return description
+
+    def _planned_source_shards(self) -> tuple[Shard, ...]:
+        if self._source_shards is None:
+            self._source_shards = tuple(self.source.list_shards())
+        return self._source_shards
+
+    def list_shards(self) -> list[Shard]:
+        if self.max_rows == 0:
+            return []
+        source_shards = self._planned_source_shards()
+        if not source_shards:
+            return []
+        return [
+            Shard.from_row_range(
+                start=0,
+                end=1,
+                global_ordinal=0,
+                start_key=source_shards[0].start_key,
+                end_key=source_shards[-1].end_key,
+            )
+        ]
+
+    def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
+        descriptor = shard.descriptor
+        if not isinstance(descriptor, RowRangeDescriptor) or (
+            descriptor.start,
+            descriptor.end,
+        ) != (0, 1):
+            raise ValueError("LimitedSource requires its synthetic row-range shard")
+
+        remaining = self.max_rows
+        if remaining == 0:
+            return
+        for source_shard in self._planned_source_shards():
+            source_units = iter(self.source.read_shard(source_shard))
+            try:
+                for unit in source_units:
+                    if isinstance(unit, Row):
+                        yield unit
+                        remaining -= 1
+                        if remaining == 0:
+                            return
+                        continue
+                    if not isinstance(unit, Tabular):
+                        raise TypeError(f"Unsupported source unit type: {type(unit)!r}")
+                    if unit.num_rows <= remaining:
+                        yield unit
+                        remaining -= unit.num_rows
+                        if remaining == 0:
+                            return
+                        continue
+                    row_indices = range(remaining) if unit.needs_row_indices else None
+                    yield unit.with_table(
+                        unit.table.slice(0, remaining),
+                        row_indices=row_indices,
+                    )
+                    return
+            finally:
+                close = getattr(source_units, "close", None)
+                if close is not None:
+                    close()
+
+
+def limit_source(source: BaseSource, max_rows: int | None) -> BaseSource:
+    """Return ``source`` unchanged or wrapped with one global row cap."""
+    if max_rows is None:
+        return source
+    return LimitedSource(source, max_rows=max_rows)
+
+
+__all__ = ["LimitedSource", "limit_source"]

--- a/tests/readers/test_files_reader.py
+++ b/tests/readers/test_files_reader.py
@@ -317,6 +317,7 @@ def test_read_videos_forwards_file_listing_options(
         recursive=True,
         target_shard_bytes=123,
         num_shards=4,
+        max_rows=2,
         file_path_column="clip",
         size_column=None,
         dtypes={"label": datatype.large_string()},
@@ -330,6 +331,7 @@ def test_read_videos_forwards_file_listing_options(
         "recursive": True,
         "target_shard_bytes": 123,
         "num_shards": 4,
+        "max_rows": 2,
         "file_path_column": "clip",
         "size_column": None,
         "dtypes": {

--- a/tests/readers/test_lance_source.py
+++ b/tests/readers/test_lance_source.py
@@ -6,8 +6,13 @@ from fsspec.implementations.memory import MemoryFileSystem
 
 from refiner import AddColumns, load_lance, read_blob
 from refiner.pipeline.data import datatype
-from refiner.pipeline.data.shard import SOURCE_ROW_ID_COLUMN, RowRangeDescriptor
+from refiner.pipeline.data.shard import (
+    SOURCE_ROW_ID_COLUMN,
+    RowRangeDescriptor,
+    ShardGroupDescriptor,
+)
 from refiner.pipeline.sources.lance import LanceSource
+from refiner.pipeline.sources.limited import LimitedSource
 from refiner.pipeline.data.tabular import Tabular
 
 
@@ -19,8 +24,6 @@ def test_load_lance_rejects_explicit_shard_count_above_limit() -> None:
 def test_load_lance_caps_automatic_shards_without_dropping_fragments() -> None:
     source = object.__new__(LanceSource)
     source.num_shards = None
-    source.max_rows = None
-    source._planned_rows_by_fragment = None
     source._dataset_cache = type(
         "Dataset",
         (),
@@ -67,7 +70,9 @@ def test_load_lance_pins_version_and_shards_by_fragment(tmp_path) -> None:
     assert [int(row["x"]) for row in pipeline.iter_rows()] == [1, 2, 3]
 
 
-def test_load_lance_max_rows_bounds_fragment_plan_and_final_batch(tmp_path) -> None:
+def test_load_lance_max_rows_uses_limited_source_and_slices_final_batch(
+    tmp_path,
+) -> None:
     lance = pytest.importorskip("lance")
     dataset_uri = tmp_path / "limited.lance"
     lance.write_dataset(
@@ -79,10 +84,11 @@ def test_load_lance_max_rows_bounds_fragment_plan_and_final_batch(tmp_path) -> N
     pipeline = load_lance(dataset_uri, batch_size=2, max_rows=3)
     shards = pipeline.list_shards()
 
-    assert [(shard.descriptor.start, shard.descriptor.end) for shard in shards] == [
-        (0, 1),
-        (1, 2),
-    ]
+    assert len(shards) == 1
+    assert isinstance(shards[0].descriptor, ShardGroupDescriptor)
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, LanceSource)
+    assert pipeline.source.source.batch_size == 2
     assert [int(row["x"]) for row in pipeline.iter_rows()] == [0, 1, 2]
     assert pipeline.source.describe()["max_rows"] == 3
 
@@ -98,7 +104,7 @@ def test_load_lance_max_rows_zero_and_negative(tmp_path) -> None:
         load_lance(dataset_uri, max_rows=-1)
 
 
-def test_load_lance_max_rows_groups_only_required_fragments(tmp_path) -> None:
+def test_load_lance_max_rows_wraps_requested_fragment_plan(tmp_path) -> None:
     lance = pytest.importorskip("lance")
     dataset_uri = tmp_path / "grouped-limited.lance"
     lance.write_dataset(
@@ -111,7 +117,16 @@ def test_load_lance_max_rows_groups_only_required_fragments(tmp_path) -> None:
     shards = pipeline.list_shards()
 
     assert len(shards) == 1
-    assert (shards[0].descriptor.start, shards[0].descriptor.end) == (0, 2)
+    descriptor = shards[0].descriptor
+    assert isinstance(descriptor, ShardGroupDescriptor)
+    assert len(descriptor.shards) == 1
+    assert (
+        descriptor.shards[0].descriptor.start,
+        descriptor.shards[0].descriptor.end,
+    ) == (
+        0,
+        3,
+    )
     assert [int(row["x"]) for row in pipeline.iter_rows()] == [0, 1, 2]
 
 
@@ -212,7 +227,9 @@ def test_load_lance_limits_leading_rows_across_fragments(tmp_path) -> None:
     )
 
     assert [int(row["x"]) for row in pipeline.iter_rows()] == list(range(5))
-    assert len(pipeline.list_shards()) == 2
+    assert len(pipeline.list_shards()) == 1
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, LanceSource)
     assert pipeline.source.describe()["max_rows"] == 5
 
 

--- a/tests/readers/test_limited_source.py
+++ b/tests/readers/test_limited_source.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from refiner.pipeline import (
+    RefinerPipeline,
+    read_csv,
+    read_files,
+    read_hdf5,
+    read_hf_dataset,
+    read_json,
+    read_jsonl,
+    read_lerobot,
+    read_mcap,
+    read_parquet,
+    read_tfds,
+    read_tfrecords,
+    read_videos,
+    read_zarr,
+)
+from refiner.pipeline.data.row import DictRow
+from refiner.pipeline.data.shard import RowRangeDescriptor, Shard
+from refiner.pipeline.data.tabular import Tabular
+from refiner.pipeline.expressions import col
+from refiner.pipeline.sources.base import BaseSource, SourceUnit
+from refiner.pipeline.sources.limited import LimitedSource, limit_source
+from refiner.pipeline.sources.readers.files import FilesReader
+from refiner.pipeline.sources.readers.parquet import ParquetReader
+from refiner.pipeline.sources.readers.tfrecord import TfrecordReader
+
+
+class _RecordingSource(BaseSource):
+    name = "recording"
+
+    def __init__(self) -> None:
+        self.list_calls = 0
+        self.read_starts: list[int] = []
+        self.units_started: list[str] = []
+
+    @property
+    def schema(self) -> pa.Schema:
+        return pa.schema([pa.field("x", pa.int64())])
+
+    def required_refiner_extras(self) -> tuple[str, ...]:
+        return ("s3",)
+
+    def describe(self) -> dict[str, object]:
+        return {"path": "recording://rows"}
+
+    def list_shards(self) -> list[Shard]:
+        self.list_calls += 1
+        return [
+            Shard.from_row_range(start=index, end=index + 1, global_ordinal=index)
+            for index in range(3)
+        ]
+
+    def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
+        descriptor = shard.descriptor
+        assert isinstance(descriptor, RowRangeDescriptor)
+        self.read_starts.append(descriptor.start)
+        if descriptor.start == 0:
+            self.units_started.append("table-0")
+            yield Tabular(pa.table({"x": [0, 1]}))
+            return
+        if descriptor.start == 1:
+            self.units_started.append("row-2")
+            yield DictRow({"x": 2})
+            self.units_started.append("table-3")
+            yield Tabular(pa.table({"x": [3, 4]}))
+            return
+        self.units_started.append("row-5")
+        yield DictRow({"x": 5})
+
+
+class _SideDataTabular(Tabular):
+    def __init__(self, table: pa.Table, side_data: tuple[str, ...]) -> None:
+        super().__init__(table)
+        self.side_data = side_data
+
+    @property
+    def needs_row_indices(self) -> bool:
+        return True
+
+    def with_table(
+        self,
+        table: pa.Table,
+        *,
+        row_indices: Sequence[int] | None = None,
+    ) -> "_SideDataTabular":
+        if row_indices is None:
+            if table.num_rows != len(self.side_data):
+                raise ValueError("side data must stay row-aligned")
+            side_data = self.side_data
+        else:
+            side_data = tuple(self.side_data[int(index)] for index in row_indices)
+        return _SideDataTabular(table, side_data)
+
+
+class _SideDataSource(BaseSource):
+    name = "side-data"
+
+    def list_shards(self) -> list[Shard]:
+        return [Shard.from_row_range(start=0, end=1, global_ordinal=0)]
+
+    def read_shard(self, shard: Shard) -> Iterator[SourceUnit]:
+        del shard
+        yield _SideDataTabular(pa.table({"x": [0, 1]}), ("zero", "one"))
+
+
+def _values(pipeline: RefinerPipeline) -> list[int]:
+    return [int(row["x"]) for row in pipeline.iter_rows()]
+
+
+def test_limited_source_applies_one_global_limit_across_source_shards() -> None:
+    source = _RecordingSource()
+    limited = LimitedSource(source, max_rows=3)
+
+    shards = limited.list_shards()
+    rows = list(RefinerPipeline(source=limited).iter_rows())
+
+    assert len(shards) == 1
+    assert [int(row["x"]) for row in rows] == [0, 1, 2]
+    assert [row.source_row_id for row in rows] == [0, 1, 2]
+    assert {row.shard_id for row in rows} == {shards[0].id}
+    assert source.list_calls == 1
+    assert source.read_starts == [0, 1]
+    assert source.units_started == ["table-0", "row-2"]
+
+
+def test_limited_source_slices_only_the_final_tabular_unit() -> None:
+    source = _RecordingSource()
+
+    assert _values(RefinerPipeline(source=LimitedSource(source, max_rows=1))) == [0]
+    assert source.units_started == ["table-0"]
+
+
+def test_limited_source_preserves_row_aligned_tabular_side_data() -> None:
+    limited = LimitedSource(_SideDataSource(), max_rows=1)
+
+    unit = next(limited.read_shard(limited.list_shards()[0]))
+
+    assert isinstance(unit, _SideDataTabular)
+    assert unit.table.column("x").to_pylist() == [0]
+    assert unit.side_data == ("zero",)
+
+
+def test_limited_source_zero_avoids_underlying_planning_and_reads() -> None:
+    source = _RecordingSource()
+    limited = LimitedSource(source, max_rows=0)
+
+    assert limited.list_shards() == []
+    assert _values(RefinerPipeline(source=limited)) == []
+    assert source.list_calls == 0
+    assert source.read_starts == []
+
+
+def test_limited_source_delegates_public_source_metadata() -> None:
+    source = _RecordingSource()
+    limited = LimitedSource(source, max_rows=2)
+
+    assert limited.name == "recording"
+    assert limited.schema == source.schema
+    assert limited.required_refiner_extras() == ("s3",)
+    assert limited.describe() == {
+        "path": "recording://rows",
+        "max_rows": 2,
+    }
+
+
+def test_limit_source_validates_and_avoids_a_wrapper_without_a_limit() -> None:
+    source = _RecordingSource()
+
+    assert limit_source(source, None) is source
+    with pytest.raises(ValueError, match="max_rows must be >= 0"):
+        limit_source(source, -1)
+
+
+@pytest.mark.parametrize(
+    "reader",
+    [
+        read_csv,
+        read_json,
+        read_jsonl,
+        read_files,
+        read_videos,
+        read_hdf5,
+        read_zarr,
+        read_mcap,
+        read_parquet,
+        read_hf_dataset,
+        read_lerobot,
+        read_tfrecords,
+        read_tfds,
+    ],
+)
+def test_builtin_reader_functions_expose_max_rows(reader) -> None:
+    assert "max_rows" in inspect.signature(reader).parameters
+
+
+def test_parquet_max_rows_is_global_and_applies_after_reader_filter(
+    tmp_path: Path,
+) -> None:
+    paths = []
+    for file_index in range(3):
+        path = tmp_path / f"part-{file_index}.parquet"
+        start = file_index * 4
+        pq.write_table(pa.table({"x": list(range(start, start + 4))}), path)
+        paths.append(path)
+
+    pipeline = read_parquet(
+        paths,
+        num_shards=3,
+        max_rows=3,
+        filter=col("x") > 4,
+        file_path_column=None,
+    )
+
+    assert _values(pipeline) == [5, 6, 7]
+    assert len(pipeline.list_shards()) == 1
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, ParquetReader)
+    assert pipeline.source.source.arrow_batch_size == 3
+
+
+def test_csv_and_jsonl_max_rows_stop_across_planned_shards(tmp_path: Path) -> None:
+    csv_path = tmp_path / "rows.csv"
+    csv_path.write_text("x\n" + "".join(f"{value}\n" for value in range(8)))
+    jsonl_path = tmp_path / "rows.jsonl"
+    jsonl_path.write_text("".join(f'{{"x": {value}}}\n' for value in range(8)))
+
+    assert _values(read_csv(csv_path, target_shard_bytes=4, max_rows=3)) == [0, 1, 2]
+    assert _values(read_jsonl(jsonl_path, target_shard_bytes=10, max_rows=3)) == [
+        0,
+        1,
+        2,
+    ]
+
+
+def test_file_max_rows_bounds_content_read_concurrency(tmp_path: Path) -> None:
+    paths = []
+    for index in range(3):
+        path = tmp_path / f"asset-{index}.bin"
+        path.write_bytes(bytes([index]))
+        paths.append(path)
+
+    pipeline = read_files(
+        paths,
+        content_column="content",
+        size_column=None,
+        max_in_flight=8,
+        max_rows=1,
+    )
+
+    rows = list(pipeline.iter_rows())
+    assert len(rows) == 1
+    assert rows[0]["content"] == b"\x00"
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, FilesReader)
+    assert pipeline.source.source.max_in_flight == 1
+
+
+def test_tfrecord_max_rows_bounds_eager_input_windows(tmp_path: Path) -> None:
+    pipeline = read_tfrecords(
+        tmp_path / "unused.tfrecord",
+        features={},
+        batch_size=1024,
+        num_parallel_calls=8,
+        prefetch=16,
+        max_rows=3,
+    )
+
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, TfrecordReader)
+    assert pipeline.source.source.batch_size == 3
+    assert pipeline.source.source.num_parallel_calls == 1
+    assert pipeline.source.source.prefetch == 1
+
+
+def test_zero_max_rows_does_not_resolve_missing_file_glob(tmp_path: Path) -> None:
+    pipeline = read_files(tmp_path / "missing-*.bin", max_rows=0)
+
+    assert pipeline.list_shards() == []
+    assert list(pipeline.iter_rows()) == []

--- a/tests/readers/test_limited_source.py
+++ b/tests/readers/test_limited_source.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 
+import cloudpickle
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -131,6 +132,19 @@ def test_limited_source_applies_one_global_limit_across_source_shards() -> None:
     assert source.list_calls == 1
     assert source.read_starts == [0, 1]
     assert source.units_started == ["table-0", "row-2"]
+
+
+def test_limited_source_claim_carries_plan_to_serialized_worker() -> None:
+    pipeline = RefinerPipeline(source=LimitedSource(_RecordingSource(), max_rows=3))
+    worker_payload = cloudpickle.dumps(pipeline)
+    claimed_shard = Shard.from_dict(pipeline.list_shards()[0].to_dict())
+
+    worker_pipeline = cloudpickle.loads(worker_payload)
+    units = list(worker_pipeline.source.read_shard(claimed_shard))
+
+    assert units[0].table.column("x").to_pylist() == [0, 1]
+    assert units[1]["x"] == 2
+    assert worker_pipeline.source.source.list_calls == 0
 
 
 def test_limited_source_slices_only_the_final_tabular_unit() -> None:
@@ -271,7 +285,7 @@ def test_tfrecord_max_rows_bounds_eager_input_windows(tmp_path: Path) -> None:
         features={},
         batch_size=1024,
         num_parallel_calls=8,
-        prefetch=16,
+        prefetch=-1,
         max_rows=3,
     )
 

--- a/tests/readers/test_limited_source.py
+++ b/tests/readers/test_limited_source.py
@@ -34,6 +34,7 @@ from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.pipeline.sources.limited import LimitedSource, limit_source
 from refiner.pipeline.sources.readers.files import FilesReader
 from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
+from refiner.pipeline.sources.readers.mcap import McapReader
 from refiner.pipeline.sources.readers.parquet import ParquetReader
 from refiner.pipeline.sources.readers.tfrecord import TfrecordReader
 
@@ -288,6 +289,26 @@ def test_lerobot_max_rows_bounds_episode_hydration_batch(tmp_path: Path) -> None
     assert isinstance(pipeline.source, LimitedSource)
     assert isinstance(pipeline.source.source, LeRobotEpisodeReader)
     assert pipeline.source.source.arrow_batch_size == 3
+
+
+def test_mcap_max_rows_streams_split_episodes(tmp_path: Path) -> None:
+    pipeline = read_mcap(
+        tmp_path / "unused.mcap",
+        max_rows=1,
+        episode_splitting={"time_gap_s": 0.5},
+    )
+
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, McapReader)
+    assert pipeline.source.source.stream_episodes is True
+
+
+def test_mcap_max_rows_does_not_stream_single_episode(tmp_path: Path) -> None:
+    pipeline = read_mcap(tmp_path / "unused.mcap", max_rows=1)
+
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, McapReader)
+    assert pipeline.source.source.stream_episodes is False
 
 
 def test_tfrecord_max_rows_bounds_eager_input_windows(tmp_path: Path) -> None:

--- a/tests/readers/test_limited_source.py
+++ b/tests/readers/test_limited_source.py
@@ -11,6 +11,7 @@ import pytest
 
 from refiner.pipeline import (
     RefinerPipeline,
+    load_lance,
     read_csv,
     read_files,
     read_hdf5,
@@ -205,6 +206,7 @@ def test_limit_source_validates_and_avoids_a_wrapper_without_a_limit() -> None:
         read_files,
         read_videos,
         read_hdf5,
+        load_lance,
         read_zarr,
         read_mcap,
         read_parquet,

--- a/tests/readers/test_limited_source.py
+++ b/tests/readers/test_limited_source.py
@@ -32,6 +32,7 @@ from refiner.pipeline.expressions import col
 from refiner.pipeline.sources.base import BaseSource, SourceUnit
 from refiner.pipeline.sources.limited import LimitedSource, limit_source
 from refiner.pipeline.sources.readers.files import FilesReader
+from refiner.pipeline.sources.readers.lerobot import LeRobotEpisodeReader
 from refiner.pipeline.sources.readers.parquet import ParquetReader
 from refiner.pipeline.sources.readers.tfrecord import TfrecordReader
 
@@ -277,6 +278,14 @@ def test_file_max_rows_bounds_content_read_concurrency(tmp_path: Path) -> None:
     assert isinstance(pipeline.source, LimitedSource)
     assert isinstance(pipeline.source.source, FilesReader)
     assert pipeline.source.source.max_in_flight == 1
+
+
+def test_lerobot_max_rows_bounds_episode_hydration_batch(tmp_path: Path) -> None:
+    pipeline = read_lerobot(tmp_path, max_rows=3)
+
+    assert isinstance(pipeline.source, LimitedSource)
+    assert isinstance(pipeline.source.source, LeRobotEpisodeReader)
+    assert pipeline.source.source.arrow_batch_size == 3
 
 
 def test_tfrecord_max_rows_bounds_eager_input_windows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- expose `max_rows` on every public built-in reader, including `load_lance`
- apply one deterministic global cap after reader-level filtering and before pipeline transforms
- use the same `LimitedSource` wrapper for Lance and all other built-in readers; remove Lance-specific limit state and fragment-prefix planning
- collapse bounded runs to one scheduling shard so multiple workers cannot each emit the limit
- carry the exact child-shard plan in that claim so cloud workers and retries never re-plan the source
- reduce eager batch/concurrency windows for Lance, Parquet, Hugging Face, file content, Zarr, LeRobot, TFRecord, and TFDS quick tests
- preserve row-aligned specialized table data while slicing the final Arrow block
- document usage, atomic-format caveats, sharding behavior, and peer-system tradeoffs

## Design

`LimitedSource` wraps the existing reader instead of duplicating limit counters across implementations. It walks the wrapped source shards in deterministic order inside one scheduled shard, stops without advancing another source unit once the cap is met, and closes a partially consumed reader iterator so pending I/O is cancelled. The scheduling shard embeds its child descriptors, which preserves the submitted physical plan across cloud execution and retries.

Lance now follows exactly this path: an unlimited load remains a plain `LanceSource`; a bounded load becomes `LimitedSource(LanceSource(...))`. Lance still pins versions, projects columns, preserves physical row addresses, and streams native Arrow batches. The wrapper owns all limit accounting and final-batch slicing.

This intentionally trades distributed parallelism for an exact global cap during small smoke tests. Production plans remain unchanged when `max_rows` is omitted.

## Test evidence

- focused reader/sink/planning integration — 183 passed
- `uv run pytest` — 1262 passed, 22 skipped
- `uv run pre-commit run --all-files` — passed
- `uv run ty check` — passed