### PR TITLE
feat(cloud): add Modal preemption shard hint

### DIFF
--- a/docs/cli/auth-and-run.md
+++ b/docs/cli/auth-and-run.md
@@ -114,6 +114,10 @@ Workers: macrodata jobs workers job_123
 Cancel: macrodata jobs cancel job_123
 ```
 
+Every successful cloud submission also prints a hint that Modal workers are
+preemptible and recommends shard runtimes of approximately 25 minutes for
+CPU-only workloads and 2 hours for GPU workloads.
+
 Pass script arguments after the script path:
 
 ```bash

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -38,6 +38,10 @@ shard registration. Pass a positive integer when you want a fixed worker count.
 
 Modal remains the default. For a CPU-only run on AWS Batch, pass `provider="aws"`:
 
+After a successful Modal submission, Refiner reminds you that Modal workers are
+preemptible. For more resilient runs, target approximately 25 minutes per shard
+for CPU-only workloads and 2 hours per shard for GPU workloads.
+
 ```python
 pipeline.launch_cloud(
     name="aws-normalization",

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -626,6 +626,13 @@ class CloudLauncher(BaseLauncher):
             stage_index=resp.stage_index,
         )
         print(f"Cloud job launched. View job:\n  {tracking_url}", flush=True)
+        if self.provider == "modal":
+            print(
+                "Hint: Modal workers are preemptible. For resilient runs, target about "
+                "25 minutes per shard for CPU-only workloads and 2 hours per shard for "
+                "GPU workloads.",
+                flush=True,
+            )
         if debug:
             return CloudLaunchResult(
                 job_id=resp.job_id,

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -286,7 +286,7 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert captured["events"] == ["upload-urls", "upload", "complete", "submit"]
 
 
-def test_pipeline_launch_cloud_selects_aws_batch(monkeypatch) -> None:
+def test_pipeline_launch_cloud_selects_aws_batch(monkeypatch, capsys) -> None:
     captured = _stub_cloud_submit(monkeypatch)
     monkeypatch.setattr(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
@@ -304,6 +304,7 @@ def test_pipeline_launch_cloud_selects_aws_batch(monkeypatch) -> None:
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.provider == "aws_batch"
     assert request.stage_payloads[0].runtime.gpu is None
+    assert "Modal workers are preemptible" not in capsys.readouterr().out
 
 
 def test_pipeline_launch_cloud_rejects_gpu_for_aws() -> None:
@@ -1417,10 +1418,13 @@ def test_pipeline_launch_cloud_detached_mode_prints_followup_commands(
     out = capsys.readouterr()
 
     assert result.job_id == "job-123"
+    assert "Modal workers are preemptible" in out.out
+    assert "25 minutes per shard for CPU-only workloads" in out.out
+    assert "2 hours per shard for GPU workloads" in out.out
     assert "attach job-123" in out.out
 
 
-def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch) -> None:
+def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch, capsys) -> None:
     _stub_cloud_submit(monkeypatch)
     monkeypatch.setattr(
         "refiner.launchers.cloud.refiner_ref_exists_on_remote",
@@ -1441,8 +1445,12 @@ def test_pipeline_launch_cloud_attached_mode_calls_attach(monkeypatch) -> None:
     )
 
     result = read_jsonl("input.jsonl").launch_cloud(name="demo cloud")
+    out = capsys.readouterr()
 
     assert result.job_id == "job-123"
+    assert "Modal workers are preemptible" in out.out
+    assert "25 minutes per shard for CPU-only workloads" in out.out
+    assert "2 hours per shard for GPU workloads" in out.out
     assert captured["job_id"] == "job-123"
     assert captured["stage_index_hint"] == 0
     assert captured["force_attach"] is True


### PR DESCRIPTION
## Summary

- show a Modal preemption advisory after every successful cloud submission
- recommend approximately 25 minutes per shard for CPU-only workloads and 2 hours per shard for GPU workloads
- cover attached and detached launches and document the behavior

## Verification

- `uv run ruff format --check src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run ruff check src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run pytest tests/launchers/test_cloud_launcher.py -q` (52 passed)
- `uv run ty check`
- `git diff --check`