### PR TITLE
fix(debug): poll retained attempts and reuse IDs on retries

### DIFF
--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -154,13 +154,6 @@ session to continue. Synchronized files, profiles, and changes made through
 exec are ephemeral. AWS debug sessions remain CPU-only and do not support
 runtime services.
 
-## Internal Notes
-
-Shard claims and completions are written to an atomic, private SQLite ledger in
-the retained worker rather than the job's canonical shard ledger. Each attempt
-resets that private ledger and passes it explicitly to the normal cloud worker
-entrypoint.
-
 ## Resume a debug command after a connection failure
 
 `macrodata debug run` and `macrodata debug exec` print an attempt ID before
@@ -183,3 +176,11 @@ and keep the output prefix fixed between create and sync. Otherwise the changed
 hash is an environment change and requires a new worker. Source-only changes
 can reuse the worker; dependency, resource, secret, and environment changes still
 require recreating the session.
+
+
+## Internal Notes
+
+Shard claims and completions are written to an atomic, private SQLite ledger in
+the retained worker rather than the job's canonical shard ledger. Each attempt
+resets that private ledger and passes it explicitly to the normal cloud worker
+entrypoint.

--- a/docs/running-pipelines/cloud-debug-sessions.md
+++ b/docs/running-pipelines/cloud-debug-sessions.md
@@ -160,3 +160,26 @@ Shard claims and completions are written to an atomic, private SQLite ledger in
 the retained worker rather than the job's canonical shard ledger. Each attempt
 resets that private ledger and passes it explicitly to the normal cloud worker
 entrypoint.
+
+## Resume a debug command after a connection failure
+
+`macrodata debug run` and `macrodata debug exec` print an attempt ID before
+starting. They poll for the result while the command runs on the retained worker.
+If your connection fails, repeat the same command and options with
+`--attempt-id <printed-UUID>` to retrieve or continue waiting for that attempt.
+Reusing the ID does not run the command again. Use a new ID for an intentional
+rerun. A command timeout returns exit code 124.
+
+Attempts remain available while the retained worker exists. A stopped or lost
+worker cannot recover its local results. Each session retains up to 128 attempts;
+command output is limited to 256 KiB each for stdout and stderr.
+
+## Keep generated configuration stable during source sync
+
+If your launcher publishes a manifest and passes its key/hash through `env`,
+recapturing the same launch must produce identical manifest bytes. Use the pinned
+inventory timestamp instead of the current time, serialize deterministically,
+and keep the output prefix fixed between create and sync. Otherwise the changed
+hash is an environment change and requires a new worker. Source-only changes
+can reuse the worker; dependency, resource, secret, and environment changes still
+require recreating the session.

--- a/src/refiner/cli/debug.py
+++ b/src/refiner/cli/debug.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 import tempfile
 import time
