### PR TITLE
add cloud scratch disk and progress tracking

### DIFF
--- a/docs/cli/jobs-logs-and-metrics.md
+++ b/docs/cli/jobs-logs-and-metrics.md
@@ -68,8 +68,8 @@ Created By: ada@example.com
 Available: manifest, logs, metrics
 
 Stages
-Index  Name    Status   Progress
-0      ingest  running  run=2 done=1 tot=4
+Idx  Name    Status   Shards                 Workers               CPU  Memory  Scratch  GPU
+0    ingest  running  c=1 a=2 p=1 t=4 (25%)  active=2 requested=4  8    16384   512000   1 a10
 
 Steps
 Stage  Step  Name          Type  Columns

--- a/docs/platform/submitting-to-the-platform.md
+++ b/docs/platform/submitting-to-the-platform.md
@@ -74,6 +74,7 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
+    scratch_disk_mb_per_worker=512_000,
     secrets=mdr.Secrets.env(name="production", keys=["HF_TOKEN"]),
 )
 ```
@@ -86,6 +87,7 @@ Common launch settings:
 | `num_workers` | Number of workers that claim shards. |
 | `cpus_per_worker` | CPU allocation per worker. |
 | `mem_mb_per_worker` | Memory allocation per worker. |
+| `scratch_disk_mb_per_worker` | Ephemeral scratch disk per Modal worker, in MB. |
 | `gpu` | GPU type/count per worker. |
 | `refiner_extras` | Extra Refiner [optional dependency groups](../reference/optional-dependencies.md) to install on workers. Built-in blocks declare their own required extras automatically. |
 | `dependencies` | Additional pip requirement strings to install on workers. |

--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -100,10 +100,10 @@ with its default arguments:
 macrodata debug sync pipeline.py --job JOB_ID -- --rows 20
 ```
 
-Dependencies, Python and Refiner versions, CPU, memory, GPU, cloud placement,
-runtime services, secrets, and plain environment variables are fixed when the
-worker is allocated. If any of these settings change, sync asks you to stop and
-create a new session:
+Dependencies, Python and Refiner versions, CPU, memory, scratch disk, GPU,
+cloud placement, runtime services, secrets, and plain environment variables are
+fixed when the worker is allocated. If any of these settings change, sync asks
+you to stop and create a new session:
 
 ```bash
 macrodata debug stop pipeline.py

--- a/docs/running-pipelines/cloud-launcher.md
+++ b/docs/running-pipelines/cloud-launcher.md
@@ -20,6 +20,7 @@ pipeline.launch_cloud(
     num_workers="auto",
     cpus_per_worker=4,
     mem_mb_per_worker=8192,
+    scratch_disk_mb_per_worker=100_000,
     secrets={"HF_TOKEN": None},
 )
 ```
