### PR TITLE
Use p4 and Lanczos for GPU video encoding

### DIFF
--- a/docs/transforms/gpu-video-transcoding.md
+++ b/docs/transforms/gpu-video-transcoding.md
@@ -67,7 +67,7 @@ RGB frame arrays are created. The output frame count must match the list length.
 | Setting | Default | Behavior |
 | --- | --- | --- |
 | Codec | H.264 NVENC | 8-bit `yuv420p`, limited range, MP4 faststart |
-| `preset` | `"p1"` | Fastest NVENC preset; `"p6"` spends more work on compression |
+| `preset` | `"p4"` | FFmpeg NVENC default preset; choose `"p1"` for faster encoding or `"p6"` for more compression effort |
 | `cq` | `29` | VBR constant-quality target; lower values request higher quality |
 | `gop` | `17` | Fixed keyframe interval in frames, no scene cuts or B-frames |
 | Bounds | 1920 × 1080 | Keep aspect ratio approximately, round down to even dimensions, never upscale |
@@ -85,14 +85,16 @@ Resize associated keypoints, boxes, and intrinsics to match output dimensions;
 these blocks do not modify annotation columns. HDR inputs require tone mapping
 before this SDR block.
 
+Resizing uses Lanczos on both the CUDA and CPU paths.
+
 On the CUDA path, decode surfaces remain on the GPU through `scale_cuda` and
 NVENC. Full-range inputs use CPU range conversion in `auto` mode. `decode="cpu"`
 still uses NVENC for encoding. `decode="cuda"` forces hardware decoding and
 reports unsupported input/build errors; it does not silently retry on the CPU.
 
-The defaults prioritize throughput. Choosing `preset="p6"` restores the preset
-used in earlier dataset converters, but does not promise bit-identical output:
-this block disables lookahead, multipass, and B-frames and fixes the GOP.
+The defaults use p4/HQ, VBR CQ29, and Lanczos scaling. The earlier dataset
+quality calibration used p6 and does not validate this exact configuration.
+This block disables lookahead, multipass, and B-frames and fixes the GOP at 17.
 CQ 29 is an encoder quality target, not an equivalence to x264 CRF 29.
 
 Measure on your own videos before scaling worker count:
@@ -109,7 +111,8 @@ which configuration wins.
 
 An L4 validation run on September 8, 2026 used 8 CPUs, 8 GiB RAM, NVIDIA driver
 580.95.05, and FFmpeg 8.1. It encoded eight copies of a 600-frame, 1920×1080
-`testsrc2` H.264 video for each configuration:
+`testsrc2` H.264 video for each configuration. This run predates explicit Lanczos
+scaling and does not measure the current defaults:
 
 | Concurrent lanes | `p1` aggregate fps | `p6` aggregate fps |
 | --- | --- | --- |
@@ -118,7 +121,7 @@ An L4 validation run on September 8, 2026 used 8 CPUs, 8 GiB RAM, NVIDIA driver
 | 3 | 663.1 | 395.3 |
 | 4 | 660.6 | 394.7 |
 
-Three and four lanes performed similarly on the final implementation. These are
+Three and four lanes performed similarly in that run. These are
 single-run synthetic local-file measurements, not a throughput guarantee for
 datasets or remote storage. Earlier runs varied, so benchmark both settings on
 your worker image and representative input.

--- a/src/refiner/video/nvenc.py
+++ b/src/refiner/video/nvenc.py
@@ -23,7 +23,7 @@ _T = TypeVar("_T")
 class NVENCConfig:
     """H.264 settings for L4 dataset preparation; requires NVIDIA FFmpeg."""
 
-    preset: Literal["p1", "p2", "p3", "p4", "p5", "p6", "p7"] = "p1"
+    preset: Literal["p1", "p2", "p3", "p4", "p5", "p6", "p7"] = "p4"
     cq: int = 29
     gop: int = 17
     max_width: int = 1920
@@ -192,9 +192,9 @@ def _command(
         command += ["-an"]
     if cuda:
         # passthrough=0 gives the encoder its own frames, releasing decoder surfaces.
-        filters = f"scale_cuda={width}:{height}:format=yuv420p:passthrough=0"
+        filters = f"scale_cuda={width}:{height}:format=yuv420p:interp_algo=lanczos:passthrough=0"
     else:
-        filters = f"scale={width}:{height}:out_range=tv,format=yuv420p"
+        filters = f"scale={width}:{height}:flags=lanczos:out_range=tv,format=yuv420p"
     command += [
         "-vf",
         filters,

--- a/tests/test_video_nvenc.py
+++ b/tests/test_video_nvenc.py
@@ -55,15 +55,20 @@ def test_gpu_path_has_no_host_download_or_frame_rate_conversion():
     )
     assert command[command.index("-hwaccel_device") + 1] == "1"
     assert command[command.index("-gpu") + 1] == "1"
-    assert "scale_cuda=640:480:format=yuv420p:passthrough=0" in command
+    assert (
+        "scale_cuda=640:480:format=yuv420p:interp_algo=lanczos:passthrough=0" in command
+    )
     assert command[command.index("-c:v") + 1] == "h264_nvenc"
-    assert command[command.index("-preset") + 1] == "p1"
+    assert command[command.index("-preset") + 1] == "p4"
     assert command[command.index("-fps_mode") + 1] == "passthrough"
     assert command[command.index("-enc_time_base") + 1] == "demux"
     assert "hwdownload" not in " ".join(command)
     assert "-r" not in command
     assert command[command.index("-g") + 1] == "17"
     assert command[command.index("-bf") + 1] == "0"
+    assert command[command.index("-cq") + 1] == "29"
+    assert command[command.index("-rc-lookahead") + 1] == "0"
+    assert command[command.index("-multipass") + 1] == "disabled"
 
 
 @pytest.mark.parametrize(
@@ -78,7 +83,7 @@ def test_gpu_path_has_no_host_download_or_frame_rate_conversion():
 def test_auto_selects_cpu_conversion_but_always_gpu_encoding(stream):
     command = nvenc._command(Path("in"), Path("out"), stream, nvenc.NVENCConfig())
     assert "-hwaccel" not in command
-    assert "scale=640:480:out_range=tv,format=yuv420p" in command
+    assert "scale=640:480:flags=lanczos:out_range=tv,format=yuv420p" in command
     assert command[command.index("-c:v") + 1] == "h264_nvenc"
 
 


### PR DESCRIPTION
Video resizing previously relied on FFmpeg scaler defaults, which were the source of quality loss in an earlier 4K-to-1080p dataset calibration. Select Lanczos explicitly on both CUDA and CPU conversion paths, and change the default NVENC preset from p1 to p4 (FFmpeg’s default).

Keep CQ29, GOP17, and the existing disabled B-frame, lookahead, and multipass settings. Update command tests and documentation, including clarifying that historical p1/p6 speed measurements and the p6 quality calibration do not validate this exact configuration.

Validation: `uv run pytest tests/test_video_nvenc.py` — 46 passed, 3 GPU tests skipped locally. Ruff, formatting, and type-check commit hooks passed. No benchmark sweep was run; p4 speed and quality remain unmeasured for this configuration.
