### PR TITLE
Add L4-optimized GPU video transcoding blocks

### DIFF
--- a/docs/reading-data/files-and-videos.md
+++ b/docs/reading-data/files-and-videos.md
@@ -48,6 +48,6 @@ through `row.videos`.
 
 ## Related pages
 
+- [GPU Video Transcoding](../transforms/gpu-video-transcoding.md)
 - [Video Sources](../episode-data/frames-and-videos.md)
 - [Media Assets and Reducers](../writing-data/media-assets-and-reducers.md)
-

--- a/docs/transforms/gpu-video-transcoding.md
+++ b/docs/transforms/gpu-video-transcoding.md
@@ -1,0 +1,194 @@
+---
+title: "GPU video transcoding"
+description: "Prepare H.264 training videos and ordered image sequences with NVIDIA NVENC"
+---
+
+Use `mdr.video.transcode_videos` to transcode whole video files, or
+`mdr.video.encode_image_sequences` to turn ordered JPEG or PNG sequences into
+videos. Both are async map blocks that always encode with NVIDIA NVENC.
+
+## Transcode videos
+
+```python
+import refiner as mdr
+
+pipeline = mdr.read_videos("/data/source/*.mp4", file_path_column="video").map_async(
+    mdr.video.transcode_videos(
+        video_key="video",
+        output_folder="/data/encoded",
+        output_key="training_video",
+        config=mdr.video.NVENCConfig(),
+    ),
+    max_in_flight=4,
+    preserve_order=False,
+    dtypes={"training_video": mdr.datatype.video_path()},
+)
+```
+
+Input values can be paths, `mdr.io.DataFile` objects, or whole
+`mdr.video.VideoFile` objects. Each output row keeps its original fields and adds
+the new MP4 path. Use a durable shared `output_folder` for cloud pipelines,
+for example an S3 bucket accessible to the worker. Clipped views are rejected;
+materialize the desired clip before using this block.
+
+Request one L4 per worker on the launch call and begin with three or four in-flight rows.
+Each row uses one FFmpeg process. `max_in_flight` bounds decoding, encoding, and
+file staging together; it is per worker, not a global limit. Start with 8 CPUs
+and 8 GiB RAM per worker and provision scratch disk for the concurrently staged
+inputs and outputs. GPU allocation belongs on the launcher, not the block.
+
+## Encode ordered images
+
+```python
+import refiner as mdr
+
+pipeline = mdr.from_items([
+    {"episode_id": "episode-1", "images": ["/data/0001.jpg", "/data/0002.jpg"]},
+]).map_async(
+    mdr.video.encode_image_sequences(
+        images_key="images",
+        output_folder="/data/encoded",
+        fps=30,
+    ),
+    max_in_flight=4,
+    dtypes={"encoded_video": mdr.datatype.video_path()},
+)
+```
+
+Supply a nonempty list of uniformly sized files, all JPEG or all PNG. List order
+is frame order; the block does not sort filenames. Image decode and conversion
+to limited-range YUV happen on the CPU; encoding happens on the GPU. No Python
+RGB frame arrays are created. The output frame count must match the list length.
+
+## Output and tuning
+
+| Setting | Default | Behavior |
+| --- | --- | --- |
+| Codec | H.264 NVENC | 8-bit `yuv420p`, limited range, MP4 faststart |
+| `preset` | `"p1"` | Fastest NVENC preset; `"p6"` spends more work on compression |
+| `cq` | `29` | VBR constant-quality target; lower values request higher quality |
+| `gop` | `17` | Fixed keyframe interval in frames, no scene cuts or B-frames |
+| Bounds | 1920 × 1080 | Keep aspect ratio approximately, round down to even dimensions, never upscale |
+| `decode` | `"auto"` | CUDA for common 8-bit 4:2:0 H.264/HEVC/VP9/AV1; CPU conversion otherwise |
+| `audio` | `"drop"` | Choose `"aac"` to retain the first audio stream as 128 kbps AAC |
+| `gpu` | `0` | CUDA device ordinal as visible inside the worker |
+| `cpu_threads` | `2` | Decoder thread budget per FFmpeg process |
+| `timeout_s` | `3600` | Timeout for each FFmpeg/ffprobe subprocess |
+
+Video frame timing passes through without an FPS conversion. Source timestamps
+are normalized by FFmpeg's normal input handling; do not use output timestamps
+as an absolute source clock. Image sequences receive a regular timeline at `fps`.
+Automatic rotation is disabled so pixels remain in source annotation coordinates.
+Resize associated keypoints, boxes, and intrinsics to match output dimensions;
+these blocks do not modify annotation columns. HDR inputs require tone mapping
+before this SDR block.
+
+On the CUDA path, decode surfaces remain on the GPU through `scale_cuda` and
+NVENC. Full-range inputs use CPU range conversion in `auto` mode. `decode="cpu"`
+still uses NVENC for encoding. `decode="cuda"` forces hardware decoding and
+reports unsupported input/build errors; it does not silently retry on the CPU.
+
+The defaults prioritize throughput. Choosing `preset="p6"` restores the preset
+used in earlier dataset converters, but does not promise bit-identical output:
+this block disables lookahead, multipass, and B-frames and fixes the GOP.
+CQ 29 is an encoder quality target, not an equivalence to x264 CRF 29.
+
+Measure on your own videos before scaling worker count:
+
+```bash
+python examples/benchmark_video_nvenc.py /data/representative.mp4 --copies 8
+```
+
+The benchmark compares `p1` and `p6` with one through four concurrent lanes.
+It reports aggregate frames per second including probing and local publication,
+after a warmup. It excludes remote transfer and does not measure perceptual
+quality. Short clips, image decoding, storage, and scene complexity can change
+which configuration wins.
+
+An L4 validation run on September 8, 2026 used 8 CPUs, 8 GiB RAM, NVIDIA driver
+580.95.05, and FFmpeg 8.1. It encoded eight copies of a 600-frame, 1920×1080
+`testsrc2` H.264 video for each configuration:
+
+| Concurrent lanes | `p1` aggregate fps | `p6` aggregate fps |
+| --- | --- | --- |
+| 1 | 308.4 | 205.8 |
+| 2 | 550.7 | 364.4 |
+| 3 | 663.1 | 395.3 |
+| 4 | 660.6 | 394.7 |
+
+Three and four lanes performed similarly on the final implementation. These are
+single-run synthetic local-file measurements, not a throughput guarantee for
+datasets or remote storage. Earlier runs varied, so benchmark both settings on
+your worker image and representative input.
+
+## Worker setup and validation
+
+Install a recent FFmpeg build (8.x is used for validation) and `ffprobe` on the
+worker's `PATH`, or set `NVENCConfig(ffmpeg=..., ffprobe=...)`. The build must
+include `h264_nvenc` and, for CUDA decoding/scaling, `scale_cuda`. Install a
+compatible NVIDIA driver and expose the GPU's video capabilities to the
+container. Installing Refiner's Python `video` extra alone does not install
+these executables or the NVIDIA driver.
+
+Run the hardware tests on the actual worker image:
+
+```bash
+REFINER_TEST_NVENC=1 pytest tests/test_video_nvenc.py -q
+```
+
+The CUDA and CPU-decode tests check frame count, a variable-rate timeline,
+keyframe positions, and faststart MP4. The image test also checks frame order and
+color conversion. All 40 tests passed on the L4 validation worker. Ordinary unit
+tests run without a GPU.
+
+Each encode checks codec, pixel format, dimensions, and positive output frame
+count before publishing. It also compares frame counts when the source container
+reports one; image sequence counts are always checked. This fast path does not
+fully decode every source/output for a timestamp audit. Use the hardware tests
+and dataset-specific validation when strict annotation alignment is required.
+
+## Direct calls
+
+```python
+import refiner as mdr
+
+# Inside an async function:
+video = await mdr.video.transcode_video("source.mp4", "new.mp4")
+video = await mdr.video.encode_image_sequence(
+    ["0001.jpg", "0002.jpg"], "images.mp4", fps=30,
+)
+```
+
+Direct calls return `mdr.video.VideoFile`. Existing destinations are rejected.
+Local files publish atomically. For remote storage, use a unique destination
+per invocation: object-store publication is not a cross-worker lock or transaction.
+The map blocks generate unique names automatically. Retries can leave orphaned
+objects from earlier attempts; these helpers do not implement dataset checkpoints
+or garbage collection.
+
+Very small images or extreme resize bounds can fall below the GPU encoder's
+minimum supported dimensions. The block reports FFmpeg's error rather than
+upscaling or switching to a software encoder.
+
+## Internal Notes
+
+Remote files are staged through `DataFile` so configured storage credentials
+remain with fsspec. Local videos are read directly; local image sequences use
+numbered links. Completed MP4s are validated on disk before upload. Timeout and
+cancellation kill and reap FFmpeg; outstanding file copies finish before scratch
+cleanup. The async block uses the existing pipeline window, without another pool
+of GPU workers.
+The H.264 bitstream filter explicitly signals limited range even when NVENC
+omits that tag. Callable descriptions live in a lightweight module so video
+blocks can be imported before the pipeline planner.
+
+Spark's partition tasks and Beam/Dataflow's element processing could host an
+external encoder, but would require their own scheduling integration. Hugging
+Face Datasets offers process-based mapping. Daft and Ray Data provide GPU task
+or actor scheduling; adding either scheduler here would duplicate Refiner's
+worker and bounded async execution. Refiner keeps those controls and delegates
+codec execution to FFmpeg. This also avoids transferring decoded frame arrays
+through Python merely to feed an encoder.
+
+The device-resident path and concurrent-session design follow
+[NVIDIA's FFmpeg guide](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.1/ffmpeg-with-nvidia-gpu/index.html).

--- a/docs/transforms/gpu-video-transcoding.md
+++ b/docs/transforms/gpu-video-transcoding.md
@@ -25,17 +25,19 @@ pipeline = mdr.read_videos("/data/source/*.mp4", file_path_column="video").map_a
 )
 ```
 
-Input values can be paths, `mdr.io.DataFile` objects, or whole
-`mdr.video.VideoFile` objects. Each output row keeps its original fields and adds
-the new MP4 path. Use a durable shared `output_folder` for cloud pipelines,
-for example an S3 bucket accessible to the worker. Clipped views are rejected;
-materialize the desired clip before using this block.
+Inputs and outputs must be local files. Input values can be local paths,
+`mdr.io.DataFile` objects, or whole `mdr.video.VideoFile` objects. Each output
+row keeps its original fields and adds the new local MP4 path. Remote URLs are
+rejected before accessing their storage backend, including S3, GCS, and HTTP.
+The copying job owns downloading, uploading, and checkpoints: download to a local
+path, call the encoder, then upload its completed output. On cloud workers,
+`output_folder` is worker-local storage; transfer results before the worker exits.
+Clipped views are rejected; materialize the desired clip before using this block.
 
 Request one L4 per worker on the launch call and begin with three or four in-flight rows.
-Each row uses one FFmpeg process. `max_in_flight` bounds decoding, encoding, and
-file staging together; it is per worker, not a global limit. Start with 8 CPUs
-and 8 GiB RAM per worker and provision scratch disk for the concurrently staged
-inputs and outputs. GPU allocation belongs on the launcher, not the block.
+Each row uses one FFmpeg process. `max_in_flight` bounds concurrent local encodes;
+it is per worker, not a global limit. Start with 8 CPUs and 8 GiB RAM per worker
+and provision scratch disk for the local inputs and concurrent outputs. GPU allocation belongs on the launcher, not the block.
 
 ## Encode ordered images
 
@@ -55,7 +57,7 @@ pipeline = mdr.from_items([
 )
 ```
 
