### PR TITLE
feat(io): stream blob references

### DIFF
--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -82,6 +82,21 @@ encoded = mdr.read_blob(row["image"])
 
 Each reference contains `path`, `offset`, and `size`. `read_blob(...)` performs
 an exact byte-range read, so scanning rows does not materialize the blob bytes.
+For large assets such as video, stream the byte range into a consumer instead:
+
+```python
+import av
+
+with mdr.open_blob_stream(row["video"]) as stream:
+    with av.open(stream, mode="r") as container:
+        frames = list(container.decode(video=0))
+```
+
+`open_blob_stream(...)` is non-seekable and context-managed. It reads 8 MiB
+chunks by default and buffers at most four queued chunks, applying backpressure
+when the consumer is slower than storage. Set `chunk_bytes` and
+`prefetch_chunks` when a workload needs different bounds. Closing the stream
+early cancels pending prefetch work and releases its producer thread.
 The reference remains valid only while the pinned dataset version's data files
 are retained.
 Lance Blob V2 columns are currently rejected because packed and dedicated V2

--- a/docs/reading-data/lance.md
+++ b/docs/reading-data/lance.md
@@ -96,7 +96,9 @@ with mdr.open_blob_stream(row["video"]) as stream:
 chunks by default and buffers at most four queued chunks, applying backpressure
 when the consumer is slower than storage. Set `chunk_bytes` and
 `prefetch_chunks` when a workload needs different bounds. Closing the stream
