### PR TITLE
Suggest debug mode for smoke jobs

### DIFF
--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -27,6 +27,11 @@ pipeline.launch_cloud(
 To validate one retained worker before scaling out, see
 [Cloud debug sessions](cloud-debug-sessions.md).
 
+When a successfully submitted job name contains `smoke` (case-insensitive),
+Refiner suggests the retained debug workflow instead of the Modal preemption
+hint. The message shows how to start a session, run one shard, and discover all
+options with `macrodata debug --help`. The job still launches normally.
+
 Set `num_workers="auto"` to request one worker for every shard in each stage.
 The cloud registration runtime discovers shards after secrets and environment
 variables are mounted, then Macrodata Cloud applies its normal worker and GPU

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -48,6 +48,13 @@ if TYPE_CHECKING:
 
 _FALLBACK_ENV_VAR = "MACRODATA_FALLBACK_TO_LATEST_PYPI"
 _CLOUD_FILE_BATCH_SIZE = 100
+_SMOKE_DEBUG_HINT = (
+    "Hint: Refiner debug mode is usually a better fit than smoke jobs. "
+    "Run `macrodata debug pipeline.py`, then "
+    "`macrodata debug run pipeline.py --max-shards 1` (replace "
+    "`pipeline.py` with the script that calls `launch_cloud(...)`). "
+    "Run `macrodata debug --help` to learn more."
+)
 _CLOUD_PROVIDER_KEYS = {"modal": "modal", "aws": "aws_batch"}
 _SUPPORTED_CLOUDS = frozenset({"aws", "oci", "gcp"})
 _SUPPORTED_REGIONS = frozenset(
@@ -626,7 +633,9 @@ class CloudLauncher(BaseLauncher):
             stage_index=resp.stage_index,
         )
         print(f"Cloud job launched. View job:\n  {tracking_url}", flush=True)
-        if self.provider == "modal":
+        if "smoke" in self.name.casefold():
+            print(_SMOKE_DEBUG_HINT, flush=True)
+        elif self.provider == "modal":
             print(
                 "Hint: Modal workers are preemptible. For resilient runs, target about "
                 "25 minutes per shard for CPU-only workloads and 2 hours per shard for "

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -633,7 +633,7 @@ class CloudLauncher(BaseLauncher):
             stage_index=resp.stage_index,
         )
         print(f"Cloud job launched. View job:\n  {tracking_url}", flush=True)
-        if "smoke" in self.name.casefold():
+        if not debug and "smoke" in self.name.casefold():
             print(_SMOKE_DEBUG_HINT, flush=True)
         elif self.provider == "modal":
             print(

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -356,7 +356,7 @@ def test_pipeline_launch_cloud_rejects_runtime_services_for_aws_before_upload(
     assert captured["events"] == []
 
 
-def test_captured_pipeline_launch_submits_debug_and_does_not_attach(
+def test_captured_smoke_launch_submits_debug_without_smoke_hint_or_attach(
     monkeypatch, capsys
 ) -> None:
     from refiner.launchers.cloud_debug_capture import capture_cloud_launches
@@ -370,7 +370,7 @@ def test_captured_pipeline_launch_submits_debug_and_does_not_attach(
 
     with capture_cloud_launches() as capture:
         placeholder = read_jsonl("input.jsonl").launch_cloud(
-            name="debug cloud",
+            name="smoke debug",
             num_workers=16,
         )
     assert placeholder.status == "captured"
@@ -380,7 +380,9 @@ def test_captured_pipeline_launch_submits_debug_and_does_not_attach(
     assert request.debug is True
     assert request.stage_payloads[0].runtime.num_workers == 16
     assert result.job_id == "job-123"
-    assert "Cloud job launched" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "Cloud job launched" in out
+    assert "better fit than smoke jobs" not in out
 
 
 def test_debug_launch_preserves_aws_batch_provider(monkeypatch) -> None:

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -307,6 +307,25 @@ def test_pipeline_launch_cloud_selects_aws_batch(monkeypatch, capsys) -> None:
     assert "Modal workers are preemptible" not in capsys.readouterr().out
 
 
+def test_pipeline_launch_cloud_suggests_debug_mode_for_smoke_job(
+    monkeypatch, capsys
+) -> None:
+    _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    read_jsonl("input.jsonl").launch_cloud(name="Reader SMOKE check")
+
+    out = capsys.readouterr().out
+    assert "Refiner debug mode" in out
+    assert "macrodata debug pipeline.py" in out
+    assert "macrodata debug run pipeline.py --max-shards 1" in out
+    assert "macrodata debug --help" in out
+    assert "Modal workers are preemptible" not in out
+
+
 def test_pipeline_launch_cloud_rejects_gpu_for_aws() -> None:
     with pytest.raises(ValueError, match="does not support GPU"):
         read_jsonl("input.jsonl").launch_cloud(


### PR DESCRIPTION
## Purpose

Guide users toward retained cloud debug sessions when a launched job name contains `smoke`.

## Key decisions

- Match `smoke` case-insensitively after a successful cloud submission.
- Show the session creation, one-shard run, and `--help` commands.
- Replace the Modal preemption hint for smoke-named jobs so the launcher does not print competing guidance.
- Leave submission and attachment behavior unchanged.

## Test evidence

- `uv run pytest tests/launchers/test_cloud_launcher.py -q` — 78 passed
- `uv run ruff check --force-exclude src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run ruff format --force-exclude --check src/refiner/launchers/cloud.py tests/launchers/test_cloud_launcher.py`
- `uv run ty check src/refiner/launchers/cloud.py`
- Commit hooks: Ruff, Ruff format, and ty passed

## Behavior

Before: Modal smoke jobs showed only the generic preemption hint.

After: Any cloud job containing `smoke` in its name shows retained-debug commands and a `macrodata debug --help` discovery path; the Modal hint is suppressed for that job.