### PR TITLE
fix(cli): show logical execution summaries

### DIFF
--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -28,7 +28,7 @@ keeps the run inspectable after submission:
 
 - what code and pipeline plan was submitted
 - who submitted it and when it started
-- which stages, workers, and shards are running
+- active worker slots versus requested capacity, plus completed, active, and pending shards
 - where logs, metrics, services, manifests, and output references live
 - whether the run is queued, running, succeeded, failed, or canceled
 

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -28,7 +28,7 @@ keeps the run inspectable after submission:
 
 - what code and pipeline plan was submitted
 - who submitted it and when it started
-- active worker slots versus requested capacity, plus completed, active, and pending shards
+- active worker slots versus requested capacity (`N/A` until automatic capacity registers a logical slot), plus completed, active, and pending shards
 - where logs, metrics, services, manifests, and output references live
 - whether the run is queued, running, succeeded, failed, or canceled
 

--- a/src/refiner/cli/jobs/get.py
+++ b/src/refiner/cli/jobs/get.py
@@ -117,6 +117,10 @@ def _stage_gpu_text(runtime_config: Any) -> str:
     return f"{count} {gpu_type}"
 
 
+def _worker_requested_text(value: Any) -> str:
+    return "N/A" if value is None else _safe_text(value)
+
+
 def _render_job(payload: dict[str, Any]) -> int:
     job = payload
     if not isinstance(job.get("id"), str):
@@ -195,7 +199,7 @@ def _render_job(payload: dict[str, Any]) -> int:
                     ),
                     (
                         f"active={_safe_text(stage.get('runningWorkers'))} "
-                        f"requested={_safe_text(stage.get('totalWorkers'))}"
+                        f"requested={_worker_requested_text(stage.get('totalWorkers'))}"
                     ),
                     _stage_runtime_value(runtime_config, "cpuCores"),
                     _stage_runtime_value(runtime_config, "memoryMb"),

--- a/src/refiner/cli/jobs/get.py
+++ b/src/refiner/cli/jobs/get.py
@@ -173,7 +173,6 @@ def _render_job(payload: dict[str, Any]) -> int:
                 _dim_text("Status"),
                 _dim_text("Shards"),
                 _dim_text("Workers"),
-                _dim_text("Req"),
                 _dim_text("CPU"),
                 _dim_text("Memory"),
                 _dim_text("GPU"),
@@ -188,13 +187,16 @@ def _render_job(payload: dict[str, Any]) -> int:
                     _safe_text(stage.get("index")),
                     _safe_text(stage.get("name")),
                     _status_text(stage.get("status")),
-                    f"{_safe_text(stage.get('shardDone'))}/{_safe_text(stage.get('shardTotal'))}",
                     (
-                        f"run={_safe_text(stage.get('runningWorkers'))} "
-                        f"done={_safe_text(stage.get('completedWorkers'))} "
-                        f"tot={_safe_text(stage.get('totalWorkers'))}"
+                        f"c={_safe_text(stage.get('shardDone'))} "
+                        f"a={_safe_text(stage.get('shardRunning'))} "
+                        f"p={_safe_text(stage.get('shardPending'))} "
+                        f"t={_safe_text(stage.get('shardTotal'))}"
                     ),
-                    _stage_runtime_value(runtime_config, "requestedNumWorkers"),
+                    (
+                        f"active={_safe_text(stage.get('runningWorkers'))} "
+                        f"requested={_safe_text(stage.get('totalWorkers'))}"
+                    ),
                     _stage_runtime_value(runtime_config, "cpuCores"),
                     _stage_runtime_value(runtime_config, "memoryMb"),
                     _stage_gpu_text(runtime_config),

--- a/src/refiner/cli/run/cloud.py
+++ b/src/refiner/cli/run/cloud.py
@@ -285,22 +285,20 @@ def _build_snapshot(
             ):
                 current_stage = stage_dict
                 break
-    total_workers = int(job.get("totalWorkers", 0) or 0)
-    running_workers = int(job.get("runningWorkers", 0) or 0)
     stage_status = (
         _safe_text(current_stage.get("status")).lower()
         if current_stage is not None
         else _job_status(job_payload)
     )
