### PR TITLE
chore(release): bump Refiner to 0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "macrodata-refiner"
-version = "0.3.7"
+version = "0.3.8"
 description = "Refiner by Macrodata Labs, a data processing framework for Machine Learning large scale datasets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2082,7 +2082,7 @@ wheels = [
 
 [[package]]
 name = "macrodata-refiner"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- bump `macrodata-refiner` from 0.3.7 to 0.3.8
- update the lockfile package metadata
- release the merged Modal preemption shard guidance through the established production publish workflow

## Verification

- `uv lock --check`
- `git diff --check`
- full CI will run on this PR before merge