+import uuid
 from typing import Any
 
 from refiner.cli.debug_sessions import (
@@ -40,6 +41,16 @@ def _print_json(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
 
+def _attempt_id(args: argparse.Namespace) -> str:
+    value = str(uuid.UUID(args.attempt_id)) if args.attempt_id else str(uuid.uuid4())
+    print(
+        f"Debug attempt {value} (reuse --attempt-id to resume)",
+        file=sys.stderr,
+        flush=True,
+    )
+    return value
+
+
 def _emit_exec_result(payload: dict[str, Any]) -> int:
     stdout = payload.get("stdout")
     stderr = payload.get("stderr")
@@ -47,6 +58,11 @@ def _emit_exec_result(payload: dict[str, Any]) -> int:
         print(stdout, end="" if stdout.endswith("\n") else "\n")
     if isinstance(stderr, str) and stderr:
         print(stderr, end="" if stderr.endswith("\n") else "\n", file=sys.stderr)
+    if payload.get("output_truncated"):
+        print(
+            "Debug output exceeded the retained output limit and was truncated.",
+            file=sys.stderr,
+        )
     return_code = payload.get("exit_code")
     return return_code if isinstance(return_code, int) else 1
 
@@ -130,6 +146,9 @@ def _debug_parser() -> argparse.ArgumentParser:
 
     run = subparsers.add_parser("run", help="Run the synchronized pipeline once")
     _add_target(run)
+    run.add_argument(
+        "--attempt-id", help="Resume/retry an existing attempt without rerunning it"
+    )
     run.add_argument("--max-shards", type=int)
     run.add_argument("--timeout", type=int, default=3600)
     run.add_argument("--profile", action="store_true")
@@ -155,6 +174,9 @@ def _debug_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_target(execute)
+    execute.add_argument(
+        "--attempt-id", help="Resume/retry an existing attempt without rerunning it"
+    )
     execute.add_argument("--workdir", metavar="PATH", help="Worker working directory")
     execute.add_argument(
         "--timeout",
@@ -467,7 +489,9 @@ def _dispatch(args: argparse.Namespace) -> int:
     if args.debug_command == "run":
         if args.max_shards is not None and args.max_shards <= 0:
             raise SystemExit("--max-shards must be greater than zero")
+        attempt_id = _attempt_id(args)
         payload = client.cloud_debug_run(
+            attempt_id=attempt_id,
             job_id=job_id,
             max_shards=args.max_shards,
             timeout_secs=args.timeout,
@@ -492,6 +516,7 @@ def _dispatch(args: argparse.Namespace) -> int:
             raise SystemExit("debug exec requires a command after --")
         return _emit_exec_result(
             client.cloud_debug_exec(
+                attempt_id=_attempt_id(args),
                 job_id=job_id,
                 command=command,
                 workdir=args.workdir,

--- a/src/refiner/platform/client/api.py
+++ b/src/refiner/platform/client/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, TypeVar
 from urllib.parse import quote, urlencode
@@ -417,6 +418,7 @@ class MacrodataClient:
         self,
         *,
         job_id: str,
+        attempt_id: str | None = None,
         command: list[str],
         workdir: str | None = None,
         timeout_secs: int = 300,
@@ -427,18 +429,22 @@ class MacrodataClient:
         }
         if workdir is not None:
             payload["workdir"] = workdir
-        return self._request_raw(
+        attempt_id = str(uuid.UUID(attempt_id)) if attempt_id else str(uuid.uuid4())
+        payload["attempt_id"] = attempt_id
+        result = self._request_raw(
             method="POST",
             path=f"/api/cloud/debug/{quote(job_id, safe='')}/exec",
             json_payload=payload,
-            timeout_s=float(timeout_secs + 30),
-            retry_attempts=1,
+            timeout_s=40.0,
+            retry_attempts=4,
         )
+        return self._wait_debug_attempt(job_id, attempt_id, result, timeout_secs)
 
     def cloud_debug_run(
         self,
         *,
         job_id: str,
+        attempt_id: str | None = None,
         max_shards: int | None = None,
         timeout_secs: int = 3600,
         profile: bool = False,
@@ -448,13 +454,39 @@ class MacrodataClient:
             payload["max_shards"] = max_shards
         if profile:
             payload["profile"] = True
-        return self._request_raw(
+        attempt_id = str(uuid.UUID(attempt_id)) if attempt_id else str(uuid.uuid4())
+        payload["attempt_id"] = attempt_id
+        result = self._request_raw(
             method="POST",
             path=f"/api/cloud/debug/{quote(job_id, safe='')}/run",
             json_payload=payload,
-            timeout_s=float(timeout_secs + 30),
-            retry_attempts=1,
+            timeout_s=40.0,
+            retry_attempts=4,
         )
+        return self._wait_debug_attempt(job_id, attempt_id, result, timeout_secs)
+
+    def cloud_debug_attempt(self, *, job_id: str, attempt_id: str) -> dict[str, Any]:
+        return self._request_raw(
+            method="GET",
+            path=f"/api/cloud/debug/{quote(job_id, safe='')}/attempts/{quote(attempt_id, safe='')}",
+            timeout_s=40.0,
+        )
+
+    def _wait_debug_attempt(
+        self, job_id: str, attempt_id: str, result: dict[str, Any], timeout_secs: int
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_secs + 60
+        while result.get("status") == "running":
+            if time.monotonic() >= deadline:
+                raise MacrodataApiError(
+                    status=408,
+                    message=f"Timed out waiting for debug attempt {attempt_id}; resume using the same attempt ID",
+                )
+            time.sleep(1)
+            result = self.cloud_debug_attempt(job_id=job_id, attempt_id=attempt_id)
+        if result.get("status") not in {"completed", "failed"}:
+            raise MacrodataApiError(status=502, message="Invalid debug attempt result")
+        return result
 
     def cloud_debug_profile(self, *, job_id: str) -> dict[str, Any]:
         return self._request_raw(

--- a/tests/cli/test_debug_commands.py
+++ b/tests/cli/test_debug_commands.py
@@ -42,7 +42,13 @@ class _FakeClient:
 
 
 def _args(command: str, **kwargs) -> Namespace:
-    return Namespace(debug_command=command, pipeline=None, job_id="job-1", **kwargs)
+    return Namespace(
+        debug_command=command,
+        pipeline=None,
+        job_id="job-1",
+        attempt_id=kwargs.pop("attempt_id", None),
+        **kwargs,
+    )
 
 
 def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
@@ -81,6 +87,7 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
             "exec",
             {
                 "job_id": "job-1",
+                "attempt_id": client.calls[1][1]["attempt_id"],
                 "command": ["python", "-V"],
                 "workdir": None,
                 "timeout_secs": 20,
@@ -90,6 +97,7 @@ def test_debug_commands_forward_to_cloud_api(monkeypatch, capsys) -> None:
             "run",
             {
                 "job_id": "job-1",
+                "attempt_id": client.calls[2][1]["attempt_id"],
                 "max_shards": 1,
                 "timeout_secs": 30,
                 "profile": False,
@@ -507,3 +515,15 @@ def test_debug_reports_expected_errors_without_traceback(monkeypatch, capsys) ->
         == 1
     )
     assert capsys.readouterr().err == "not ready\n"
+
+
+def test_exec_resume_uses_and_prints_supplied_attempt_id(monkeypatch, capsys):
+    client = _FakeClient()
+    monkeypatch.setattr(debug, "MacrodataClient", lambda: client)
+    attempt_id = "00000000-0000-4000-8000-000000000001"
+    args = debug._parse_debug_args(
+        ["exec", "--job", "job-1", "--attempt-id", attempt_id, "--", "python", "-V"]
+    )
+    assert debug._dispatch(args) == 0
+    assert client.calls[0][1]["attempt_id"] == attempt_id
+    assert attempt_id in capsys.readouterr().err

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -174,11 +174,18 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
     client.cloud_debug_status(job_id="job/1")
     client.cloud_debug_exec(
         job_id="job/1",
+        attempt_id="00000000-0000-4000-8000-000000000001",
         command=["python", "-V"],
         workdir="/tmp/refiner-debug",
         timeout_secs=12,
     )
-    client.cloud_debug_run(job_id="job/1", max_shards=1, timeout_secs=30, profile=True)
+    client.cloud_debug_run(
+        job_id="job/1",
+        attempt_id="00000000-0000-4000-8000-000000000002",
+        max_shards=1,
+        timeout_secs=30,
+        profile=True,
+    )
     client.cloud_debug_profile(job_id="job/1")
     client.cloud_debug_stop(job_id="job/1")
     client.cloud_debug_doctor(job_id="job/1")
@@ -192,13 +199,13 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         "/api/cloud/debug/job%2F1/doctor",
     ]
     assert calls[1]["json_payload"] == {
-        "attempt_id": calls[1]["json_payload"]["attempt_id"],
+        "attempt_id": "00000000-0000-4000-8000-000000000001",
         "command": ["python", "-V"],
         "timeout_secs": 12,
         "workdir": "/tmp/refiner-debug",
     }
     assert calls[2]["json_payload"] == {
-        "attempt_id": calls[2]["json_payload"]["attempt_id"],
+        "attempt_id": "00000000-0000-4000-8000-000000000002",
         "timeout_secs": 30,
         "max_shards": 1,
         "profile": True,

--- a/tests/platform/test_cloud_client.py
+++ b/tests/platform/test_cloud_client.py
@@ -166,7 +166,9 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
     monkeypatch.setattr(
         client,
         "_request_raw",
-        lambda **kwargs: calls.append(kwargs) or {"status": "ready"},
+        lambda **kwargs: (
+            calls.append(kwargs) or {"status": "completed", "exit_code": 0}
+        ),
     )
 
     client.cloud_debug_status(job_id="job/1")
@@ -190,17 +192,19 @@ def test_cloud_debug_client_uses_retained_session_routes(monkeypatch) -> None:
         "/api/cloud/debug/job%2F1/doctor",
     ]
     assert calls[1]["json_payload"] == {
+        "attempt_id": calls[1]["json_payload"]["attempt_id"],
         "command": ["python", "-V"],
         "timeout_secs": 12,
         "workdir": "/tmp/refiner-debug",
     }
     assert calls[2]["json_payload"] == {
+        "attempt_id": calls[2]["json_payload"]["attempt_id"],
         "timeout_secs": 30,
         "max_shards": 1,
         "profile": True,
     }
-    assert calls[1]["retry_attempts"] == 1
-    assert calls[2]["retry_attempts"] == 1
+    assert calls[1]["retry_attempts"] == 4
+    assert calls[2]["retry_attempts"] == 4
 
 
 def test_cloud_debug_sync_streams_bundle_bytes() -> None:
@@ -498,3 +502,37 @@ def test_cloud_client_completes_cloud_files(monkeypatch) -> None:
     assert response.files[0].file_id == "00000000-0000-7000-8000-000000000123"
     assert response.files[0].uploaded_at == _TEST_TIMESTAMP
     assert response.files[0].expires_at is None
+
+
+def test_debug_attempt_survives_lost_start_response(monkeypatch):
+    from refiner.platform.client.api import MacrodataApiError
+
+    calls = []
+    attempt_id = "00000000-0000-4000-8000-000000000001"
+
+    def request(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise MacrodataApiError(status=504, message="response lost")
+        if kwargs["method"] == "POST":
+            return {"attempt_id": attempt_id, "status": "running"}
+        return {
+            "attempt_id": attempt_id,
+            "status": "completed",
+            "exit_code": 0,
+            "stdout": "done",
+        }
+
+    monkeypatch.setattr("refiner.platform.client.api.request_json", request)
+    monkeypatch.setattr("refiner.platform.client.api.time.sleep", lambda _: None)
+    client = MacrodataClient(api_key="md_test", base_url="https://example.com")
+    result = client.cloud_debug_run(job_id="job/1", attempt_id=attempt_id)
+    assert result["stdout"] == "done"
+    assert [call["method"] for call in calls] == ["POST", "POST", "GET"]
+    assert (
+        calls[0]["json_payload"]["attempt_id"]
+        == calls[1]["json_payload"]["attempt_id"]
+        == attempt_id
+    )
+    assert calls[2]["path"] == f"/api/cloud/debug/job%2F1/attempts/{attempt_id}"
+    assert all(call["timeout_s"] == 40 for call in calls)


### PR DESCRIPTION
Debug run/exec currently wait on one HTTP request for the entire remote command, which can outlast the gateway's 60-second idle timeout. This client submits an attempt ID, polls for its result, and reuses the same ID when retrying a lost start response.

The CLI prints the ID before submission and accepts `--attempt-id` to resume the same command after a disconnect. It reports truncated output and preserves command exit codes. Documentation also explains deterministic manifest generation for source sync; actual environment or dependency changes still require worker recreation.

Validation: 41 targeted client/CLI/sync tests passed, including a lost start response and explicit attempt resumption. Scoped Ruff and type checks passed.

Rollout: requires the companion cloud-controller/worker implementation before this client is used. Recreate sessions that use older worker runtime images. Attempt results survive controller restarts but remain local to the retained worker. This change has not been deployed.

Companion controller and worker PR: https://github.com/macrodata-labs/perpetuity/pull/950