-Supply a nonempty list of uniformly sized files, all JPEG or all PNG. List order
+Supply a nonempty list of uniformly sized local files, all JPEG or all PNG. List order
 is frame order; the block does not sort filenames. Image decode and conversion
 to limited-range YUV happen on the CPU; encoding happens on the GPU. No Python
 RGB frame arrays are created. The output frame count must match the list length.
@@ -138,8 +140,8 @@ REFINER_TEST_NVENC=1 pytest tests/test_video_nvenc.py -q
 
 The CUDA and CPU-decode tests check frame count, a variable-rate timeline,
 keyframe positions, and faststart MP4. The image test also checks frame order and
-color conversion. All 40 tests passed on the L4 validation worker. Ordinary unit
-tests run without a GPU.
+color conversion. The encoding path was validated on an L4. Ordinary unit tests
+run without a GPU and verify that remote inputs and outputs are rejected.
 
 Each encode checks codec, pixel format, dimensions, and positive output frame
 count before publishing. It also compares frame counts when the source container
@@ -160,11 +162,10 @@ video = await mdr.video.encode_image_sequence(
 ```
 
 Direct calls return `mdr.video.VideoFile`. Existing destinations are rejected.
-Local files publish atomically. For remote storage, use a unique destination
-per invocation: object-store publication is not a cross-worker lock or transaction.
-The map blocks generate unique names automatically. Retries can leave orphaned
-objects from earlier attempts; these helpers do not implement dataset checkpoints
-or garbage collection.
+Completed local files publish atomically. The map blocks generate unique names
+automatically. Use direct calls with job-controlled destinations for checkpointed
+copying jobs. The caller owns retries and cleanup of earlier outputs; these
+helpers do not implement dataset checkpoints or garbage collection.
 
 Very small images or extreme resize bounds can fall below the GPU encoder's
 minimum supported dimensions. The block reports FFmpeg's error rather than
@@ -172,11 +173,10 @@ upscaling or switching to a software encoder.
 
 ## Internal Notes
 
-Remote files are staged through `DataFile` so configured storage credentials
-remain with fsspec. Local videos are read directly; local image sequences use
-numbered links. Completed MP4s are validated on disk before upload. Timeout and
-cancellation kill and reap FFmpeg; outstanding file copies finish before scratch
-cleanup. The async block uses the existing pipeline window, without another pool
+Videos are read directly from local paths; image sequences use numbered links.
+Completed MP4s are validated in a temporary directory beside the destination,
+then published with an atomic hard link. Timeout and cancellation kill and reap
+FFmpeg; outstanding local filesystem operations finish before scratch cleanup. The async block uses the existing pipeline window, without another pool
 of GPU workers.
 The H.264 bitstream filter explicitly signals limited range even when NVENC
 omits that tag. Callable descriptions live in a lightweight module so video

--- a/docs/transforms/index.md
+++ b/docs/transforms/index.md
@@ -15,7 +15,7 @@ Python rows, async I/O, batches, or Arrow-backed vectorized tables.
 | [Vectorized Transforms](vectorized-transforms.md) | Fast columnar filtering, projection, renaming, and computed columns. |
 | [Expressions](expressions.md) | The expression DSL behind vectorized transforms. |
 | [Schemas and DTypes](schemas-and-dtypes.md) | Type hints for assets, media, and writer schemas. |
+| [GPU Video Transcoding](gpu-video-transcoding.md) | NVENC video conversion and ordered image sequence encoding. |
 
 For packaged episode-level workflows, see
 [Episode Operations](../episode-operations/index.md).
-

--- a/examples/benchmark_video_nvenc.py
+++ b/examples/benchmark_video_nvenc.py
@@ -1,0 +1,73 @@
+"""Compare NVENC presets and concurrency on a local video: python this.py input.mp4."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+
+import refiner as mdr
+
+
+async def benchmark(source: Path, *, copies: int = 8) -> list[dict]:
+    if copies <= 0:
+        raise ValueError("copies must be positive")
+    stream = json.loads(
+        subprocess.check_output(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_streams",
+                "-of",
+                "json",
+                str(source),
+            ]
+        )
+    )["streams"][0]
+    frames = int(stream["nb_frames"])
+    results = []
+    for preset in ("p1", "p6"):
+        for lanes in (1, 2, 3, 4):
+            semaphore = asyncio.Semaphore(lanes)
+            config = mdr.video.NVENCConfig(preset=preset)
+            with tempfile.TemporaryDirectory(prefix="refiner-benchmark-") as temp:
+                # Exclude driver initialization from the measured batch.
+                await mdr.video.transcode_video(
+                    source, Path(temp) / "warmup.mp4", config=config
+                )
+
+                async def encode(index: int) -> None:
+                    async with semaphore:
+                        await mdr.video.transcode_video(
+                            source, Path(temp) / f"{index}.mp4", config=config
+                        )
+
+                started = time.perf_counter()
+                await asyncio.gather(*(encode(index) for index in range(copies)))
+                elapsed = time.perf_counter() - started
+            result = {
+                "preset": preset,
+                "lanes": lanes,
+                "copies": copies,
+                "frames": frames * copies,
+                "wall_s": round(elapsed, 3),
+                "fps": round(frames * copies / elapsed, 1),
+            }
+            results.append(result)
+            print(json.dumps(result), flush=True)
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("--copies", type=int, default=8)
+    args = parser.parse_args()
+    asyncio.run(benchmark(args.source.resolve(), copies=args.copies))

--- a/src/refiner/pipeline/builtins.py
+++ b/src/refiner/pipeline/builtins.py
@@ -1,0 +1,22 @@
+"""Lightweight callable descriptions, usable without importing the planner."""
+
+from typing import Any
+
+
+def describe_builtin(
+    name: str, *, refiner_extras: tuple[str, ...] = (), **args: Any
+) -> Any:
+    def _decorate(fn: Any) -> Any:
+        setattr(
+            fn,
+            "__refiner_builtin_call__",
+            {
+                "name": name,
+                "args": args,
+                "services": (),
+                "refiner_extras": refiner_extras,
+            },
+        )
+        return fn
+
+    return _decorate

--- a/src/refiner/pipeline/planning.py
+++ b/src/refiner/pipeline/planning.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from types import CodeType
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
+from refiner.pipeline.builtins import describe_builtin as describe_builtin
 from refiner.pipeline.steps import (
     CastStep,
     DropStep,
@@ -369,25 +370,6 @@ def _builtin_description(fn: Any) -> dict[str, Any] | None:
             return None
         parsed_services.append(service)
     return {"name": name, "args": args, "services": tuple(parsed_services)}
-
-
-def describe_builtin(
-    name: str, *, refiner_extras: tuple[str, ...] = (), **args: Any
-) -> Any:
-    def _decorate(fn: Any) -> Any:
-        setattr(
-            fn,
-            _REFINER_BUILTIN_CALL_ATTR,
-            {
-                "name": name,
-                "args": args,
-                "services": (),
-                "refiner_extras": refiner_extras,
-            },
-        )
-        return fn
-
-    return _decorate
 
 
 def _step_payload(

--- a/src/refiner/video/__init__.py
+++ b/src/refiner/video/__init__.py
@@ -1,3 +1,5 @@
+from refiner.video.blocks import encode_image_sequences, transcode_videos
+from refiner.video.nvenc import NVENCConfig, encode_image_sequence, transcode_video
 from refiner.video.decode import (
     DecodedFrameWindow,
     DecodedVideoFrame,
@@ -37,6 +39,11 @@ from refiner.video.writer import (
 )
 
 __all__ = [
+    "NVENCConfig",
+    "encode_image_sequence",
+    "encode_image_sequences",
+    "transcode_video",
+    "transcode_videos",
     "DecodedFrameWindow",
     "DecodedVideoFrame",
     "FrameObserver",

--- a/src/refiner/video/blocks.py
+++ b/src/refiner/video/blocks.py
@@ -9,7 +9,12 @@ from refiner.io.datafolder import DataFolderLike
 from refiner.pipeline.builtins import describe_builtin
 from refiner.pipeline.data.row import Row
 from refiner.pipeline.steps import AsyncMapFn
-from refiner.video.nvenc import NVENCConfig, encode_image_sequence, transcode_video
+from refiner.video.nvenc import (
+    NVENCConfig,
+    _local_path,
+    encode_image_sequence,
+    transcode_video,
+)
 
 
 def transcode_videos(
@@ -22,24 +27,24 @@ def transcode_videos(
     """Build an NVENC ``map_async`` block; start with max_in_flight=4 on one L4.
 
     Rows contain whole VideoFile objects, DataFile objects, or paths. Each result
-    adds a durable MP4 path. Unique object names isolate concurrent rows/retries.
+    adds a local MP4 path. The calling job owns transfers and checkpoints.
     """
     if not video_key or not output_key:
         raise ValueError("video_key and output_key must be nonempty")
-    folder = DataFolder.resolve(output_folder)
+    folder = _local_path(DataFolder.resolve(output_folder).abs_path())
     settings = config or NVENCConfig()
 
     @describe_builtin(
         "video.transcode_videos",
         video_key=video_key,
         output_key=output_key,
-        output_folder=folder.abs_path(),
+        output_folder=str(folder),
         config=asdict(settings),
     )
     async def _transcode(row: Row) -> Row:
         result = await transcode_video(
             row[video_key],
-            folder.file(f"{uuid.uuid4().hex}.mp4"),
+            folder / f"{uuid.uuid4().hex}.mp4",
             config=settings,
         )
         return row.update({output_key: result.uri})
@@ -64,21 +69,21 @@ def encode_image_sequences(
         raise ValueError("images_key and output_key must be nonempty")
     if not math.isfinite(fps) or fps <= 0:
         raise ValueError("fps must be finite and > 0")
-    folder = DataFolder.resolve(output_folder)
+    folder = _local_path(DataFolder.resolve(output_folder).abs_path())
     settings = config or NVENCConfig()
 
     @describe_builtin(
         "video.encode_image_sequences",
         images_key=images_key,
         output_key=output_key,
-        output_folder=folder.abs_path(),
+        output_folder=str(folder),
         fps=fps,
         config=asdict(settings),
     )
     async def _encode(row: Row) -> Row:
         result = await encode_image_sequence(
             row[images_key],
-            folder.file(f"{uuid.uuid4().hex}.mp4"),
+            folder / f"{uuid.uuid4().hex}.mp4",
             fps=fps,
             config=settings,
         )

--- a/src/refiner/video/blocks.py
+++ b/src/refiner/video/blocks.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import math
+import uuid
+
+from refiner.io import DataFolder
+from refiner.io.datafolder import DataFolderLike
+from refiner.pipeline.builtins import describe_builtin
+from refiner.pipeline.data.row import Row
+from refiner.pipeline.steps import AsyncMapFn
+from refiner.video.nvenc import NVENCConfig, encode_image_sequence, transcode_video
+
+
+def transcode_videos(
+    *,
+    video_key: str,
+    output_folder: DataFolderLike,
+    output_key: str = "transcoded_video",
+    config: NVENCConfig | None = None,
+) -> AsyncMapFn:
+    """Build an NVENC ``map_async`` block; start with max_in_flight=4 on one L4.
+
+    Rows contain whole VideoFile objects, DataFile objects, or paths. Each result
+    adds a durable MP4 path. Unique object names isolate concurrent rows/retries.
+    """
+    if not video_key or not output_key:
+        raise ValueError("video_key and output_key must be nonempty")
+    folder = DataFolder.resolve(output_folder)
+    settings = config or NVENCConfig()
+
+    @describe_builtin(
+        "video.transcode_videos",
+        video_key=video_key,
+        output_key=output_key,
+        output_folder=folder.abs_path(),
+        config=asdict(settings),
+    )
+    async def _transcode(row: Row) -> Row:
+        result = await transcode_video(
+            row[video_key],
+            folder.file(f"{uuid.uuid4().hex}.mp4"),
+            config=settings,
+        )
+        return row.update({output_key: result.uri})
+
+    return _transcode
+
+
+def encode_image_sequences(
+    *,
+    images_key: str,
+    output_folder: DataFolderLike,
+    fps: float,
+    output_key: str = "encoded_video",
+    config: NVENCConfig | None = None,
+) -> AsyncMapFn:
+    """Build an NVENC ``map_async`` block for ordered JPEG/PNG file sequences.
+
+    ``row[images_key]`` is a nonempty list of uniformly sized images, all JPEG or
+    all PNG. Its order is the output frame order; no glob or lexical sort is used.
+    """
+    if not images_key or not output_key:
+        raise ValueError("images_key and output_key must be nonempty")
+    if not math.isfinite(fps) or fps <= 0:
+        raise ValueError("fps must be finite and > 0")
+    folder = DataFolder.resolve(output_folder)
+    settings = config or NVENCConfig()
+
+    @describe_builtin(
+        "video.encode_image_sequences",
+        images_key=images_key,
+        output_key=output_key,
+        output_folder=folder.abs_path(),
+        fps=fps,
+        config=asdict(settings),
+    )
+    async def _encode(row: Row) -> Row:
+        result = await encode_image_sequence(
+            row[images_key],
+            folder.file(f"{uuid.uuid4().hex}.mp4"),
+            fps=fps,
+            config=settings,
+        )
+        return row.update({output_key: result.uri})
+
+    return _encode

--- a/src/refiner/video/nvenc.py
+++ b/src/refiner/video/nvenc.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Literal, TypeVar
+
+from refiner.io import DataFile
+from refiner.io.datafile import DataFileLike
+from refiner.video.types import VideoFile
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, slots=True)
+class NVENCConfig:
+    """H.264 settings for L4 dataset preparation; requires NVIDIA FFmpeg."""
+
+    preset: Literal["p1", "p2", "p3", "p4", "p5", "p6", "p7"] = "p1"
+    cq: int = 29
+    gop: int = 17
+    max_width: int = 1920
+    max_height: int = 1080
+    decode: Literal["auto", "cuda", "cpu"] = "auto"
+    gpu: int = 0
+    cpu_threads: int = 2
+    audio: Literal["drop", "aac"] = "drop"
+    timeout_s: float = 3600
+    ffmpeg: str = "ffmpeg"
+    ffprobe: str = "ffprobe"
+
+    def __post_init__(self) -> None:
+        if self.preset not in {f"p{i}" for i in range(1, 8)}:
+            raise ValueError("preset must be p1 through p7")
+        for name, minimum in (
+            ("cq", 0),
+            ("gop", 1),
+            ("max_width", 2),
+            ("max_height", 2),
+            ("gpu", 0),
+            ("cpu_threads", 1),
+        ):
+            value = getattr(self, name)
+            if type(value) is not int or value < minimum:
+                raise ValueError(f"{name} must be an integer >= {minimum}")
+        if self.cq > 51:
+            raise ValueError("cq must be <= 51")
+        if self.decode not in {"auto", "cuda", "cpu"}:
+            raise ValueError("decode must be auto, cuda, or cpu")
+        if self.audio not in {"drop", "aac"}:
+            raise ValueError("audio must be drop or aac")
+        if not math.isfinite(self.timeout_s) or self.timeout_s <= 0:
+            raise ValueError("timeout_s must be finite and > 0")
+
+
+async def _run(command: list[str], timeout: float) -> bytes:
+    # Files avoid unbounded pipe buffers and retain the useful end of FFmpeg errors.
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command, stdin=asyncio.subprocess.DEVNULL, stdout=stdout, stderr=stderr
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"{command[0]} is missing; install FFmpeg/ffprobe with NVENC and scale_cuda"
+            ) from exc
+        try:
+            await asyncio.wait_for(process.wait(), timeout)
+        except asyncio.TimeoutError as exc:
+            raise asyncio.TimeoutError(
+                f"{command[0]} exceeded {timeout} seconds"
+            ) from exc
+        finally:
+            if process.returncode is None:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                await process.wait()
+        if process.returncode:
+            stderr.seek(max(0, stderr.tell() - 16384))
+            detail = stderr.read().decode(errors="replace")
+            raise RuntimeError(
+                f"{command[0]} exited with {process.returncode}: {detail}"
+            )
+        stdout.seek(0)
+        return stdout.read()
+
+
+async def _io(fn: Callable[..., _T], *args: Any) -> _T:
+    # A cancelled copy must finish before its temporary directory can be removed.
+    task = asyncio.create_task(asyncio.to_thread(fn, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+async def _probe(path: Path, config: NVENCConfig) -> dict[str, Any]:
+    payload = await _run(
+        [
+            config.ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_streams",
+            "-of",
+            "json",
+            str(path),
+        ],
+        config.timeout_s,
+    )
+    streams = json.loads(payload).get("streams", [])
+    if (
+        not streams
+        or int(streams[0].get("width", 0)) < 2
+        or int(streams[0].get("height", 0)) < 2
+    ):
+        raise ValueError("source must contain a video stream at least 2x2 pixels")
+    return streams[0]
+
+
+def _dimensions(stream: dict[str, Any], config: NVENCConfig) -> tuple[int, int]:
+    width, height = int(stream["width"]), int(stream["height"])
+    ratio = min(1.0, config.max_width / width, config.max_height / height)
+    return max(2, int(width * ratio) // 2 * 2), max(2, int(height * ratio) // 2 * 2)
+
+
+def _command(
+    source: Path,
+    output: Path,
+    stream: dict[str, Any],
+    config: NVENCConfig,
+    *,
+    fps: float | None = None,
+) -> list[str]:
+    if stream.get("color_transfer") in {"smpte2084", "arib-std-b67"}:
+        raise ValueError("HDR inputs require tone mapping before SDR H.264 transcoding")
+    width, height = _dimensions(stream, config)
+    # Conservative auto path: unusual chroma, full range and legacy codecs use
+    # software decode/conversion, but encoding is always NVENC. Never retry on CPU.
+    cuda = fps is None and (
+        config.decode == "cuda"
+        or (
+            config.decode == "auto"
+            and stream.get("codec_name") in {"h264", "hevc", "vp9", "av1"}
+            and stream.get("pix_fmt") in {"yuv420p", "nv12"}
+            and stream.get("color_range") != "pc"
+        )
+    )
+    if cuda and stream.get("color_range") == "pc":
+        raise ValueError("full-range video requires decode='cpu' for range conversion")
+    command = [
+        config.ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-y",
+        "-noautorotate",
+        "-threads",
+        str(config.cpu_threads),
+        "-filter_threads",
+        "1",
+    ]
+    if cuda:
+        command += [
+            "-hwaccel",
+            "cuda",
+            "-hwaccel_device",
+            str(config.gpu),
+            "-hwaccel_output_format",
+            "cuda",
+            "-extra_hw_frames",
+            "8",
+        ]
+    if fps is not None:
+        command += ["-framerate", str(fps), "-start_number", "0"]
+    command += ["-i", str(source), "-map", "0:v:0"]
+    if config.audio == "aac" and fps is None:
+        command += ["-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k"]
+    else:
+        command += ["-an"]
+    if cuda:
+        # passthrough=0 gives the encoder its own frames, releasing decoder surfaces.
+        filters = f"scale_cuda={width}:{height}:format=yuv420p:passthrough=0"
+    else:
+        filters = f"scale={width}:{height}:out_range=tv,format=yuv420p"
+    command += [
+        "-vf",
+        filters,
+        "-c:v",
+        "h264_nvenc",
+        "-gpu",
+        str(config.gpu),
+        "-preset",
+        config.preset,
+        "-tune",
+        "hq",
+        "-rc",
+        "vbr",
+        "-cq",
+        str(config.cq),
+        "-b:v",
+        "0",
+        "-multipass",
+        "disabled",
+        "-rc-lookahead",
+        "0",
+        "-bf",
+        "0",
+        "-g",
+        str(config.gop),
+        "-keyint_min",
+        str(config.gop),
+        "-no-scenecut",
+        "1",
+        "-strict_gop",
+        "1",
+        "-color_range",
+        "tv",
+        "-bsf:v",
+        "h264_metadata=video_full_range_flag=0",
+        "-fps_mode",
+        "passthrough",
+        "-enc_time_base",
+        "demux",
+        "-map_metadata",
+        "-1",
+        "-metadata:s:v:0",
+        "rotate=0",
+        "-movflags",
+        "+faststart",
+        str(output),
+    ]
+    return command
+
+
+async def _stage(source: DataFile, directory: Path, name: str) -> Path:
+    if source.is_local:
+        return Path(source.path).resolve()
+    local = directory / name
+    await _io(source.copy, local)
+    return local
+
+
+async def _encode(
+    source: Path,
+    destination: DataFile,
+    directory: Path,
+    config: NVENCConfig,
+    *,
+    fps: float | None = None,
+    probe_source: Path | None = None,
+    expected_frames: int | None = None,
+) -> VideoFile:
+    before = await _probe(probe_source or source, config)
+    output = directory / "encoded.mp4"
+    await _run(_command(source, output, before, config, fps=fps), config.timeout_s)
+    after = await _probe(output, config)
+    if (after.get("codec_name"), after.get("pix_fmt")) != ("h264", "yuv420p"):
+        raise RuntimeError("NVENC output must be H.264 yuv420p")
+    if after.get("color_range") != "tv":
+        raise RuntimeError("NVENC output must use limited color range")
+    if (int(after["width"]), int(after["height"])) != _dimensions(before, config):
+        raise RuntimeError("NVENC output dimensions do not match the requested bounds")
+    expected = (
+        expected_frames if expected_frames is not None else before.get("nb_frames")
+    )
+    actual = after.get("nb_frames")
+    if actual is None or actual == "N/A" or int(actual) <= 0:
+        raise RuntimeError("NVENC produced no verifiable video frames")
+    if expected not in (None, "N/A") and int(expected) != int(actual):
+        raise RuntimeError(f"NVENC frame count changed: {expected} -> {actual}")
+    if destination.is_local:
+        # Same-filesystem link publishes atomically and refuses existing files.
+        await _io(os.link, output, destination.path)
+    else:
+        await _io(DataFile.resolve(output).copy, destination)
+    return VideoFile(destination)
+
+
+def _stage_images(sources: list[DataFile], directory: Path, suffix: str) -> None:
+    # One I/O task per sequence avoids a thread-pool roundtrip per image.
+    for index, item in enumerate(sources):
+        link = directory / f"{index:08d}{suffix}"
+        if item.is_local:
+            os.symlink(Path(item.path).resolve(), link)
+        else:
+            item.copy(link)
+
+
+async def _output_directory(destination: DataFile) -> str | None:
+    if await _io(destination.exists):
+        raise FileExistsError(str(destination))
+    if not destination.is_local:
+        return None
+    parent = Path(destination.path).resolve().parent
+    await _io(parent.mkdir, 0o777, True, True)
+    return str(parent)
+
+
+async def transcode_video(
+    source: DataFileLike | VideoFile,
+    destination: DataFileLike,
+    *,
+    config: NVENCConfig | None = None,
+) -> VideoFile:
+    """Transcode a whole video to a new MP4 using NVENC, asynchronously.
+
+    Remote inputs are staged on disk. Existing outputs and clipped views are
+    rejected. No Python frame materialization or silent software encode fallback.
+    """
+    if isinstance(source, VideoFile):
+        if source.from_timestamp_s is not None or source.to_timestamp_s is not None:
+            raise ValueError("transcode_video accepts whole videos, not clipped views")
+        source = source.data_file
+    target = DataFile.resolve(destination)
+    parent = await _output_directory(target)
+    with tempfile.TemporaryDirectory(prefix="refiner-nvenc-", dir=parent) as temp:
+        directory = Path(temp)
+        local = await _stage(DataFile.resolve(source), directory, "input")
+        return await _encode(local, target, directory, config or NVENCConfig())
+
+
+async def encode_image_sequence(
+    images: Sequence[DataFileLike],
+    destination: DataFileLike,
+    *,
+    fps: float,
+    config: NVENCConfig | None = None,
+) -> VideoFile:
+    """Encode an explicitly ordered, uniformly sized JPEG or PNG sequence on GPU."""
+    if not images or isinstance(images, (str, bytes)):
+        raise ValueError("images must be a nonempty ordered sequence of files")
+    if not math.isfinite(fps) or fps <= 0:
+        raise ValueError("fps must be finite and > 0")
+    sources = [DataFile.resolve(item) for item in images]
+    suffixes = [
+        Path(item.path).suffix.lower().replace(".jpeg", ".jpg") for item in sources
+    ]
+    if len(set(suffixes)) != 1 or suffixes[0] not in {".jpg", ".png"}:
+        raise ValueError("images must be all JPEG or all PNG")
+    target = DataFile.resolve(destination)
+    parent = await _output_directory(target)
+    with tempfile.TemporaryDirectory(prefix="refiner-nvenc-", dir=parent) as temp:
+        directory = Path(temp)
+        await _io(_stage_images, sources, directory, suffixes[0])
+        return await _encode(
+            directory / f"%08d{suffixes[0]}",
+            target,
+            directory,
+            config or NVENCConfig(),
+            fps=fps,
+            probe_source=directory / f"00000000{suffixes[0]}",
+            expected_frames=len(sources),
+        )

--- a/src/refiner/video/nvenc.py
+++ b/src/refiner/video/nvenc.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import tempfile
 from typing import Any, Literal, TypeVar
 
+from fsspec.utils import get_protocol
+
 from refiner.io import DataFile
 from refiner.io.datafile import DataFileLike
 from refiner.video.types import VideoFile
@@ -93,7 +95,7 @@ async def _run(command: list[str], timeout: float) -> bytes:
 
 
 async def _io(fn: Callable[..., _T], *args: Any) -> _T:
-    # A cancelled copy must finish before its temporary directory can be removed.
+    # Finish local filesystem operations before removing their temporary directory.
     task = asyncio.create_task(asyncio.to_thread(fn, *args))
     try:
         return await asyncio.shield(task)
@@ -243,17 +245,20 @@ def _command(
     return command
 
 
-async def _stage(source: DataFile, directory: Path, name: str) -> Path:
-    if source.is_local:
-        return Path(source.path).resolve()
-    local = directory / name
-    await _io(source.copy, local)
-    return local
+def _local_path(value: DataFileLike) -> Path:
+    file = DataFile.resolve(value)
+    uri = str(file)
+    # Reject URLs before resolving a filesystem or importing optional backends.
+    if "::" in uri or get_protocol(uri) != "file" or not file.is_local:
+        raise ValueError(
+            "NVENC accepts local files only; handle downloads and uploads in the calling job"
+        )
+    return Path(file.path).resolve()
 
 
 async def _encode(
     source: Path,
-    destination: DataFile,
+    destination: Path,
     directory: Path,
     config: NVENCConfig,
     *,
@@ -279,30 +284,22 @@ async def _encode(
         raise RuntimeError("NVENC produced no verifiable video frames")
     if expected not in (None, "N/A") and int(expected) != int(actual):
         raise RuntimeError(f"NVENC frame count changed: {expected} -> {actual}")
-    if destination.is_local:
-        # Same-filesystem link publishes atomically and refuses existing files.
-        await _io(os.link, output, destination.path)
-    else:
-        await _io(DataFile.resolve(output).copy, destination)
-    return VideoFile(destination)
+    # Same-filesystem link publishes atomically and refuses existing files.
+    await _io(os.link, output, destination)
+    return VideoFile(DataFile.resolve(destination))
 
 
-def _stage_images(sources: list[DataFile], directory: Path, suffix: str) -> None:
+def _stage_images(sources: list[Path], directory: Path, suffix: str) -> None:
     # One I/O task per sequence avoids a thread-pool roundtrip per image.
     for index, item in enumerate(sources):
         link = directory / f"{index:08d}{suffix}"
-        if item.is_local:
-            os.symlink(Path(item.path).resolve(), link)
-        else:
-            item.copy(link)
+        os.symlink(item, link)
 
 
-async def _output_directory(destination: DataFile) -> str | None:
+async def _output_directory(destination: Path) -> str:
     if await _io(destination.exists):
         raise FileExistsError(str(destination))
-    if not destination.is_local:
-        return None
-    parent = Path(destination.path).resolve().parent
+    parent = destination.parent
     await _io(parent.mkdir, 0o777, True, True)
     return str(parent)
 
@@ -315,18 +312,18 @@ async def transcode_video(
 ) -> VideoFile:
     """Transcode a whole video to a new MP4 using NVENC, asynchronously.
 
-    Remote inputs are staged on disk. Existing outputs and clipped views are
-    rejected. No Python frame materialization or silent software encode fallback.
+    Inputs and outputs must be local. The calling job owns transfers and
+    checkpoints. Existing outputs and clipped views are rejected.
     """
     if isinstance(source, VideoFile):
         if source.from_timestamp_s is not None or source.to_timestamp_s is not None:
             raise ValueError("transcode_video accepts whole videos, not clipped views")
         source = source.data_file
-    target = DataFile.resolve(destination)
+    local = _local_path(source)
+    target = _local_path(destination)
     parent = await _output_directory(target)
     with tempfile.TemporaryDirectory(prefix="refiner-nvenc-", dir=parent) as temp:
         directory = Path(temp)
-        local = await _stage(DataFile.resolve(source), directory, "input")
         return await _encode(local, target, directory, config or NVENCConfig())
 
 
@@ -337,18 +334,16 @@ async def encode_image_sequence(
     fps: float,
     config: NVENCConfig | None = None,
 ) -> VideoFile:
-    """Encode an explicitly ordered, uniformly sized JPEG or PNG sequence on GPU."""
+    """Encode ordered local JPEG/PNG files to a local MP4; the job owns transfers."""
     if not images or isinstance(images, (str, bytes)):
         raise ValueError("images must be a nonempty ordered sequence of files")
     if not math.isfinite(fps) or fps <= 0:
         raise ValueError("fps must be finite and > 0")
-    sources = [DataFile.resolve(item) for item in images]
-    suffixes = [
-        Path(item.path).suffix.lower().replace(".jpeg", ".jpg") for item in sources
-    ]
+    sources = [_local_path(item) for item in images]
+    suffixes = [item.suffix.lower().replace(".jpeg", ".jpg") for item in sources]
     if len(set(suffixes)) != 1 or suffixes[0] not in {".jpg", ".png"}:
         raise ValueError("images must be all JPEG or all PNG")
-    target = DataFile.resolve(destination)
+    target = _local_path(destination)
     parent = await _output_directory(target)
     with tempfile.TemporaryDirectory(prefix="refiner-nvenc-", dir=parent) as temp:
         directory = Path(temp)

--- a/tests/test_video_nvenc.py
+++ b/tests/test_video_nvenc.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import cloudpickle
+import pytest
+
+import refiner as mdr
+from refiner.video import blocks, nvenc
+
+
+def _stream(**patch):
+    return {
+        "codec_name": "h264",
+        "pix_fmt": "yuv420p",
+        "color_range": "tv",
+        "width": 640,
+        "height": 480,
+        "nb_frames": "34",
+        **patch,
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cq": -1},
+        {"cq": 52},
+        {"gop": 0},
+        {"gpu": -1},
+        {"max_width": 1},
+        {"max_height": 0},
+        {"cpu_threads": 0},
+        {"gop": 1.5},
+        {"preset": "fast"},
+        {"decode": "invalid"},
+        {"audio": "copy"},
+        {"timeout_s": float("nan")},
+    ],
+)
+def test_invalid_config(kwargs):
+    with pytest.raises(ValueError):
+        nvenc.NVENCConfig(**kwargs)
+
+
+def test_gpu_path_has_no_host_download_or_frame_rate_conversion():
+    command = nvenc._command(
+        Path("input.mp4"), Path("output.mp4"), _stream(), nvenc.NVENCConfig(gpu=1)
+    )
+    assert command[command.index("-hwaccel_device") + 1] == "1"
+    assert command[command.index("-gpu") + 1] == "1"
+    assert "scale_cuda=640:480:format=yuv420p:passthrough=0" in command
+    assert command[command.index("-c:v") + 1] == "h264_nvenc"
+    assert command[command.index("-preset") + 1] == "p1"
+    assert command[command.index("-fps_mode") + 1] == "passthrough"
+    assert command[command.index("-enc_time_base") + 1] == "demux"
+    assert "hwdownload" not in " ".join(command)
+    assert "-r" not in command
+    assert command[command.index("-g") + 1] == "17"
+    assert command[command.index("-bf") + 1] == "0"
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        _stream(codec_name="mpeg4"),
+        _stream(codec_name="mjpeg", pix_fmt="yuvj420p"),
+        _stream(color_range="pc"),
+        _stream(pix_fmt="yuv444p"),
+    ],
+)
+def test_auto_selects_cpu_conversion_but_always_gpu_encoding(stream):
+    command = nvenc._command(Path("in"), Path("out"), stream, nvenc.NVENCConfig())
+    assert "-hwaccel" not in command
+    assert "scale=640:480:out_range=tv,format=yuv420p" in command
+    assert command[command.index("-c:v") + 1] == "h264_nvenc"
+
+
+def test_hdr_and_forced_cuda_full_range_are_rejected():
+    for stream, config in [
+        (_stream(color_transfer="smpte2084"), nvenc.NVENCConfig()),
+        (_stream(color_range="pc"), nvenc.NVENCConfig(decode="cuda")),
+    ]:
+        with pytest.raises(ValueError):
+            nvenc._command(Path("in"), Path("out"), stream, config)
+
+
+@pytest.mark.parametrize(
+    "width,height,expected",
+    [
+        (3840, 2160, (1920, 1080)),
+        (1080, 1920, (606, 1080)),
+        (641, 481, (640, 480)),
+        (320, 240, (320, 240)),
+    ],
+)
+def test_dimensions_bound_even_without_upscaling(width, height, expected):
+    assert (
+        nvenc._dimensions(_stream(width=width, height=height), nvenc.NVENCConfig())
+        == expected
+    )
+
+
+def _fake_encoder(monkeypatch, *, output_stream=None, failure=False):
+    commands = []
+
+    async def run(command, timeout):
+        commands.append(command)
+        if command[0] == "ffprobe":
+            stream = output_stream if command[-1].endswith("encoded.mp4") else _stream()
+            return json.dumps({"streams": [stream or _stream()]}).encode()
+        if failure:
+            raise RuntimeError("NVENC unavailable")
+        Path(command[-1]).write_bytes(b"validated video")
+        return b""
+
+    monkeypatch.setattr(nvenc, "_run", run)
+    return commands
+
+
+def test_transcode_stages_remote_input_and_publishes_after_validation(
+    tmp_path, monkeypatch
+):
+    commands = _fake_encoder(monkeypatch)
+    source = mdr.io.DataFile.resolve("memory://nvenc-tests/input.mp4")
+    with source.open("wb") as handle:
+        handle.write(b"remote input")
+    target = tmp_path / "output.mp4"
+    video = asyncio.run(nvenc.transcode_video(source, target))
+    assert video.data_file.path == str(target)
+    assert target.read_bytes() == b"validated video"
+    assert commands[0][-1].endswith("/input")
+    assert list(tmp_path.iterdir()) == [target]
+
+
+@pytest.mark.parametrize(
+    "output_stream",
+    [
+        _stream(nb_frames="33"),
+        _stream(nb_frames="0"),
+        _stream(pix_fmt="yuvj420p"),
+        _stream(width=320),
+        _stream(codec_name="mpeg4"),
+        _stream(color_range="pc"),
+    ],
+)
+def test_invalid_output_is_not_published(tmp_path, monkeypatch, output_stream):
+    _fake_encoder(monkeypatch, output_stream=output_stream)
+    target = tmp_path / "output.mp4"
+    with pytest.raises(RuntimeError):
+        asyncio.run(nvenc.transcode_video(tmp_path / "input.mp4", target))
+    assert not target.exists()
+    assert not list(tmp_path.iterdir())
+
+
+def test_failure_cleans_temporary_files_and_never_retries_cpu(tmp_path, monkeypatch):
+    commands = _fake_encoder(monkeypatch, failure=True)
+    with pytest.raises(RuntimeError, match="NVENC unavailable"):
+        asyncio.run(
+            nvenc.transcode_video(tmp_path / "input.mp4", tmp_path / "output.mp4")
+        )
+    assert len([c for c in commands if c[0] == "ffmpeg"]) == 1
+    assert not list(tmp_path.iterdir())
+
+
+def test_existing_output_and_clipped_video_are_rejected(tmp_path):
+    target = tmp_path / "output.mp4"
+    target.write_bytes(b"keep me")
+    with pytest.raises(FileExistsError):
+        asyncio.run(nvenc.transcode_video("input.mp4", target))
+    assert target.read_bytes() == b"keep me"
+    clipped = mdr.video.VideoFile(
+        mdr.io.DataFile.resolve("input.mp4"), to_timestamp_s=1
+    )
+    with pytest.raises(ValueError, match="clipped"):
+        asyncio.run(nvenc.transcode_video(clipped, target))
+
+
+def test_images_keep_explicit_order_and_verify_count(tmp_path, monkeypatch):
+    sources = [tmp_path / "z.jpg", tmp_path / "a.jpg"]
+    for index, path in enumerate(sources):
+        path.write_bytes(bytes([index]))
+    original_run = _fake_encoder(monkeypatch, output_stream=_stream(nb_frames="2"))
+    fake_run = nvenc._run
+
+    async def inspect(command, timeout):
+        if command[0] == "ffmpeg":
+            pattern = Path(command[command.index("-i") + 1])
+            assert (pattern.parent / "00000000.jpg").read_bytes() == b"\x00"
+            assert (pattern.parent / "00000001.jpg").read_bytes() == b"\x01"
+            assert "-hwaccel" not in command
+            assert command[command.index("-framerate") + 1] == "30"
+        return await fake_run(command, timeout)
+
+    monkeypatch.setattr(nvenc, "_run", inspect)
+    asyncio.run(nvenc.encode_image_sequence(sources, tmp_path / "out.mp4", fps=30))
+    assert len(original_run) == 3
+    assert not list(tmp_path.glob("refiner-nvenc-*"))
+
+
+def test_blocks_are_serializable_and_use_pipeline_concurrency(tmp_path, monkeypatch):
+    active = peak = 0
+
+    async def transcode(source, destination, *, config):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return mdr.video.VideoFile(destination)
+
+    monkeypatch.setattr(blocks, "transcode_video", transcode)
+    block = mdr.video.transcode_videos(video_key="video", output_folder=tmp_path)
+    assert callable(cloudpickle.loads(cloudpickle.dumps(block)))
+    rows = (
+        mdr.from_items([{"video": f"{i}.mp4", "id": i} for i in range(6)])
+        .map_async(block, max_in_flight=3)
+        .take(6)
+    )
+    assert peak == 3
+    assert [row["id"] for row in rows] == list(range(6))
+    assert len({row["transcoded_video"] for row in rows}) == 6
+
+
+def test_subprocess_reports_stderr():
+    with pytest.raises(RuntimeError, match="encoder failed"):
+        asyncio.run(
+            nvenc._run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stderr.write('encoder failed'); sys.exit(2)",
+                ],
+                5,
+            )
+        )
+
+
+def test_blocks_can_be_imported_first_and_have_json_pipeline_plans(tmp_path):
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import refiner as m; m.video.transcode_videos(video_key='v', output_folder='/tmp/out')",
+        ],
+        check=True,
+    )
+    from refiner.pipeline.planning import compile_pipeline_plan
+
+    for block in [
+        mdr.video.transcode_videos(video_key="video", output_folder=tmp_path),
+        mdr.video.encode_image_sequences(
+            images_key="images", output_folder=tmp_path, fps=30
+        ),
+    ]:
+        pipeline = mdr.from_items([]).map_async(block, max_in_flight=4)
+        encoded = json.dumps(compile_pipeline_plan(pipeline))
+        assert "output_folder" in encoded
+        assert callable(cloudpickle.loads(cloudpickle.dumps(block)))
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+def test_subprocess_timeout_and_cancellation_reap_child(monkeypatch, cancel):
+    real_spawn = asyncio.create_subprocess_exec
+    children = []
+
+    async def spawn(*args, **kwargs):
+        process = await real_spawn(*args, **kwargs)
+        children.append(process)
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+
+    async def execute():
+        task = asyncio.create_task(
+            nvenc._run(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                0.1 if not cancel else 60,
+            )
+        )
+        if cancel:
+            while not children:
+                await asyncio.sleep(0.001)
+            task.cancel()
+        with pytest.raises(asyncio.CancelledError if cancel else asyncio.TimeoutError):
+            await task
+
+    asyncio.run(execute())
+    assert len(children) == 1 and children[0].returncode is not None
+
+
+@pytest.mark.skipif(
+    os.environ.get("REFINER_TEST_NVENC") != "1",
+    reason="set REFINER_TEST_NVENC=1 on an NVIDIA GPU worker",
+)
+@pytest.mark.parametrize("decode", ["cuda", "cpu"])
+def test_real_nvenc_frame_timing_keyframes_and_faststart(tmp_path, decode):
+    assert shutil.which("ffmpeg") and shutil.which("ffprobe")
+    source, output = tmp_path / "in.mp4", tmp_path / "out.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=320x240:rate=30",
+            "-frames:v",
+            "68",
+            "-vf",
+            "setpts='if(lt(N,34),N,N+4)/(30*TB)'",
+            "-fps_mode",
+            "vfr",
+            "-c:v",
+            "libx264",
+            str(source),
+        ],
+        check=True,
+    )
+    asyncio.run(
+        nvenc.transcode_video(source, output, config=nvenc.NVENCConfig(decode=decode))
+    )
+
+    def frames(path):
+        return json.loads(
+            subprocess.check_output(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_frames",
+                    "-show_entries",
+                    "frame=best_effort_timestamp_time,key_frame",
+                    "-of",
+                    "json",
+                    str(path),
+                ]
+            )
+        )["frames"]
+
+    before, after = frames(source), frames(output)
+    assert len(before) == len(after) == 68
+    assert [float(f["best_effort_timestamp_time"]) for f in after] == pytest.approx(
+        [float(f["best_effort_timestamp_time"]) for f in before], abs=1e-6
+    )
+    assert [i for i, frame in enumerate(after) if frame["key_frame"]] == [0, 17, 34, 51]
+    payload = output.read_bytes()
+    assert payload.index(b"moov") < payload.index(b"mdat")
+
+
+@pytest.mark.skipif(
+    os.environ.get("REFINER_TEST_NVENC") != "1", reason="requires NVIDIA GPU"
+)
+def test_real_image_nvenc_preserves_order_and_limited_range(tmp_path):
+    from PIL import Image
+    import numpy as np
+    import av
+
+    images = []
+    for index, value in enumerate([32, 128, 224]):
+        path = tmp_path / f"{2 - index}.jpg"
+        Image.fromarray(np.full((240, 320, 3), value, dtype=np.uint8)).save(path)
+        images.append(path)
+    output = tmp_path / "images.mp4"
+    asyncio.run(nvenc.encode_image_sequence(images, output, fps=30))
+    with av.open(str(output)) as container:
+        frames = list(container.decode(video=0))
+    assert len(frames) == 3
+    assert [
+        float(f.to_ndarray(format="rgb24").mean()) for f in frames
+    ] == pytest.approx([32, 128, 224], abs=5)
+    assert frames[0].format.name == "yuv420p"

--- a/tests/test_video_nvenc.py
+++ b/tests/test_video_nvenc.py
@@ -124,19 +124,86 @@ def _fake_encoder(monkeypatch, *, output_stream=None, failure=False):
     return commands
 
 
-def test_transcode_stages_remote_input_and_publishes_after_validation(
+def test_transcode_reads_local_input_and_publishes_after_validation(
     tmp_path, monkeypatch
 ):
     commands = _fake_encoder(monkeypatch)
-    source = mdr.io.DataFile.resolve("memory://nvenc-tests/input.mp4")
-    with source.open("wb") as handle:
-        handle.write(b"remote input")
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"local input")
     target = tmp_path / "output.mp4"
     video = asyncio.run(nvenc.transcode_video(source, target))
     assert video.data_file.path == str(target)
     assert target.read_bytes() == b"validated video"
-    assert commands[0][-1].endswith("/input")
-    assert list(tmp_path.iterdir()) == [target]
+    assert commands[0][-1] == str(source)
+    assert set(tmp_path.iterdir()) == {source, target}
+
+
+@pytest.mark.parametrize(
+    "remote",
+    [
+        "s3://bucket/video.mp4",
+        "gs://bucket/video.mp4",
+        "https://example.com/video.mp4",
+        "memory://video.mp4",
+        "simplecache::s3://bucket/video.mp4",
+    ],
+)
+def test_remote_inputs_and_outputs_fail_before_filesystem_or_encoder_access(
+    tmp_path, monkeypatch, remote
+):
+    def no_resolution(self):
+        raise AssertionError("must not resolve a remote filesystem")
+
+    async def no_encode(*args, **kwargs):
+        raise AssertionError("must not start FFmpeg")
+
+    monkeypatch.setattr(mdr.io.DataFile, "_resolve", no_resolution)
+    monkeypatch.setattr(nvenc, "_run", no_encode)
+    with pytest.raises(ValueError, match="local files only"):
+        asyncio.run(nvenc.transcode_video(remote, tmp_path / "out.mp4"))
+    # Remote destinations can be tested directly without resolving a local source.
+    with pytest.raises(ValueError, match="local files only"):
+        nvenc._local_path(remote)
+    with pytest.raises(ValueError, match="local files only"):
+        asyncio.run(nvenc.encode_image_sequence([remote], tmp_path / "out.mp4", fps=30))
+    with pytest.raises(ValueError, match="local files only"):
+        mdr.video.transcode_videos(output_folder=remote, video_key="video")
+    with pytest.raises(ValueError, match="local files only"):
+        mdr.video.encode_image_sequences(
+            output_folder=remote, images_key="images", fps=30
+        )
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("source_kind", ["path", "data_file", "video_file"])
+def test_local_wrappers_and_file_urls_are_supported(tmp_path, monkeypatch, source_kind):
+    _fake_encoder(monkeypatch)
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"input")
+    value = source
+    if source_kind == "data_file":
+        value = mdr.io.DataFile.resolve(source)
+    elif source_kind == "video_file":
+        value = mdr.video.VideoFile(mdr.io.DataFile.resolve(source))
+    target = tmp_path / "output.mp4"
+    asyncio.run(nvenc.transcode_video(value, target.as_uri()))
+    assert target.exists()
+
+
+def test_remote_destinations_rejected_before_output_creation(tmp_path, monkeypatch):
+    commands = _fake_encoder(monkeypatch)
+    with pytest.raises(ValueError, match="local files only"):
+        asyncio.run(
+            nvenc.transcode_video(tmp_path / "input.mp4", "s3://bucket/out.mp4")
+        )
+    with pytest.raises(ValueError, match="local files only"):
+        asyncio.run(
+            nvenc.encode_image_sequence(
+                [tmp_path / "input.jpg"], "gs://bucket/out.mp4", fps=30
+            )
+        )
+    assert not commands
+    assert not list(tmp_path.iterdir())
 
 
 @pytest.mark.parametrize(
@@ -213,7 +280,7 @@ def test_blocks_are_serializable_and_use_pipeline_concurrency(tmp_path, monkeypa
         peak = max(peak, active)
         await asyncio.sleep(0.01)
         active -= 1
-        return mdr.video.VideoFile(destination)
+        return mdr.video.VideoFile(mdr.io.DataFile.resolve(destination))
 
     monkeypatch.setattr(blocks, "transcode_video", transcode)
     block = mdr.video.transcode_videos(video_key="video", output_folder=tmp_path)


### PR DESCRIPTION
Adds reusable GPU video conversion blocks so copying pipelines can replace their custom FFmpeg encoding code. `video.transcode_videos` converts whole local video files and `video.encode_image_sequences` encodes explicitly ordered local JPEG/PNG files through `map_async`. Direct async APIs accept a local input and destination. Remote inputs and outputs are rejected before filesystem access; the calling job owns downloads, uploads, output paths, and checkpoints.

The default H.264 path uses NVENC p1, CQ 29, fixed GOP 17, limited-range yuv420p, no upscaling beyond 1920x1080, and faststart MP4. Supported videos stay on the GPU through decode and scaling; other inputs use CPU conversion with GPU encoding. Completed MP4s are checked in a local temporary directory before atomic publication, and cancellation/timeouts reap FFmpeg. Scheduling stays with Refiner's existing bounded async window. The callable-description helper is extracted into a lightweight module to avoid importing the planner when loading video blocks.

Includes usage/tuning documentation and a reproducible benchmark script. One L4 with 8 CPUs and 8 GiB RAM measured approximately 660 aggregate fps for p1 and 395 fps for p6 on synthetic 1080p local videos with 3–4 concurrent lanes. These measurements exclude remote transfers and are not a dataset throughput guarantee.

Validation:

- 99 focused tests passed on current main plus this change; 3 GPU tests skipped locally.
- The prior 40-test suite passed on an actual L4 using the unchanged FFmpeg encoding path, including variable-rate timing, frame counts, GOP positions, faststart, image order, and color conversion. All validation workers were stopped.
- Normal commit hooks: Ruff lint, Ruff formatting, and whole-project ty check.
- Full-suite success is not claimed: the earlier broad local run stalled in TensorFlow's iterator_get_next, reproduced in test_tfds_reader_shards_by_example_range.

Worker images must provide NVIDIA-enabled FFmpeg/ffprobe and a compatible driver. These blocks accept local files only and do not own downloads, uploads, dataset checkpoints, archive extraction, annotation transforms, or garbage collection. Map wrappers use unique output names; checkpointed copying jobs should use the direct APIs with job-controlled destinations.