-early cancels pending prefetch work and releases its producer thread.
+early signals cancellation and waits for the producer for a bounded time. If a
+storage backend remains blocked in `open()` or `read()`, close still returns;
+producer and source cleanup completes if and when that backend call returns.
 The reference remains valid only while the pinned dataset version's data files
 are retained.
 Lance Blob V2 columns are currently rejected because packed and dedicated V2

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -37,6 +37,7 @@ _LAZY_ATTRS = {
     "read_json": "refiner.pipeline",
     "read_jsonl": "refiner.pipeline",
     "read_lerobot": "refiner.pipeline",
+    "open_blob_stream": "refiner.io",
     "read_blob": "refiner.io",
     "read_mcap": "refiner.pipeline",
     "read_parquet": "refiner.pipeline",
@@ -80,6 +81,7 @@ __all__ = [
     "read_json",
     "read_jsonl",
     "read_lerobot",
+    "open_blob_stream",
     "read_blob",
     "load_lance",
     "read_mcap",
@@ -148,7 +150,7 @@ if TYPE_CHECKING:
         LanceIOConfig,
         Overwrite,
     )
-    from refiner.io import read_blob
+    from refiner.io import open_blob_stream, read_blob
     from refiner.pipeline import (
         CUDAVersion,
         GPU,

--- a/src/refiner/io/__init__.py
+++ b/src/refiner/io/__init__.py
@@ -1,4 +1,4 @@
-from refiner.io.blob import read_blob
+from refiner.io.blob import open_blob_stream, read_blob
 from refiner.io.datafile import DataFile
 from refiner.io.datafolder import DataFolder
 from refiner.io.fileset import DataFileSet
@@ -7,5 +7,6 @@ __all__ = [
     "DataFile",
     "DataFolder",
     "DataFileSet",
+    "open_blob_stream",
     "read_blob",
 ]

--- a/src/refiner/io/blob.py
+++ b/src/refiner/io/blob.py
@@ -1,12 +1,40 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
+import io
+import queue
+import threading
+from typing import Any, BinaryIO, cast
 
 from refiner.io.datafile import DataFile
 
+DEFAULT_BLOB_STREAM_CHUNK_BYTES = 8 * 1024 * 1024
+DEFAULT_BLOB_STREAM_PREFETCH_CHUNKS = 4
+_QUEUE_POLL_SECONDS = 0.05
 
-def read_blob(reference: Mapping[str, object]) -> bytes:
-    """Read the exact byte range described by a Refiner blob reference."""
+
+@dataclass(frozen=True, slots=True)
+class _BlobRange:
+    path: str
+    offset: int
+    size: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ProducerFailure:
+    error: BaseException
+
+
+class _EndOfBlob:
+    pass
+
+
+_END_OF_BLOB = _EndOfBlob()
+_QueueItem = bytes | _ProducerFailure | _EndOfBlob
+
+
+def _parse_blob_reference(reference: Mapping[str, object]) -> _BlobRange:
     path = reference.get("path")
     offset = reference.get("offset")
     size = reference.get("size")
@@ -16,11 +44,166 @@ def read_blob(reference: Mapping[str, object]) -> bytes:
         raise ValueError("blob offset must be a non-negative integer")
     if not isinstance(size, int) or isinstance(size, bool) or size < 0:
         raise ValueError("blob size must be a non-negative integer")
+    return _BlobRange(path=path, offset=offset, size=size)
+
+
+def _short_blob_error(blob: _BlobRange, received: int) -> EOFError:
+    return EOFError(
+        f"Blob reference requested {blob.size} bytes at offset {blob.offset}, "
+        f"but only {received} bytes were available"
+    )
+
+
+class _BlobStream(io.RawIOBase):
+    """Bounded producer-consumer stream for one exact blob byte range."""
+
+    def __init__(
+        self,
+        blob: _BlobRange,
+        *,
+        chunk_bytes: int,
+        prefetch_chunks: int,
+    ) -> None:
+        super().__init__()
+        self._blob = blob
+        self._chunk_bytes = chunk_bytes
+        self._queue: queue.Queue[_QueueItem] = queue.Queue(maxsize=prefetch_chunks)
+        self._cancelled = threading.Event()
+        self._current = memoryview(b"")
+        self._eof = False
+        self._thread = threading.Thread(
+            target=self._produce,
+            name=f"refiner-blob-stream-{id(self):x}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return False
+
+    def readinto(self, buffer: Any) -> int:
+        self._checkClosed()
+        output = memoryview(buffer).cast("B")
+        if not output or self._eof:
+            return 0
+
+        written = 0
+        while written < len(output):
+            if self._current:
+                count = min(len(output) - written, len(self._current))
+                output[written : written + count] = self._current[:count]
+                self._current = self._current[count:]
+                written += count
+                continue
+
+            item = self._queue.get()
+            if isinstance(item, bytes):
+                self._current = memoryview(item)
+                continue
+            if isinstance(item, _ProducerFailure):
+                if written:
+                    self._queue.put_nowait(item)
+                    return written
+                raise item.error
+
+            self._eof = True
+            break
+        return written
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self._cancelled.set()
+        self._thread.join()
+        self._current = memoryview(b"")
+        while True:
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+        super().close()
+
+    def _produce(self) -> None:
+        try:
+            with DataFile.resolve(self._blob.path).open(
+                "rb", cache_type="none"
+            ) as source:
+                source.seek(self._blob.offset)
+                received = 0
+                while received < self._blob.size and not self._cancelled.is_set():
+                    requested = min(self._chunk_bytes, self._blob.size - received)
+                    data = bytes(source.read(requested))
+                    if len(data) > requested:
+                        raise OSError(
+                            "Storage backend returned bytes outside the requested blob range"
+                        )
+                    if data and not self._put(data):
+                        return
+                    received += len(data)
+                    if len(data) != requested:
+                        raise _short_blob_error(self._blob, received)
+            if not self._cancelled.is_set():
+                self._put(_END_OF_BLOB)
+        except BaseException as error:
+            if not self._cancelled.is_set():
+                self._put(_ProducerFailure(error))
+
+    def _put(self, item: _QueueItem) -> bool:
+        while not self._cancelled.is_set():
+            try:
+                self._queue.put(item, timeout=_QUEUE_POLL_SECONDS)
+                return True
+            except queue.Full:
+                continue
+        return False
+
+
+def open_blob_stream(
+    reference: Mapping[str, object],
+    *,
+    chunk_bytes: int = DEFAULT_BLOB_STREAM_CHUNK_BYTES,
+    prefetch_chunks: int = DEFAULT_BLOB_STREAM_PREFETCH_CHUNKS,
+) -> BinaryIO:
+    """Open a bounded, non-seekable stream over a Refiner blob reference.
+
+    The returned stream owns one producer thread and must be closed, preferably
+    by using it as a context manager. Reads never expose bytes outside the
+    reference's exact ``offset`` and ``size`` range.
+    """
+    blob = _parse_blob_reference(reference)
+    if (
+        not isinstance(chunk_bytes, int)
+        or isinstance(chunk_bytes, bool)
+        or chunk_bytes <= 0
+    ):
+        raise ValueError("chunk_bytes must be a positive integer")
+    if (
+        not isinstance(prefetch_chunks, int)
+        or isinstance(prefetch_chunks, bool)
+        or prefetch_chunks <= 0
+    ):
+        raise ValueError("prefetch_chunks must be a positive integer")
+    return cast(
+        BinaryIO,
+        _BlobStream(
+            blob,
+            chunk_bytes=chunk_bytes,
+            prefetch_chunks=prefetch_chunks,
+        ),
+    )
+
+
+def read_blob(reference: Mapping[str, object]) -> bytes:
+    """Read the exact byte range described by a Refiner blob reference."""
+    blob = _parse_blob_reference(reference)
 
     chunks: list[bytes] = []
-    remaining = size
-    with DataFile.resolve(path).open("rb") as stream:
-        stream.seek(offset)
+    remaining = blob.size
+    with DataFile.resolve(blob.path).open("rb") as stream:
+        stream.seek(blob.offset)
         while remaining:
             chunk = stream.read(remaining)
             if not chunk:
@@ -28,12 +211,13 @@ def read_blob(reference: Mapping[str, object]) -> bytes:
             chunks.append(chunk)
             remaining -= len(chunk)
     if remaining:
-        received = size - remaining
-        raise EOFError(
-            f"Blob reference requested {size} bytes at offset {offset}, "
-            f"but only {received} bytes were available"
-        )
+        raise _short_blob_error(blob, blob.size - remaining)
     return b"".join(chunks)
 
 
-__all__ = ["read_blob"]
+__all__ = [
+    "DEFAULT_BLOB_STREAM_CHUNK_BYTES",
+    "DEFAULT_BLOB_STREAM_PREFETCH_CHUNKS",
+    "open_blob_stream",
+    "read_blob",
+]

--- a/src/refiner/io/blob.py
+++ b/src/refiner/io/blob.py
@@ -12,6 +12,7 @@ from refiner.io.datafile import DataFile
 DEFAULT_BLOB_STREAM_CHUNK_BYTES = 8 * 1024 * 1024
 DEFAULT_BLOB_STREAM_PREFETCH_CHUNKS = 4
 _QUEUE_POLL_SECONDS = 0.05
+_CLOSE_JOIN_SECONDS = 1.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,7 +118,10 @@ class _BlobStream(io.RawIOBase):
         if self.closed:
             return
         self._cancelled.set()
-        self._thread.join()
+        # A storage backend can block indefinitely inside open() or read(). The
+        # daemon producer will close its source when that call returns, but a
+        # consumer closing early must not be held hostage by the backend.
+        self._thread.join(timeout=_CLOSE_JOIN_SECONDS)
         self._current = memoryview(b"")
         while True:
             try:

--- a/src/refiner/io/blob.py
+++ b/src/refiner/io/blob.py
@@ -140,11 +140,11 @@ class _BlobStream(io.RawIOBase):
                         raise OSError(
                             "Storage backend returned bytes outside the requested blob range"
                         )
-                    if data and not self._put(data):
+                    if not data:
+                        raise _short_blob_error(self._blob, received)
+                    if not self._put(data):
                         return
                     received += len(data)
-                    if len(data) != requested:
-                        raise _short_blob_error(self._blob, received)
             if not self._cancelled.is_set():
                 self._put(_END_OF_BLOB)
         except BaseException as error:

--- a/tests/io/test_blob.py
+++ b/tests/io/test_blob.py
@@ -19,12 +19,16 @@ class RecordingMemoryFileSystem(MemoryFileSystem):
     def __init__(
         self,
         *,
+        block_reads: bool = False,
         failure: BaseException | None = None,
         max_read_bytes: int | None = None,
     ) -> None:
         super().__init__(skip_instance_cache=True)
+        self.block_reads = block_reads
         self.failure = failure
         self.max_read_bytes = max_read_bytes
+        self.read_started = threading.Event()
+        self.release_reads = threading.Event()
         self.ranges: list[tuple[int | None, int | None]] = []
         self.second_read = threading.Event()
         self.source_closed = threading.Event()
@@ -68,6 +72,9 @@ class _RecordingReader:
         return self._source.seek(offset, whence)
 
     def read(self, size: int = -1) -> bytes:
+        if self._fs.block_reads:
+            self._fs.read_started.set()
+            self._fs.release_reads.wait()
         if self._fs.max_read_bytes is not None:
             size = (
                 min(size, self._fs.max_read_bytes)
@@ -88,10 +95,12 @@ def use_filesystem(
     monkeypatch: pytest.MonkeyPatch,
     data: bytes,
     *,
+    block_reads: bool = False,
     failure: BaseException | None = None,
     max_read_bytes: int | None = None,
 ) -> Iterator[RecordingMemoryFileSystem]:
     fs = RecordingMemoryFileSystem(
+        block_reads=block_reads,
         failure=failure,
         max_read_bytes=max_read_bytes,
     )
@@ -188,6 +197,28 @@ def test_open_blob_stream_early_close_stops_blocked_producer(monkeypatch) -> Non
 
     assert not thread.is_alive()
     assert fs.ranges == [(0, 1), (1, 2)]
+    assert fs.source_closed.is_set()
+
+
+def test_open_blob_stream_close_does_not_wait_for_blocked_storage(monkeypatch) -> None:
+    monkeypatch.setattr("refiner.io.blob._CLOSE_JOIN_SECONDS", 0.01)
+    with use_filesystem(monkeypatch, b"payload", block_reads=True) as fs:
+        stream = open_blob_stream({"path": "unused", "offset": 0, "size": 7})
+        producer = getattr(stream, "_thread")
+        assert fs.read_started.wait(timeout=1)
+
+        closer = threading.Thread(target=stream.close)
+        closer.start()
+        closer.join(timeout=1)
+        try:
+            assert not closer.is_alive()
+            assert producer.is_alive()
+        finally:
+            fs.release_reads.set()
+            closer.join(timeout=1)
+            producer.join(timeout=1)
+
+    assert not producer.is_alive()
     assert fs.source_closed.is_set()
 
 

--- a/tests/io/test_blob.py
+++ b/tests/io/test_blob.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import io
+import threading
+from typing import Any
+
+from fsspec.implementations.memory import MemoryFileSystem
+import pytest
+
+from refiner import open_blob_stream
+from refiner.io.datafile import DataFile
+
+
+class RecordingMemoryFileSystem(MemoryFileSystem):
+    cachable = False
+
+    def __init__(self, *, failure: BaseException | None = None) -> None:
+        super().__init__(skip_instance_cache=True)
+        self.failure = failure
+        self.ranges: list[tuple[int | None, int | None]] = []
+        self.second_read = threading.Event()
+        self.source_closed = threading.Event()
+
+    def open(
+        self,
+        path,
+        mode="rb",
+        block_size=None,
+        cache_options=None,
+        compression=None,
+        **kwargs,
+    ):
+        source = super().open(
+            path,
+            mode=mode,
+            block_size=block_size,
+            cache_options=cache_options,
+            compression=compression,
+            **kwargs,
+        )
+        if mode != "rb":
+            return source
+        return _RecordingReader(source, self)
+
+
+class _RecordingReader:
+    def __init__(self, source: Any, fs: RecordingMemoryFileSystem) -> None:
+        self._source = source
+        self._fs = fs
+
+    def __enter__(self) -> _RecordingReader:
+        self._source.__enter__()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._source.__exit__(*args)
+        self._fs.source_closed.set()
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        return self._source.seek(offset, whence)
+
+    def read(self, size: int = -1) -> bytes:
+        start = self._source.tell()
+        self._fs.ranges.append((start, None if size < 0 else start + size))
+        if len(self._fs.ranges) >= 2:
+            self._fs.second_read.set()
+        if self._fs.failure is not None:
+            raise self._fs.failure
+        return self._source.read(size)
+
+
+@contextmanager
+def use_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+    data: bytes,
+    *,
+    failure: BaseException | None = None,
+) -> Iterator[RecordingMemoryFileSystem]:
+    fs = RecordingMemoryFileSystem(failure=failure)
+    fs.pipe_file("blocks/data.bin", data)
+    data_file = DataFile(fs=fs, path="blocks/data.bin")
+    monkeypatch.setattr(DataFile, "resolve", lambda path: data_file)
+    yield fs
+
+
+def test_open_blob_stream_reads_only_exact_ranges(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"prefix-payload-suffix") as fs:
+        with open_blob_stream(
+            {"path": "unused", "offset": 7, "size": 7},
+            chunk_bytes=3,
+            prefetch_chunks=2,
+        ) as stream:
+            assert stream.read() == b"payload"
+
+    assert fs.ranges == [(7, 10), (10, 13), (13, 14)]
+    assert fs.source_closed.is_set()
+
+
+def test_open_blob_stream_reads_local_datafile(tmp_path) -> None:
+    block = tmp_path / "block.bin"
+    block.write_bytes(b"prefix-payload-suffix")
+
+    with open_blob_stream(
+        {"path": str(block), "offset": 7, "size": 7},
+        chunk_bytes=2,
+    ) as stream:
+        assert stream.read() == b"payload"
+
+
+@pytest.mark.parametrize(
+    ("offset", "size", "expected"),
+    [(2, 1, b"c"), (5, 0, b"")],
+)
+def test_open_blob_stream_reads_small_and_empty_blobs(
+    monkeypatch, offset: int, size: int, expected: bytes
+) -> None:
+    with use_filesystem(monkeypatch, b"abcdef") as fs:
+        with open_blob_stream(
+            {"path": "unused", "offset": offset, "size": size},
+            chunk_bytes=4,
+        ) as stream:
+            assert stream.read() == expected
+            assert stream.read() == b""
+
+    assert fs.ranges == ([] if size == 0 else [(offset, offset + size)])
+
+
+def test_open_blob_stream_supports_partial_consumer_reads(monkeypatch) -> None:
+    payload = bytes(range(31))
+    with use_filesystem(monkeypatch, b"xx" + payload + b"yy"):
+        with open_blob_stream(
+            {"path": "unused", "offset": 2, "size": len(payload)},
+            chunk_bytes=5,
+            prefetch_chunks=2,
+        ) as stream:
+            parts = [stream.read(size) for size in (1, 3, 2, 9, 4, 12)]
+            parts.append(stream.read(1))
+
+    assert b"".join(parts) == payload
+    assert [len(part) for part in parts] == [1, 3, 2, 9, 4, 12, 0]
+
+
+def test_open_blob_stream_early_close_stops_blocked_producer(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"abcdefgh") as fs:
+        stream = open_blob_stream(
+            {"path": "unused", "offset": 0, "size": 8},
+            chunk_bytes=1,
+            prefetch_chunks=1,
+        )
+        thread = getattr(stream, "_thread")
+        assert fs.second_read.wait(timeout=1)
+        assert fs.ranges == [(0, 1), (1, 2)]
+
+        stream.close()
+
+    assert not thread.is_alive()
+    assert fs.ranges == [(0, 1), (1, 2)]
+    assert fs.source_closed.is_set()
+
+
+def test_open_blob_stream_rejects_short_underlying_object(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"abc"):
+        with open_blob_stream(
+            {"path": "unused", "offset": 1, "size": 5},
+            chunk_bytes=4,
+        ) as stream:
+            with pytest.raises(EOFError, match="only 2 bytes were available"):
+                stream.read()
+
+
+def test_open_blob_stream_propagates_producer_failure(monkeypatch) -> None:
+    failure = RuntimeError("storage unavailable")
+    with use_filesystem(monkeypatch, b"payload", failure=failure):
+        with open_blob_stream({"path": "unused", "offset": 0, "size": 7}) as stream:
+            with pytest.raises(RuntimeError, match="storage unavailable") as exc_info:
+                stream.read(1)
+
+    assert exc_info.value is failure
+
+
+def test_open_blob_stream_repeated_eof_reads(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"payload"):
+        with open_blob_stream(
+            {"path": "unused", "offset": 0, "size": 7},
+            chunk_bytes=2,
+        ) as stream:
+            assert stream.read() == b"payload"
+            assert stream.read() == b""
+            assert stream.read(100) == b""
+            buffer = bytearray(3)
+            assert getattr(stream, "readinto")(buffer) == 0
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"chunk_bytes": 0}, "chunk_bytes must be a positive integer"),
+        ({"chunk_bytes": True}, "chunk_bytes must be a positive integer"),
+        ({"prefetch_chunks": 0}, "prefetch_chunks must be a positive integer"),
+        ({"prefetch_chunks": False}, "prefetch_chunks must be a positive integer"),
+    ],
+)
+def test_open_blob_stream_validates_buffering_options(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        open_blob_stream({"path": "unused", "offset": 0, "size": 1}, **kwargs)
+
+
+def test_open_blob_stream_is_non_seekable(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"payload"):
+        with open_blob_stream({"path": "unused", "offset": 0, "size": 7}) as stream:
+            assert not stream.seekable()
+            with pytest.raises(OSError):
+                stream.seek(0)
+
+
+def test_open_blob_stream_does_not_leave_thread_after_context_exit(monkeypatch) -> None:
+    with use_filesystem(monkeypatch, b"payload"):
+        with open_blob_stream({"path": "unused", "offset": 0, "size": 7}) as stream:
+            thread = getattr(stream, "_thread")
+            assert stream.read(1) == b"p"
+
+    assert not thread.is_alive()

--- a/tests/io/test_blob.py
+++ b/tests/io/test_blob.py
@@ -16,9 +16,15 @@ from refiner.io.datafile import DataFile
 class RecordingMemoryFileSystem(MemoryFileSystem):
     cachable = False
 
-    def __init__(self, *, failure: BaseException | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        failure: BaseException | None = None,
+        max_read_bytes: int | None = None,
+    ) -> None:
         super().__init__(skip_instance_cache=True)
         self.failure = failure
+        self.max_read_bytes = max_read_bytes
         self.ranges: list[tuple[int | None, int | None]] = []
         self.second_read = threading.Event()
         self.source_closed = threading.Event()
@@ -62,6 +68,12 @@ class _RecordingReader:
         return self._source.seek(offset, whence)
 
     def read(self, size: int = -1) -> bytes:
+        if self._fs.max_read_bytes is not None:
+            size = (
+                min(size, self._fs.max_read_bytes)
+                if size >= 0
+                else self._fs.max_read_bytes
+            )
         start = self._source.tell()
         self._fs.ranges.append((start, None if size < 0 else start + size))
         if len(self._fs.ranges) >= 2:
@@ -77,8 +89,12 @@ def use_filesystem(
     data: bytes,
     *,
     failure: BaseException | None = None,
+    max_read_bytes: int | None = None,
 ) -> Iterator[RecordingMemoryFileSystem]:
-    fs = RecordingMemoryFileSystem(failure=failure)
+    fs = RecordingMemoryFileSystem(
+        failure=failure,
+        max_read_bytes=max_read_bytes,
+    )
     fs.pipe_file("blocks/data.bin", data)
     data_file = DataFile(fs=fs, path="blocks/data.bin")
     monkeypatch.setattr(DataFile, "resolve", lambda path: data_file)
@@ -140,6 +156,21 @@ def test_open_blob_stream_supports_partial_consumer_reads(monkeypatch) -> None:
 
     assert b"".join(parts) == payload
     assert [len(part) for part in parts] == [1, 3, 2, 9, 4, 12, 0]
+
+
+def test_open_blob_stream_supports_partial_producer_reads(monkeypatch) -> None:
+    with use_filesystem(
+        monkeypatch,
+        b"xxpayloadyy",
+        max_read_bytes=2,
+    ) as fs:
+        with open_blob_stream(
+            {"path": "unused", "offset": 2, "size": 7},
+            chunk_bytes=5,
+        ) as stream:
+            assert stream.read() == b"payload"
+
+    assert fs.ranges == [(2, 4), (4, 6), (6, 8), (8, 9)]
 
 
 def test_open_blob_stream_early_close_stops_blocked_producer(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add public open_blob_stream API with 8 MiB chunks and four-chunk bounded prefetch by default
- use a single producer thread with fsspec/DataFile range confinement, backpressure, EOF validation, exception propagation, and joined early-close cleanup
- preserve read_blob behavior and keep LanceSource references lazy
- document direct PyAV consumption for large Lance-backed video assets

## Verification

- uv run ruff check --force-exclude .
- uv run pytest tests/io/test_blob.py tests/io/test_datafile_datafolder.py tests/readers/test_lance_source.py -q (64 passed)
- uv run ty check
- git diff --check
- PyAV smoke test decoded four frames from an MP4 embedded at a non-zero blob offset

## Motivation

The measured 14-video workload improved from 15.61 sampled frames/s with full read_blob materialization to 26.41 frames/s with bounded streamed feeding into PyAV, while retaining the standard Lance reader path.