@@ -60,7 +61,8 @@ pipeline.launch_cloud(
 AWS Batch supports pip dependencies, secrets, environment variables, multiple
 workers, continuation, and multi-stage pipelines. It does not currently support
 GPUs, managed runtime services, apt packages, custom images, or arbitrary file
-and directory attachments. Retained cloud debugging uses the same
+and directory attachments. Configurable scratch disk is also Modal-only;
+`provider="aws"` rejects `scratch_disk_mb_per_worker`. Retained cloud debugging uses the same
 `provider="aws"` selection; see [Cloud debug sessions](cloud-debug-sessions.md).
 
 ## Cloud and region placement

--- a/docs/running-pipelines/observability.md
+++ b/docs/running-pipelines/observability.md
@@ -37,6 +37,35 @@ import refiner as mdr
 mdr.log_gauge("queue_depth", 12, unit="items")
 ```
 
+## Progress
+
+Use `mdr.progress` like the common `tqdm` pattern when work has a meaningful
+completed count. Iterable wrapping infers the total when the iterable has a
+length:
+
+```python
+for frame in mdr.progress(frames, desc="Colorizing", unit="frame"):
+    colorize(frame)
+```
+
+For callbacks and batched work, update the tracker manually:
+
+```python
+with mdr.progress(total=31_678, desc="Colorizing", unit="frame") as progress:
+    for batch in frame_batches:
+        colorize(batch)
+        progress.update(len(batch))
+        progress.set_postfix(gpu_utilization=72)
+```
+
+The tracker supports `total`, `desc`, `unit`, `initial`, `mininterval`,
+`update()`, `set_description()`, `set_postfix()`, `refresh()`, and `close()`.
+Interactive local runs render a terminal line. Launched workers emit throttled,
+absolute `completed`, `total`, `elapsed_seconds`, and `rate` gauges under a
+`progress.<description>` metric label. Absolute snapshots avoid replaying
+cumulative increments when an attempt is retried. Progress is observational and
+does not create checkpoints.
+
 ## Logs
 
 Use the worker logger for structured job logs:

--- a/docs/running-pipelines/resources-gpus-and-services.md
+++ b/docs/running-pipelines/resources-gpus-and-services.md
@@ -14,7 +14,7 @@ description: "CPU, memory, GPU, and runtime service configuration for launched R
 Resource settings belong on launch calls, not inside transform functions. This
 keeps the pipeline logic portable between local debugging and cloud execution.
 
-## CPU and memory
+## CPU, memory, and scratch disk
 
 ```python
 pipeline.launch_cloud(
@@ -22,11 +22,19 @@ pipeline.launch_cloud(
     num_workers=16,
     cpus_per_worker=8,
     mem_mb_per_worker=32768,
+    scratch_disk_mb_per_worker=512_000,
 )
 ```
 
 Use more memory for video-heavy readers and writers, large frame tables, and
 large vectorized batches.
+
+`scratch_disk_mb_per_worker` requests ephemeral scratch space for every Modal
+worker. Use it for archive extraction, media conversion, external sorting, and
+other workloads whose temporary files exceed the default worker disk. Scratch
+data is discarded with the worker; persist outputs to the configured dataset or
+object-store destination. The AWS Batch provider does not currently support a
+configurable scratch-disk request and rejects this option before submission.
 
 ## GPUs
 

--- a/src/refiner/__init__.py
+++ b/src/refiner/__init__.py
@@ -58,6 +58,8 @@ _LAZY_ATTRS = {
     "log_histogram": "refiner.worker.metrics.api",
     "log_throughput": "refiner.worker.metrics.api",
     "register_gauge": "refiner.worker.metrics.api",
+    "Progress": "refiner.progress_api",
+    "progress": "refiner.progress_api",
     "logger": "refiner.worker.context",
 }
 
@@ -103,6 +105,8 @@ __all__ = [
     "log_gauges",
     "log_histogram",
     "register_gauge",
+    "Progress",
+    "progress",
     "logger",
     # expressions
     "col",
@@ -184,6 +188,7 @@ if TYPE_CHECKING:
     from refiner.pipeline.data import datatype
     from refiner.pipeline.expressions import coalesce, col, if_else, lit
     from refiner.pipeline.sinks.assets import BlobAssetConfig, FileAssetConfig
+    from refiner.progress_api import Progress, progress
     from refiner.worker.context import logger
     from refiner.worker.metrics.api import (
         log_gauge,

--- a/src/refiner/cli/jobs/get.py
+++ b/src/refiner/cli/jobs/get.py
@@ -186,6 +186,7 @@ def _render_job(payload: dict[str, Any]) -> int:
                 _dim_text("Workers"),
                 _dim_text("CPU"),
                 _dim_text("Memory"),
+                _dim_text("Scratch"),
                 _dim_text("GPU"),
             ]
         ]
@@ -210,6 +211,7 @@ def _render_job(payload: dict[str, Any]) -> int:
                     ),
                     _stage_runtime_value(runtime_config, "cpuCores"),
                     _stage_runtime_value(runtime_config, "memoryMb"),
+                    _stage_runtime_value(runtime_config, "scratchDiskMb"),
                     _stage_gpu_text(runtime_config),
                 ]
             )

--- a/src/refiner/launchers/base.py
+++ b/src/refiner/launchers/base.py
@@ -94,6 +94,11 @@ class BaseLauncher(ABC):
                 if compute.memory_mb_per_worker is not None
                 else getattr(self, "mem_mb_per_worker", None)
             ),
+            scratch_disk_mb_per_worker=(
+                compute.scratch_disk_mb_per_worker
+                if compute.scratch_disk_mb_per_worker is not None
+                else getattr(self, "scratch_disk_mb_per_worker", None)
+            ),
             gpu=compute.gpu if compute.gpu is not None else getattr(self, "gpu", None),
         )
 

--- a/src/refiner/launchers/cloud.py
+++ b/src/refiner/launchers/cloud.py
@@ -160,6 +160,7 @@ class CloudLauncher(BaseLauncher):
             ``"auto"`` to launch one worker per stage shard.
         cpus_per_worker: Optional requested CPU cores per worker.
         mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
+        scratch_disk_mb_per_worker: Optional scratch disk in MB per worker.
         gpu: Optional GPU runtime request for cloud scheduling.
         sync_local_dependencies: Whether to include packages detected from the
             local environment in the cloud runtime.
@@ -181,6 +182,7 @@ class CloudLauncher(BaseLauncher):
         num_workers: int | Literal["auto"] = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
+        scratch_disk_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         cloud: CloudProvider = "aws",
         region: CloudRegion | Sequence[CloudRegion] = ("us", "eu", "ca"),
@@ -204,6 +206,8 @@ class CloudLauncher(BaseLauncher):
             raise ValueError("unsafe_continue requires continue_from_job")
         if mem_mb_per_worker is not None and mem_mb_per_worker <= 0:
             raise ValueError("mem_mb_per_worker must be > 0")
+        if scratch_disk_mb_per_worker is not None and scratch_disk_mb_per_worker <= 0:
+            raise ValueError("scratch_disk_mb_per_worker must be > 0")
         normalized_provider = provider.strip().lower()
         if normalized_provider not in _CLOUD_PROVIDER_KEYS:
             raise ValueError("provider must be 'modal' or 'aws'")
@@ -212,6 +216,7 @@ class CloudLauncher(BaseLauncher):
         self.provider = normalized_provider
         self.cpus_per_worker = cpus_per_worker
         self.mem_mb_per_worker = mem_mb_per_worker
+        self.scratch_disk_mb_per_worker = scratch_disk_mb_per_worker
         self.cloud = _normalize_cloud(cloud)
         self.region = _normalize_regions(region)
         self.sync_local_dependencies = sync_local_dependencies
@@ -473,6 +478,7 @@ class CloudLauncher(BaseLauncher):
                 cpus_per_worker=stage.compute.cpus_per_worker,
                 mem_mb_per_worker=stage.compute.memory_mb_per_worker,
                 gpu=stage.compute.gpu,
+                scratch_disk_mb_per_worker=stage.compute.scratch_disk_mb_per_worker,
             ).to_dict()
             runtime.pop("num_workers", None)
             stage_specs.append(
@@ -592,6 +598,14 @@ class CloudLauncher(BaseLauncher):
                     raise ValueError(
                         "provider='aws' does not support managed runtime services"
                     )
+                if any(
+                    stage.compute.scratch_disk_mb_per_worker is not None
+                    for stage in stages
+                ):
+                    raise ValueError(
+                        "provider='aws' does not support configurable scratch disk; "
+                        "use provider='modal' or omit scratch_disk_mb_per_worker"
+                    )
             pipeline_payloads = self._upload_stage_payloads(
                 client=client, stages=stages
             )
@@ -610,6 +624,9 @@ class CloudLauncher(BaseLauncher):
                             cpus_per_worker=stage.compute.cpus_per_worker,
                             mem_mb_per_worker=stage.compute.memory_mb_per_worker,
                             gpu=stage.compute.gpu,
+                            scratch_disk_mb_per_worker=(
+                                stage.compute.scratch_disk_mb_per_worker
+                            ),
                         ),
                         runtime_services=collect_pipeline_services(stage.pipeline),
                     )

--- a/src/refiner/pipeline/pipeline.py
+++ b/src/refiner/pipeline/pipeline.py
@@ -1046,6 +1046,7 @@ class RefinerPipeline:
         num_workers: int | Literal["auto"] = 1,
         cpus_per_worker: int | None = None,
         mem_mb_per_worker: int | None = None,
+        scratch_disk_mb_per_worker: int | None = None,
         gpu: GPU | None = None,
         cloud: CloudProvider = "aws",
         region: CloudRegion | Sequence[CloudRegion] = ("us", "eu", "ca"),
@@ -1067,6 +1068,7 @@ class RefinerPipeline:
                 launch one worker per stage shard.
             cpus_per_worker: Optional requested CPU cores per worker.
             mem_mb_per_worker: Optional requested memory in MB per worker for cloud scheduling.
+            scratch_disk_mb_per_worker: Optional scratch disk in MB per worker.
             gpu: Optional structured GPU request.
             cloud: Public cloud provider. Supported values are ``"aws"``,
                 ``"oci"``, and ``"gcp"``.
@@ -1102,6 +1104,7 @@ class RefinerPipeline:
             num_workers=num_workers,
             cpus_per_worker=cpus_per_worker,
             mem_mb_per_worker=mem_mb_per_worker,
+            scratch_disk_mb_per_worker=scratch_disk_mb_per_worker,
             gpu=gpu,
             cloud=cloud,
             region=region,

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -48,6 +48,7 @@ class StageComputeRequirements:
     num_workers: WorkerCount
     cpus_per_worker: int | None = None
     memory_mb_per_worker: int | None = None
+    scratch_disk_mb_per_worker: int | None = None
     gpu: GPU | None = None
     inherit_launcher_resources: bool = True
 
@@ -57,6 +58,8 @@ class StageComputeRequirements:
             payload["cpus_per_worker"] = self.cpus_per_worker
         if self.memory_mb_per_worker is not None:
             payload["memory_mb_per_worker"] = self.memory_mb_per_worker
+        if self.scratch_disk_mb_per_worker is not None:
+            payload["scratch_disk_mb_per_worker"] = self.scratch_disk_mb_per_worker
         if self.gpu is not None:
             payload["gpu"] = self.gpu.to_dict()
         return payload

--- a/src/refiner/platform/client/models.py
+++ b/src/refiner/platform/client/models.py
@@ -144,6 +144,7 @@ class CloudRuntimeConfig:
     gpu: GPU | None = None
     cloud: CloudProvider = "aws"
     region: tuple[CloudRegion, ...] = ("us", "eu", "ca")
+    scratch_disk_mb_per_worker: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -155,6 +156,8 @@ class CloudRuntimeConfig:
             payload["cpus_per_worker"] = self.cpus_per_worker
         if self.mem_mb_per_worker is not None:
             payload["mem_mb_per_worker"] = self.mem_mb_per_worker
+        if self.scratch_disk_mb_per_worker is not None:
+            payload["scratch_disk_mb_per_worker"] = self.scratch_disk_mb_per_worker
         if self.gpu is not None:
             payload["gpu"] = self.gpu.to_dict()
         return payload

--- a/src/refiner/progress_api.py
+++ b/src/refiner/progress_api.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+import math
+import sys
+import time
+from typing import Any, Generic, TextIO, TypeVar
+
+from refiner.worker.context import (
+    get_active_step_index,
+    get_active_user_metrics_emitter,
+)
+
+
+T = TypeVar("T")
+
+
+def _length(value: object) -> int | None:
+    try:
+        return len(value)  # type: ignore[arg-type]
+    except (TypeError, AttributeError):
+        return None
+
+
+def _metric_name(description: str | None) -> str:
+    normalized = " ".join((description or "").split())
+    return f"progress.{normalized}" if normalized else "progress"
+
+
+def _format_interval(seconds: float | None) -> str:
+    if seconds is None or not math.isfinite(seconds):
+        return "?"
+    seconds = max(0, int(seconds))
+    minutes, second = divmod(seconds, 60)
+    hours, minute = divmod(minutes, 60)
+    if hours:
+        return f"{hours:d}:{minute:02d}:{second:02d}"
+    return f"{minute:02d}:{second:02d}"
+
+
+class Progress(Generic[T]):
+    """Track iterable or manually updated work with tqdm-style semantics.
+
+    Progress is emitted as absolute gauges, so a retried worker attempt does not
+    replay previously emitted increments. Interactive local runs also render a
+    compact terminal progress line.
+    """
+
+    def __init__(
+        self,
+        iterable: Iterable[T] | None = None,
+        *,
+        total: float | None = None,
+        desc: str | None = None,
+        unit: str = "it",
+        initial: float = 0,
+        mininterval: float = 0.5,
+        file: TextIO | None = None,
+        disable: bool | None = None,
+    ) -> None:
+        if total is None and iterable is not None:
+            total = _length(iterable)
+        if total is not None and total < 0:
+            raise ValueError("total must be >= 0")
+        if initial < 0:
+            raise ValueError("initial must be >= 0")
+        if mininterval < 0:
+            raise ValueError("mininterval must be >= 0")
+        if not unit.strip():
+            raise ValueError("unit must be non-empty")
+
+        self.iterable = iterable
+        self.total = float(total) if total is not None else None
+        self.desc = desc or ""
+        self.unit = unit
+        self.n = float(initial)
+        self.mininterval = float(mininterval)
+        self.file = file or sys.stderr
+        self.disable = (
+            not bool(getattr(self.file, "isatty", lambda: False)())
+            if disable is None
+            else disable
+        )
+        self.postfix: dict[str, Any] = {}
+        self._metric_label = _metric_name(desc)
+        self._started_at = time.monotonic()
+        self._last_refresh_at: float | None = None
+        self._last_render_width = 0
+        self._closed = False
+        self.refresh()
+
+    @property
+    def elapsed(self) -> float:
+        return max(0.0, time.monotonic() - self._started_at)
+
+    @property
+    def rate(self) -> float | None:
+        elapsed = self.elapsed
+        if elapsed <= 0:
+            return None
+        return max(0.0, self.n / elapsed)
+
+    def update(self, n: float = 1) -> None:
+        if self._closed:
+            return
+        self.n += n
+        self.refresh()
+
+    def set_description(self, desc: str | None = None, refresh: bool = True) -> None:
+        self.desc = desc or ""
+        if refresh:
+            self.refresh(force=True)
+
+    def set_postfix(
+        self,
+        ordered_dict: Mapping[str, Any] | None = None,
+        refresh: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.postfix = dict(ordered_dict or {})
+        self.postfix.update(kwargs)
+        if refresh:
+            self.refresh(force=True)
+
+    def _emit_metrics(self, *, elapsed: float, rate: float | None) -> None:
+        emitter = get_active_user_metrics_emitter()
+        step_index = get_active_step_index()
+        values: dict[str, float] = {
+            "completed": self.n,
+            "elapsed_seconds": elapsed,
+        }
+        if self.total is not None:
+            values["total"] = self.total
+        if rate is not None:
+            values["rate"] = rate
+        for key, value in self.postfix.items():
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                values[f"postfix.{key}"] = float(value)
+        for kind, value in values.items():
+            emitter.emit_user_gauge(
+                label=self._metric_label,
+                value=float(value),
+                kind=kind,
+                step_index=step_index,
+                unit=(
+                    f"{self.unit}/s"
+                    if kind == "rate"
+                    else self.unit
+                    if kind in {"completed", "total"}
+                    else None
+                ),
+            )
+
+    def _render(self, *, elapsed: float, rate: float | None) -> None:
+        if self.disable:
+            return
+        prefix = f"{self.desc}: " if self.desc else ""
+        count = f"{self.n:g}"
+        if self.total is None:
+            amount = count
+            percent = ""
+            remaining = None
+        else:
+            amount = f"{count}/{self.total:g}"
+            percent = f" {0 if self.total == 0 else self.n / self.total:6.1%}"
+            remaining = (
+                None
+                if rate is None or rate <= 0
+                else max(0.0, self.total - self.n) / rate
+            )
+        rate_text = "?" if rate is None else f"{rate:.2f}"
+        postfix = ", ".join(f"{key}={value}" for key, value in self.postfix.items())
+        text = (
+            f"{prefix}{amount} {self.unit}{percent} "
+            f"[{_format_interval(elapsed)}<{_format_interval(remaining)}, "
+            f"{rate_text} {self.unit}/s]"
+        )
+        if postfix:
+            text += f" {postfix}"
+        padding = " " * max(0, self._last_render_width - len(text))
+        self.file.write(f"\r{text}{padding}")
+        self.file.flush()
+        self._last_render_width = len(text)
+
+    def refresh(self, *, force: bool = False) -> bool:
+        if self._closed:
+            return False
+        now = time.monotonic()
+        if (
+            not force
+            and self._last_refresh_at is not None
+            and now - self._last_refresh_at < self.mininterval
+        ):
+            return False
+        elapsed = max(0.0, now - self._started_at)
+        rate = None if elapsed <= 0 else max(0.0, self.n / elapsed)
+        self._emit_metrics(elapsed=elapsed, rate=rate)
+        self._render(elapsed=elapsed, rate=rate)
+        self._last_refresh_at = now
+        return True
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.refresh(force=True)
+        self._closed = True
+        if not self.disable:
+            self.file.write("\n")
+            self.file.flush()
+
+    def __iter__(self) -> Iterator[T]:
+        if self.iterable is None:
+            raise TypeError("Progress is not iterable without an iterable")
+        try:
+            for item in self.iterable:
+                yield item
+                self.update()
+        finally:
+            self.close()
+
+    def __enter__(self) -> Progress[T]:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def progress(
+    iterable: Iterable[T] | None = None,
+    *,
+    total: float | None = None,
+    desc: str | None = None,
+    unit: str = "it",
+    initial: float = 0,
+    mininterval: float = 0.5,
+    file: TextIO | None = None,
+    disable: bool | None = None,
+) -> Progress[T]:
+    """Create a cloud-observable progress tracker with tqdm-style semantics."""
+
+    return Progress(
+        iterable,
+        total=total,
+        desc=desc,
+        unit=unit,
+        initial=initial,
+        mininterval=mininterval,
+        file=file,
+        disable=disable,
+    )
+
+
+__all__ = ["Progress", "progress"]

--- a/tests/cli/test_job_commands.py
+++ b/tests/cli/test_job_commands.py
@@ -93,6 +93,7 @@ class _FakeClient:
                         "requestedNumWorkers": 4,
                         "cpuCores": 8,
                         "memoryMb": 16384,
+                        "scratchDiskMb": 512000,
                         "gpuCount": 1,
                         "gpuType": "a10g",
                         "gpuTypes": ["a10", "l4", "t4"],
@@ -304,6 +305,8 @@ def test_jobs_get_plain_output(monkeypatch, capsys) -> None:
     assert "c=3 a=2 p=5 t=10" in out.out
     assert "CPU" in out.out
     assert "Memory" in out.out
+    assert "Scratch" in out.out
+    assert "512000" in out.out
     assert "GPU" in out.out
     assert "  8  " in out.out
     assert "16384" in out.out

--- a/tests/launchers/test_cloud_launcher.py
+++ b/tests/launchers/test_cloud_launcher.py
@@ -231,6 +231,7 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
         num_workers=3,
         cpus_per_worker=2,
         mem_mb_per_worker=4096,
+        scratch_disk_mb_per_worker=512_000,
         gpu=GPU(count=2, type="h100", cuda_version="12.8"),
     )
 
@@ -245,6 +246,7 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert request.plan["stages"][0]["requested_num_workers"] == 3
     assert request.plan["stages"][0]["cpus_per_worker"] == 2
     assert request.plan["stages"][0]["memory_mb_per_worker"] == 4096
+    assert request.plan["stages"][0]["scratch_disk_mb_per_worker"] == 512_000
     assert request.plan["stages"][0]["gpu"] == {
         "count": 2,
         "type": "h100",
@@ -262,6 +264,7 @@ def test_pipeline_launch_cloud_submits_compiled_plan(monkeypatch) -> None:
     assert request.stage_payloads[0].runtime.region == ("us", "eu", "ca")
     assert request.stage_payloads[0].runtime.cpus_per_worker == 2
     assert request.stage_payloads[0].runtime.mem_mb_per_worker == 4096
+    assert request.stage_payloads[0].runtime.scratch_disk_mb_per_worker == 512_000
     assert request.stage_payloads[0].runtime.gpu == GPU(
         count=2,
         type="h100",
@@ -348,6 +351,33 @@ def test_pipeline_sequence_launch_cloud_rejects_gpu_for_aws(monkeypatch) -> None
         sequence.launch_cloud(name="invalid aws gpu job", provider="aws")
 
     assert captured["events"] == []
+
+
+def test_pipeline_launch_cloud_rejects_scratch_disk_for_aws_before_upload(
+    monkeypatch,
+) -> None:
+    captured = _stub_cloud_submit(monkeypatch)
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote",
+        lambda ref: True,
+    )
+
+    with pytest.raises(SystemExit, match="does not support configurable scratch disk"):
+        read_jsonl("input.jsonl").launch_cloud(
+            name="invalid aws scratch job",
+            provider="aws",
+            scratch_disk_mb_per_worker=100_000,
+        )
+
+    assert captured["events"] == []
+
+
+def test_pipeline_launch_cloud_rejects_invalid_scratch_disk() -> None:
+    with pytest.raises(ValueError, match="scratch_disk_mb_per_worker must be > 0"):
+        read_jsonl("input.jsonl").launch_cloud(
+            name="invalid scratch job",
+            scratch_disk_mb_per_worker=0,
+        )
 
 
 def test_pipeline_launch_cloud_rejects_runtime_services_for_aws_before_upload(
@@ -542,7 +572,10 @@ def test_debug_allocation_fingerprint_ignores_unselected_workspace_secret(
     assert first.allocation_fingerprint == second.allocation_fingerprint
 
 
-def test_debug_allocation_fingerprint_changes_with_provider() -> None:
+def test_debug_allocation_fingerprint_changes_with_provider(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
     modal = CloudLauncher(pipeline=read_jsonl("input.jsonl"), name="debug")
     aws = CloudLauncher(
         pipeline=read_jsonl("input.jsonl"), name="debug", provider="aws"
@@ -559,6 +592,24 @@ def test_debug_allocation_fingerprint_changes_with_provider() -> None:
         modal_preparation.allocation_fingerprint
         != aws_preparation.allocation_fingerprint
     )
+
+
+def test_debug_allocation_fingerprint_changes_with_scratch_disk(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "refiner.launchers.cloud.refiner_ref_exists_on_remote", lambda _ref: True
+    )
+    small = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        scratch_disk_mb_per_worker=100_000,
+    ).prepare_debug_sync()
+    large = CloudLauncher(
+        pipeline=read_jsonl("input.jsonl"),
+        name="debug",
+        scratch_disk_mb_per_worker=200_000,
+    ).prepare_debug_sync()
+
+    assert small.allocation_fingerprint != large.allocation_fingerprint
 
 
 def test_debug_launch_fingerprint_changes_with_workspace_secret_version(
@@ -1755,12 +1806,14 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
         name="demo cloud",
         cpus_per_worker=4,
         mem_mb_per_worker=8192,
+        scratch_disk_mb_per_worker=100_000,
         gpu=GPU(count=1, type="h100", cuda_version="12.6"),
     )
 
     request = cast(CloudRunCreateRequest, captured["submit_request"])
     assert request.plan["stages"][0]["cpus_per_worker"] == 4
     assert request.plan["stages"][0]["memory_mb_per_worker"] == 8192
+    assert request.plan["stages"][0]["scratch_disk_mb_per_worker"] == 100_000
     assert request.plan["stages"][0]["gpu"] == {
         "count": 1,
         "type": "h100",
@@ -1768,6 +1821,7 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
     }
     assert "cpus_per_worker" not in request.plan["stages"][1]
     assert "memory_mb_per_worker" not in request.plan["stages"][1]
+    assert "scratch_disk_mb_per_worker" not in request.plan["stages"][1]
     assert "gpu" not in request.plan["stages"][1]
     first_runtime = request.stage_payloads[0].runtime
     second_runtime = request.stage_payloads[1].runtime
@@ -1775,9 +1829,11 @@ def test_pipeline_launch_cloud_preserves_reducer_stage_resource_opt_out(
     assert second_runtime is not None
     assert first_runtime.cpus_per_worker == 4
     assert first_runtime.mem_mb_per_worker == 8192
+    assert first_runtime.scratch_disk_mb_per_worker == 100_000
     assert first_runtime.gpu == GPU(count=1, type="h100", cuda_version="12.6")
     assert second_runtime.cpus_per_worker is None
     assert second_runtime.mem_mb_per_worker is None
+    assert second_runtime.scratch_disk_mb_per_worker is None
     assert second_runtime.gpu is None
 
 

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -38,6 +38,7 @@ def _request() -> CloudRunCreateRequest:
                     num_workers=2,
                     cpus_per_worker=4,
                     mem_mb_per_worker=8192,
+                    scratch_disk_mb_per_worker=512_000,
                     gpu=GPU(count=2, type="h100", cuda_version="12.4"),
                 ),
                 runtime_services=(
@@ -125,6 +126,7 @@ def test_cloud_client_cloud_submit_job_posts_to_cloud_runs(monkeypatch) -> None:
                 "region": ["us", "eu", "ca"],
                 "cpus_per_worker": 4,
                 "mem_mb_per_worker": 8192,
+                "scratch_disk_mb_per_worker": 512_000,
                 "gpu": {
                     "count": 2,
                     "type": "h100",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -14,3 +14,19 @@ def test_inference_import_does_not_cycle() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_progress_is_available_from_top_level() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import refiner as mdr; assert callable(mdr.progress); assert mdr.Progress",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/worker/test_progress.py
+++ b/tests/worker/test_progress.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from io import StringIO
+from importlib import import_module
+
+import pytest
+
+import refiner as mdr
+from refiner.worker.metrics.emitter import UserMetricsEmitter
+
+
+class _RecordingEmitter(UserMetricsEmitter):
+    def __init__(self) -> None:
+        self.gauges: list[dict[str, object]] = []
+
+    def emit_user_gauge(self, **kwargs: object) -> None:
+        self.gauges.append(kwargs)
+
+
+def test_progress_wraps_iterable_and_emits_absolute_snapshots(monkeypatch) -> None:
+    emitter = _RecordingEmitter()
+    module = import_module("refiner.progress_api")
+    monkeypatch.setattr(module, "get_active_user_metrics_emitter", lambda: emitter)
+    monkeypatch.setattr(module, "get_active_step_index", lambda: 4)
+
+    tracker = mdr.progress(
+        ["a", "b", "c"],
+        desc="Colorizing",
+        unit="frame",
+        mininterval=0,
+        disable=True,
+    )
+
+    assert list(tracker) == ["a", "b", "c"]
+    assert tracker.n == 3
+    assert tracker.total == 3
+    completed = [
+        call["value"] for call in emitter.gauges if call["kind"] == "completed"
+    ]
+    assert completed == [0.0, 1.0, 2.0, 3.0, 3.0]
+    assert all(call["label"] == "progress.Colorizing" for call in emitter.gauges)
+    assert all(call["step_index"] == 4 for call in emitter.gauges)
+
+
+def test_progress_supports_manual_tqdm_style_updates_and_postfix(monkeypatch) -> None:
+    emitter = _RecordingEmitter()
+    module = import_module("refiner.progress_api")
+    monkeypatch.setattr(module, "get_active_user_metrics_emitter", lambda: emitter)
+    output = StringIO()
+
+    with mdr.progress(
+        total=10,
+        desc="Encoding",
+        unit="video",
+        mininterval=0,
+        file=output,
+        disable=False,
+    ) as tracker:
+        tracker.update(4)
+        tracker.set_description("Encoding camera 2")
+        tracker.set_postfix(gpu=72, state="active")
+
+    assert tracker.n == 4
+    assert "Encoding camera 2: 4/10 video" in output.getvalue()
+    assert "gpu=72" in output.getvalue()
+    assert output.getvalue().endswith("\n")
+    postfix = [call for call in emitter.gauges if call["kind"] == "postfix.gpu"]
+    assert postfix[-1]["value"] == 72.0
+    assert not any(call["kind"] == "postfix.state" for call in emitter.gauges)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"total": -1}, "total must be >= 0"),
+        ({"initial": -1}, "initial must be >= 0"),
+        ({"mininterval": -1}, "mininterval must be >= 0"),
+        ({"unit": ""}, "unit must be non-empty"),
+    ],
+)
+def test_progress_validates_configuration(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        mdr.progress(disable=True, **kwargs)
+
+
+def test_manual_progress_is_not_iterable() -> None:
+    tracker = mdr.progress(total=1, disable=True)
+    with pytest.raises(TypeError, match="not iterable"):
+        next(iter(tracker))
+    tracker.close()


### PR DESCRIPTION
## Purpose

Make large media and archive workloads easier to size and observe on Macrodata Cloud.

## Changes

- add `scratch_disk_mb_per_worker` to `launch_cloud()`
- propagate scratch disk through stage planning, cloud runtime payloads, and retained-debug allocation fingerprints
- reject configurable scratch disk on AWS Batch before source upload; Modal remains supported
- show scratch disk in `macrodata jobs get`
- add `mdr.progress` with tqdm-style iterable and manual-update semantics
- emit throttled absolute progress gauges for completed count, total, elapsed time, rate, and numeric postfix values
- render local interactive progress and document that progress is observational rather than a checkpoint
- update cloud, resource, debug, CLI, and observability documentation

## Design notes

Progress uses the existing user-metrics transport. Absolute gauge snapshots avoid replaying cumulative increments when an attempt is retried. Existing `log_throughput`, gauge, and histogram APIs are unchanged.

The cloud platform must map `scratch_disk_mb_per_worker` to the Modal ephemeral-disk setting and can recognize `progress.*` metric labels for a dedicated progress presentation.

## Test evidence

- `uv run pytest`: 1324 passed, 22 skipped
- `uv run ruff check --force-exclude .`
- `uv run ruff format --force-exclude .`
- `uv run ty check`
- `uv run pre-commit run --all-files`
- `git diff --check`