-    completed_workers = (
-        int(current_stage.get("completedWorkers", 0) or 0)
+    stage_workers = (
+        int(current_stage.get("totalWorkers", 0) or 0)
         if current_stage is not None
         else 0
     )
-    stage_workers = (
-        int(current_stage.get("totalWorkers", total_workers) or total_workers)
+    running_workers = (
+        int(current_stage.get("runningWorkers", 0) or 0)
         if current_stage is not None
-        else total_workers
+        else 0
     )
     shard_total = (
         int(current_stage.get("shardTotal", 0) or 0)
@@ -317,6 +315,11 @@ def _build_snapshot(
         if current_stage is not None and current_stage.get("shardRunning") is not None
         else None
     )
+    shard_pending = (
+        int(current_stage.get("shardPending", 0) or 0)
+        if current_stage is not None and current_stage.get("shardPending") is not None
+        else None
+    )
     return StageSnapshot(
         job_id=context.job_id,
         job_name=context.job_name,
@@ -326,14 +329,15 @@ def _build_snapshot(
         stage_workers=stage_workers,
         tracking_url=context.tracking_url,
         status=stage_status,
-        worker_total=max(total_workers, stage_workers),
+        worker_total=stage_workers,
         worker_running=running_workers,
-        worker_completed=completed_workers,
+        worker_completed=0,
         worker_failed=0,
         elapsed_seconds=_elapsed_seconds(job),
         shard_total=shard_total,
         shard_completed=shard_completed,
         shard_running=shard_running,
+        shard_pending=shard_pending,
     )
 
 

--- a/src/refiner/cli/run/cloud.py
+++ b/src/refiner/cli/run/cloud.py
@@ -290,11 +290,11 @@ def _build_snapshot(
         if current_stage is not None
         else _job_status(job_payload)
     )
-    stage_workers = (
-        int(current_stage.get("totalWorkers", 0) or 0)
-        if current_stage is not None
-        else 0
+    requested_workers = (
+        current_stage.get("totalWorkers") if current_stage is not None else None
     )
+    worker_total = int(requested_workers) if requested_workers is not None else None
+    stage_workers = worker_total or 0
     running_workers = (
         int(current_stage.get("runningWorkers", 0) or 0)
         if current_stage is not None
@@ -329,7 +329,7 @@ def _build_snapshot(
         stage_workers=stage_workers,
         tracking_url=context.tracking_url,
         status=stage_status,
-        worker_total=stage_workers,
+        worker_total=worker_total,
         worker_running=running_workers,
         worker_completed=0,
         worker_failed=0,

--- a/src/refiner/cli/ui/console.py
+++ b/src/refiner/cli/ui/console.py
@@ -105,7 +105,7 @@ class StageSnapshot:
     stage_workers: int
     tracking_url: str | None
     status: str
-    worker_total: int
+    worker_total: int | None
     worker_running: int
     worker_completed: int
     worker_failed: int
@@ -348,7 +348,7 @@ class StageConsole:
         self._total_stages = total_stages
         self._tracking_url = tracking_url
         self._status = "running"
-        self._worker_total = stage_workers
+        self._worker_total: int | None = stage_workers
         self._worker_running = stage_workers
         self._worker_completed = 0
         self._worker_failed = 0
@@ -629,9 +629,10 @@ class StageConsole:
         return stage_token(self._stage_index)
 
     def _format_worker_counts(self, *, max_width: int) -> str:
+        requested = "N/A" if self._worker_total is None else str(self._worker_total)
         if not self._interactive:
             return _truncate_plain(
-                f"active={self._worker_running} requested={self._worker_total}",
+                f"active={self._worker_running} requested={requested}",
                 max_width,
             )
         for active_label, requested_label in [
@@ -642,14 +643,14 @@ class StageConsole:
             text = " ".join(
                 [
                     f"{active_label}={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET}",
-                    f"{requested_label}={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}",
+                    f"{requested_label}={_VALUE_COLOR}{requested}{_ANSI_RESET}",
                 ]
             )
             if _visible_width(text) <= max_width:
                 return text
         return (
             f"a={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET} "
-            f"r={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}"
+            f"r={_VALUE_COLOR}{requested}{_ANSI_RESET}"
         )
 
     def _format_shard_counts(self, *, max_width: int) -> str:

--- a/src/refiner/cli/ui/console.py
+++ b/src/refiner/cli/ui/console.py
@@ -113,6 +113,7 @@ class StageSnapshot:
     shard_total: int | None = None
     shard_completed: int | None = None
     shard_running: int | None = None
+    shard_pending: int | None = None
 
 
 def _loguru_markup_to_ansi(markup: str) -> str:
@@ -354,6 +355,7 @@ class StageConsole:
         self._shard_total: int | None = None
         self._shard_completed: int | None = None
         self._shard_running: int | None = None
+        self._shard_pending: int | None = None
         self._elapsed_seconds = 0.0
         self._elapsed_synced_at = time.monotonic()
         self._lines: deque[str] = deque(maxlen=self._MAX_BUFFERED_LINES)
@@ -412,6 +414,7 @@ class StageConsole:
         previous_shard_total = self._shard_total
         previous_shard_completed = self._shard_completed
         previous_shard_running = self._shard_running
+        previous_shard_pending = self._shard_pending
         previous_elapsed_seconds = int(self._elapsed_seconds)
         self._apply_snapshot_values(snapshot)
         if (
@@ -425,6 +428,7 @@ class StageConsole:
             or self._shard_total != previous_shard_total
             or self._shard_completed != previous_shard_completed
             or self._shard_running != previous_shard_running
+            or self._shard_pending != previous_shard_pending
             or int(self._elapsed_seconds) != previous_elapsed_seconds
         ):
             self._render()
@@ -440,6 +444,7 @@ class StageConsole:
         self._shard_total = snapshot.shard_total
         self._shard_completed = snapshot.shard_completed
         self._shard_running = snapshot.shard_running
+        self._shard_pending = snapshot.shard_pending
         self._elapsed_seconds = snapshot.elapsed_seconds
         self._elapsed_synced_at = time.monotonic()
 
@@ -626,36 +631,25 @@ class StageConsole:
     def _format_worker_counts(self, *, max_width: int) -> str:
         if not self._interactive:
             return _truncate_plain(
-                f"running={self._worker_running} "
-                f"completed={self._worker_completed} "
-                f"failed={self._worker_failed} "
-                f"total={self._worker_total}",
+                f"active={self._worker_running} requested={self._worker_total}",
                 max_width,
             )
-        variants = [
-            ("running", "completed", "failed", "total"),
-            ("run", "done", "fail", "tot"),
-            ("r", "d", "f", "t"),
-        ]
-        for variant in variants:
+        for active_label, requested_label in [
+            ("active", "requested"),
+            ("act", "req"),
+            ("a", "r"),
+        ]:
             text = " ".join(
                 [
-                    f"{variant[0]}={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET}",
-                    f"{variant[1]}={_STATUS_COLORS['completed']}{self._worker_completed}{_ANSI_RESET}",
-                    f"{variant[2]}={_STATUS_COLORS['failed']}{self._worker_failed}{_ANSI_RESET}",
-                    f"{variant[3]}={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}",
+                    f"{active_label}={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET}",
+                    f"{requested_label}={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}",
                 ]
             )
             if _visible_width(text) <= max_width:
                 return text
-        last = variants[-1]
-        return " ".join(
-            [
-                f"{last[0]}={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET}",
-                f"{last[1]}={_STATUS_COLORS['completed']}{self._worker_completed}{_ANSI_RESET}",
-                f"{last[2]}={_STATUS_COLORS['failed']}{self._worker_failed}{_ANSI_RESET}",
-                f"{last[3]}={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}",
-            ]
+        return (
+            f"a={_STATUS_COLORS['running']}{self._worker_running}{_ANSI_RESET} "
+            f"r={_VALUE_COLOR}{self._worker_total}{_ANSI_RESET}"
         )
 
     def _format_shard_counts(self, *, max_width: int) -> str:
@@ -664,28 +658,37 @@ class StageConsole:
         completed = max(0, self._shard_completed or 0)
         total = max(0, self._shard_total)
         running = max(0, self._shard_running or 0)
+        pending = max(0, self._shard_pending or 0)
         percent = 0 if total == 0 else int((completed / total) * 100)
         percent_color = _STATUS_COLORS.get(self._status, _VALUE_COLOR)
         if not self._interactive:
             return _truncate_plain(
-                f"running={running} completed={completed} total={total} ({percent}%)",
+                f"completed={completed} active={running} pending={pending} total={total} ({percent}%)",
                 max_width,
             )
         variants = [
             (
-                "running",
                 "completed",
+                "active",
+                "pending",
                 "total",
                 f"({percent}%)",
             ),
-            ("run", "done", "tot", f"({percent}%)"),
-            ("r", "d", "t", f"{percent}%"),
+            ("done", "act", "pend", "tot", f"({percent}%)"),
+            ("d", "a", "p", "t", f"{percent}%"),
         ]
-        for running_label, completed_label, total_label, percent_label in variants:
+        for (
+            completed_label,
+            active_label,
+            pending_label,
+            total_label,
+            percent_label,
+        ) in variants:
             text = " ".join(
                 [
-                    f"{running_label}={_STATUS_COLORS['running']}{running}{_ANSI_RESET}",
                     f"{completed_label}={_STATUS_COLORS['completed']}{completed}{_ANSI_RESET}",
+                    f"{active_label}={_STATUS_COLORS['running']}{running}{_ANSI_RESET}",
+                    f"{pending_label}={_VALUE_COLOR}{pending}{_ANSI_RESET}",
                     f"{total_label}={_VALUE_COLOR}{total}{_ANSI_RESET}",
                     f"{percent_color}{percent_label}{_ANSI_RESET}",
                 ]
@@ -693,8 +696,9 @@ class StageConsole:
             if _visible_width(text) <= max_width:
                 return text
         return (
-            f"r={_STATUS_COLORS['running']}{running}{_ANSI_RESET} "
             f"d={_STATUS_COLORS['completed']}{completed}{_ANSI_RESET} "
+            f"a={_STATUS_COLORS['running']}{running}{_ANSI_RESET} "
+            f"p={_VALUE_COLOR}{pending}{_ANSI_RESET} "
             f"t={_VALUE_COLOR}{total}{_ANSI_RESET} "
             f"{percent_color}{percent}%{_ANSI_RESET}"
         )

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -164,6 +164,37 @@ def test_build_snapshot_preserves_stage_zero_progress() -> None:
     assert snapshot.shard_pending == 3
 
 
+def test_build_snapshot_preserves_unknown_requested_worker_capacity() -> None:
+    context = cloud_run.CloudAttachContext(
+        job_id="job-1",
+        job_name="cloud pipeline",
+        tracking_url="https://example.com/jobs/job-1",
+        stage_index=0,
+    )
+
+    snapshot = cloud_run._build_snapshot(
+        context=context,
+        job_payload={
+            "id": "job-1",
+            "name": "cloud pipeline",
+            "status": "pending",
+            "createdAt": 1_700_000_000_000,
+            "startedAt": None,
+            "stages": [
+                {
+                    "index": 0,
+                    "status": "pending",
+                    "runningWorkers": 0,
+                    "totalWorkers": None,
+                }
+            ],
+        },
+    )
+
+    assert snapshot.worker_running == 0
+    assert snapshot.worker_total is None
+
+
 def test_build_snapshot_reads_stage_shard_running() -> None:
     context = cloud_run.CloudAttachContext(
         job_id="job-1",

--- a/tests/cli/test_cloud_run.py
+++ b/tests/cli/test_cloud_run.py
@@ -131,22 +131,23 @@ def test_build_snapshot_preserves_stage_zero_progress() -> None:
             "status": "running",
             "createdAt": 1_700_000_000_000,
             "startedAt": 1_700_000_001_000,
-            "runningWorkers": 2,
+            "runningWorkers": 9,
             "totalWorkers": 4,
             "stages": [
                 {
                     "index": 0,
                     "status": "running",
-                    "completedWorkers": 3,
+                    "runningWorkers": 2,
                     "totalWorkers": 5,
                     "shardDone": 4,
                     "shardTotal": 9,
                     "shardRunning": 2,
+                    "shardPending": 3,
                 },
                 {
                     "index": 1,
                     "status": "queued",
-                    "completedWorkers": 0,
+                    "runningWorkers": 0,
                     "totalWorkers": 7,
                 },
             ],
@@ -154,11 +155,13 @@ def test_build_snapshot_preserves_stage_zero_progress() -> None:
     )
 
     assert snapshot.stage_index == 0
-    assert snapshot.worker_completed == 3
+    assert snapshot.worker_running == 2
+    assert snapshot.worker_completed == 0
     assert snapshot.stage_workers == 5
     assert snapshot.shard_completed == 4
     assert snapshot.shard_total == 9
     assert snapshot.shard_running == 2
+    assert snapshot.shard_pending == 3
 
 
 def test_build_snapshot_reads_stage_shard_running() -> None:
@@ -183,7 +186,7 @@ def test_build_snapshot_reads_stage_shard_running() -> None:
                 {
                     "index": 0,
                     "status": "running",
-                    "completedWorkers": 3,
+                    "runningWorkers": 2,
                     "totalWorkers": 5,
                     "shardDone": 4,
                     "shardTotal": 9,
@@ -220,13 +223,13 @@ def test_build_snapshot_tolerates_null_stage_indexes() -> None:
                 {
                     "index": None,
                     "status": "running",
-                    "completedWorkers": 3,
+                    "runningWorkers": 2,
                     "totalWorkers": 5,
                 },
                 {
                     "index": 1,
                     "status": "queued",
-                    "completedWorkers": 0,
+                    "runningWorkers": 0,
                     "totalWorkers": 7,
                 },
             ],
@@ -234,7 +237,8 @@ def test_build_snapshot_tolerates_null_stage_indexes() -> None:
     )
 
     assert snapshot.stage_index == 0
-    assert snapshot.worker_completed == 3
+    assert snapshot.worker_running == 2
+    assert snapshot.worker_completed == 0
     assert snapshot.stage_workers == 5
 
 

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -83,9 +83,10 @@ class _FakeClient:
                     "index": 0,
                     "status": "running",
                     "shardDone": 3,
+                    "shardRunning": 2,
+                    "shardPending": 5,
                     "shardTotal": 10,
                     "runningWorkers": 2,
-                    "completedWorkers": 1,
                     "totalWorkers": 4,
                     "name": "stage-0",
                     "runtimeConfig": {
@@ -298,12 +299,11 @@ def test_jobs_get_plain_output(monkeypatch, capsys) -> None:
     assert "Workers:" not in out.out
     assert "Stages" in out.out
     assert "Steps" in out.out
-    assert "run=2 done=1 tot=4" in out.out
-    assert "Req" in out.out
+    assert "active=2 requested=4" in out.out
+    assert "c=3 a=2 p=5 t=10" in out.out
     assert "CPU" in out.out
     assert "Memory" in out.out
     assert "GPU" in out.out
-    assert "  4  " in out.out
     assert "  8  " in out.out
     assert "16384" in out.out
     assert "1 a10g" in out.out

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -313,6 +313,26 @@ def test_jobs_get_plain_output(monkeypatch, capsys) -> None:
     assert "\x1b[" not in out.out
 
 
+def test_jobs_get_plain_output_shows_unknown_requested_capacity(
+    monkeypatch, capsys
+) -> None:
+    class UnknownCapacityClient(_FakeClient):
+        def cli_get_job(self, *, job_id: str) -> dict[str, object]:
+            payload = super().cli_get_job(job_id=job_id)
+            stages = cast(list[dict[str, object]], payload["stages"])
+            stages[0]["totalWorkers"] = None
+            return payload
+
+    _patch_job_client(monkeypatch, UnknownCapacityClient)
+    monkeypatch.setattr("refiner.cli.jobs.common.stdout_is_interactive", lambda: False)
+
+    rc = jobs.cmd_jobs_get(Namespace(job_id="job-1", json=False))
+    out = capsys.readouterr()
+
+    assert rc == 0
+    assert "active=2 requested=N/A" in out.out
+
+
 def test_jobs_get_json_output_prints_job_object(monkeypatch, capsys) -> None:
     _patch_job_client(monkeypatch, lambda: _FakeClient())
 

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -336,7 +336,8 @@ def test_local_stage_console_colors_timestamp_level_and_message(
     assert "2" in header_lines[2]
     assert "Job ID:" in header_lines[3]
     assert "Workers:" in header_lines[3]
-    assert "running=\x1b[" in header_lines[3] or "run=\x1b[" in header_lines[3]
+    assert "active=\x1b[" in header_lines[3]
+    assert "requested=\x1b[" in header_lines[3]
     assert "\x1b[1;38;5;220m1\x1b[0m" in header_lines[3]
     assert "Rundir:" in header_lines[4]
     assert "Runtime:" in header_lines[4]
@@ -408,6 +409,7 @@ def test_stage_console_shows_shards_on_cloud_runtime_row(
                 shard_total=9,
                 shard_completed=4,
                 shard_running=2,
+                shard_pending=3,
             )
         )
         header_lines = console._build_header_lines(width=100)
@@ -419,7 +421,7 @@ def test_stage_console_shows_shards_on_cloud_runtime_row(
         "Runtime:" in line and "00:12" in line and "Shards:" in line
         for line in plain_lines
     )
-    assert any("running=2 completed=4 total=9 (44%)" in line for line in plain_lines)
+    assert any("completed=4 active=2 pending=3 total=9" in line for line in plain_lines)
 
 
 def test_stage_console_runtime_advances_between_snapshot_polls(
@@ -500,6 +502,7 @@ def test_stage_console_shows_zero_percent_when_shard_total_is_zero(
                 shard_total=0,
                 shard_completed=0,
                 shard_running=0,
+                shard_pending=0,
             )
         )
         header_lines = console._build_header_lines(width=100)
@@ -507,7 +510,7 @@ def test_stage_console_shows_zero_percent_when_shard_total_is_zero(
         console.close()
 
     plain_lines = [_ANSI_RE.sub("", line) for line in header_lines]
-    assert any("running=0 completed=0 total=0 (0%)" in line for line in plain_lines)
+    assert any("completed=0 active=0 pending=0 total=0" in line for line in plain_lines)
 
 
 def test_stage_console_colors_shard_percent_with_status_color(

--- a/tests/launchers/test_local_launcher.py
+++ b/tests/launchers/test_local_launcher.py
@@ -424,6 +424,44 @@ def test_stage_console_shows_shards_on_cloud_runtime_row(
     assert any("completed=4 active=2 pending=3 total=9" in line for line in plain_lines)
 
 
+def test_stage_console_shows_unknown_requested_worker_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("refiner.cli.ui.console.stdout_is_interactive", lambda: False)
+    console = StageConsole(
+        job_id="job-1",
+        job_name="cloud-attach-demo",
+        rundir=None,
+        stage_index=0,
+        total_stages=1,
+        stage_workers=0,
+        tracking_url="https://example.com/jobs/job-1",
+    )
+    try:
+        console.apply_snapshot(
+            StageSnapshot(
+                job_id="job-1",
+                job_name="cloud-attach-demo",
+                rundir=None,
+                stage_index=0,
+                total_stages=1,
+                stage_workers=0,
+                tracking_url="https://example.com/jobs/job-1",
+                status="pending",
+                worker_total=None,
+                worker_running=0,
+                worker_completed=0,
+                worker_failed=0,
+                elapsed_seconds=0,
+            )
+        )
+        worker_counts = console._format_worker_counts(max_width=80)
+    finally:
+        console.close()
+
+    assert worker_counts == "active=0 requested=N/A"
+
+
 def test_stage_console_runtime_advances_between_snapshot_polls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- display workers as active logical slots out of requested slots
- stop mixing job-level totals, stage totals, and historical attempts
- display shard completed, active, pending, and total counts consistently
- keep failed, canceled, and preempted attempts in worker history only
- update CLI documentation

## Verification

- `uv run pytest tests/cli/test_cloud_run.py tests/launchers/test_local_launcher.py tests/cli/test_job_commands.py -q` — 154 passed
- focused stage snapshot regression test passed
- `uv run ruff check --force-exclude ...`
- `uv run ty check`
- Ruff formatting check passed
- `git diff --check`

## Companion PR

- https://github.com/macrodata-labs/perpetuity/pull/939